### PR TITLE
Add new rule handle-done-callback

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,3 +1,4 @@
 # Rules
 
 * [no-exclusive-tests](no-exclusive-tests.md) - disallow exclusive mocha tests
+* [handle-done-callback](handle-done-callback.md) - enforces handling of callbacks for async tests

--- a/docs/rules/handle-done-callback.md
+++ b/docs/rules/handle-done-callback.md
@@ -1,0 +1,68 @@
+# Enforces handling of callbacks for async tests (no-exclusive-tests)
+
+Mocha allows you to write asynchronous tests by adding a `done` callback to the parameters of your test function.
+It is easy to forget calling this callback after the asynchronous operation is done.
+
+Example:
+
+```js
+
+it('should work', function (done) {
+    fetchData(options, function (error, data) {
+        expect(error).not.to.be.ok;
+        expect(data).to.deep.equal({ foo: 'bar' });
+    });
+});
+```
+
+In this example the `done callback was never called and test will time out.
+
+## Rule Details
+
+This rule checks each `FunctionExpression` or `ArrowFunctionExpression` inside of `it`, `it.only`, `test`, `test.only`, `before`, `after`, `beforeEach` and `afterEach`.
+
+The following patterns are considered warnings:
+
+```js
+it('foo', function (done) { });
+
+it('foo', function (done) {
+    asyncFunction(function (err, result) {
+        expect(err).to.not.exist;
+    });
+});
+
+before(function (done) {
+    asyncInitialization(function () {
+        initialized = true;
+    });
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+it('foo', function (done) { done(); });
+
+it('foo', function (done) {
+    asyncFunction(function (err, result) {
+        expect(err).to.not.exist;
+        done();
+    });
+});
+
+before(function (done) {
+    asyncInitialization(function () {
+        initialized = true;
+        done();
+    });
+});
+```
+
+## When Not To Use It
+
+If you don’t write asynchronous tests you can safely disable this rule.
+
+## Further Reading
+
+* [Asynchronous test code](http://mochajs.org/#asynchronous-code)

--- a/docs/rules/handle-done-callback.md
+++ b/docs/rules/handle-done-callback.md
@@ -16,7 +16,7 @@ it('should work', function (done) {
 });
 ```
 
-In this example the `done callback was never called and test will time out.
+In this example the `done` callback was never called and test will time out.
 
 ## Rule Details
 

--- a/docs/rules/handle-done-callback.md
+++ b/docs/rules/handle-done-callback.md
@@ -1,4 +1,4 @@
-# Enforces handling of callbacks for async tests (no-exclusive-tests)
+# Enforces handling of callbacks for async tests (handle-done-callback)
 
 Mocha allows you to write asynchronous tests by adding a `done` callback to the parameters of your test function.
 It is easy to forget calling this callback after the asynchronous operation is done.

--- a/docs/rules/handle-done-callback.md
+++ b/docs/rules/handle-done-callback.md
@@ -11,6 +11,7 @@ it('should work', function (done) {
     fetchData(options, function (error, data) {
         expect(error).not.to.be.ok;
         expect(data).to.deep.equal({ foo: 'bar' });
+        // done callback was not called
     });
 });
 ```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
     rules: {
-        'no-exclusive-tests': require('./lib/rules/no-exclusive-tests')
+        'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
+        'handle-done-callback': require('./lib/rules/handle-done-callback')
     }
 };

--- a/lib/rules/handle-done-callback.js
+++ b/lib/rules/handle-done-callback.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function (context) {
+    var possibleAsyncFunctionNames = [
+        'it',
+        'it.only',
+        'test',
+        'test.only',
+        'before',
+        'after',
+        'beforeEach',
+        'afterEach'
+    ];
+
+    function getCalleeName(callee) {
+        if (callee.type === 'MemberExpression') {
+             return callee.object.name + '.' + callee.property.name;
+        }
+
+        return callee.name;
+    }
+
+    function hasParentMochaFunctionCall(functionExpression) {
+        var name;
+
+        if (functionExpression.parent && functionExpression.parent.type === 'CallExpression') {
+            name = getCalleeName(functionExpression.parent.callee);
+            return possibleAsyncFunctionNames.indexOf(name) > -1;
+        }
+
+        return false;
+    }
+
+    function isAsyncFunction(functionExpression) {
+        return functionExpression.params.length === 1;
+    }
+
+    function findParamInScope(paramName, scope) {
+        return _.find(scope.variables, function (variable) {
+            return variable.name === paramName && variable.defs[0].type === 'Parameter';
+        });
+    }
+
+    function checkAsyncMochaFunction(functionExpression) {
+        var scope = context.getScope(),
+            callback = functionExpression.params[0],
+            callbackName = callback.name,
+            callbackVariable = findParamInScope(callbackName, scope);
+
+        if (callbackVariable && callbackVariable.references.length === 0) {
+            context.report(callback, 'Expected "{{name}}" callback to be handled.', { name: callbackName });
+        }
+    }
+
+    function check(node) {
+        if (hasParentMochaFunctionCall(node) && isAsyncFunction(node)) {
+            checkAsyncMochaFunction(node);
+        }
+    }
+
+    return {
+        FunctionExpression: check,
+        ArrowFunctionExpression: check
+    };
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         "coveralls": "cat ./build/coverage/lcov.info | coveralls",
         "changelog": "pr-log"
     },
+    "dependencies": {
+        "lodash": "^3.9.3"
+    },
     "devDependencies": {
         "pr-log": "1.1.0",
         "istanbul": "0.3.7",

--- a/test/rules/handle-done-callback.js
+++ b/test/rules/handle-done-callback.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var linter = require('eslint').linter,
+    ESLintTester = require('eslint-tester'),
+    eslintTester = new ESLintTester(linter);
+
+eslintTester.addRuleTest('lib/rules/handle-done-callback', {
+    valid: [
+        'foo(function (done) { });',
+        'var foo = function (done) { };',
+        'it();',
+        'it("");',
+        'it("", function () {});',
+        'it("", function () { done(); });',
+        'it("", function (done) { done(); });',
+        'it("", function () { callback(); });',
+        'it("", function (callback) { callback(); });',
+        'it("", function (done) { if (a) { done(); } });',
+        'it("", function (done) { function foo() { done(); } });',
+        'it("", function (done) { setTimeout(done, 300); });',
+        'it("", function (done) { done(new Error("foo")); });',
+        'it("", function (done) { promise.then(done).catch(done); });',
+        'it.only("", function (done) { done(); });',
+        'test("", function (done) { done(); });',
+        'test.only("", function (done) { done(); });',
+        'before(function (done) { done(); });',
+        'after(function (done) { done(); });',
+        'beforeEach(function (done) { done(); });',
+        'afterEach(function (done) { done(); });',
+
+        {
+            code: 'it("", (done) => { done(); });',
+            ecmaFeatures: { arrowFunctions: true }
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'it("", function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 17, line: 1 } ]
+        },
+        {
+            code: 'it("", function (done) { callback(); });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 17, line: 1 } ]
+        },
+        {
+            code: 'it("", function (callback) { });',
+            errors: [ { message: 'Expected "callback" callback to be handled.', column: 17, line: 1 } ]
+        },
+        {
+            code: 'it("", function (done) { asyncFunction(function (error) { expect(error).to.be.null; }); });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 17, line: 1 } ]
+        },
+        {
+            code: 'it.only("", function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 22, line: 1 } ]
+        },
+        {
+            code: 'test("", function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 19, line: 1 } ]
+        },
+        {
+            code: 'test.only("", function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 24, line: 1 } ]
+        },
+        {
+            code: 'before(function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 17, line: 1 } ]
+        },
+        {
+            code: 'after(function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 16, line: 1 } ]
+        },
+        {
+            code: 'beforeEach(function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 21, line: 1 } ]
+        },
+        {
+            code: 'afterEach(function (done) { });',
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 20, line: 1 } ]
+        },
+        {
+            code: 'it("", (done) => { });',
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [ { message: 'Expected "done" callback to be handled.', column: 8, line: 1 } ]
+        }
+    ]
+});


### PR DESCRIPTION
For now the rule performs a really simple check and may not cover each
possible use-case.

* It doesn’t include branch-tracking to make sure that the `done` callback is called in every possible branch.
* It doesn’t check **HOW** the callback is handled, so e.g. `return done;` would be sufficient.