### PR TITLE
Disable sudo on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
 notifications:


### PR DESCRIPTION
With this change, the build should run sooner on travis-ci (see: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).