### PR TITLE
Add no-synchronous-tests rule

### DIFF
--- a/docs/rules/no-synchronous-tests.md
+++ b/docs/rules/no-synchronous-tests.md
@@ -1,0 +1,30 @@
+# Disallow Synchronous Tests (no-synchronous-tests)
+
+Mocha automatically determines whether a test is synchronous or asynchronous based on the arity of the function passed into it. When writing tests for a asynchronous function, omitting the `done` callback or forgetting to return a promise can often lead to false-positive test cases. This rule warns against the implicit synchronous feature, and should be combined with `handle-done-callback` for best results.
+
+## Rule Details
+
+This rule looks for either an asynchronous callback or a return statement within the function body of any mocha test statement. If the mocha callback is not used and a promise is not returned, this rule will raise a warning.
+
+### Caveats:
+
+This rule cannot guarantee that a returned function call is actually a promise, it only confirms that the return was made.
+
+If a dynamic function is passed into the test call, it cannot be inspected because the function is only defined at runtime. Example:
+
+```js
+var myTestFn = function(){
+  // it cannot verify this
+}
+it('test name', myTestFn);
+```
+
+## When Not To Use It
+
+* If you are primarily writing synchronous tests, and rarely need the `done` callback or promise functionality.
+
+## Further Reading
+
+* [Synchronous Code](http://mochajs.org/#synchronous-code)
+* [Asynchronous Code](http://mochajs.org/#asynchronous-code)
+* [Working with Promises](http://mochajs.org/#working-with-promises)

--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function (context) {
+    var possibleAsyncFunctionNames = [
+        'it',
+        'it.only',
+        'test',
+        'test.only',
+        'before',
+        'after',
+        'beforeEach',
+        'afterEach'
+    ];
+
+    function getCalleeName(callee) {
+        if (callee.type === 'MemberExpression') {
+             return callee.object.name + '.' + callee.property.name;
+        }
+
+        return callee.name;
+    }
+
+    function hasParentMochaFunctionCall(functionExpression) {
+        var name;
+
+        if (functionExpression.parent && functionExpression.parent.type === 'CallExpression') {
+            name = getCalleeName(functionExpression.parent.callee);
+            return possibleAsyncFunctionNames.indexOf(name) > -1;
+        }
+
+        return false;
+    }
+
+    function hasAsyncCallback(functionExpression) {
+        return functionExpression.params.length === 1;
+    }
+
+    function findPromiseReturnStatement(nodes) {
+      return _.find(nodes, function (node) {
+        return node.type === 'ReturnStatement' && node.argument && node.argument.type !== 'Literal';
+      });
+    }
+
+    function checkPromiseReturn(functionExpression) {
+        var bodyStatement = functionExpression.body;
+        var returnStatement = null;
+        if (bodyStatement.type === 'BlockStatement') {
+            returnStatement = findPromiseReturnStatement(functionExpression.body.body);
+        } else if (bodyStatement.type === 'CallExpression') {
+            //  allow arrow statements calling a promise with implicit return.
+            returnStatement = bodyStatement;
+        }
+
+        if (!returnStatement) {
+            context.report(functionExpression, 'Expected test to handle a callback or return a promise.');
+        }
+    }
+
+    function check(node) {
+        if (hasParentMochaFunctionCall(node) && !hasAsyncCallback(node)) {
+            checkPromiseReturn(node);
+        }
+    }
+
+    return {
+        FunctionExpression: check,
+        ArrowFunctionExpression: check
+    };
+};

--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -54,7 +54,7 @@ module.exports = function (context) {
         }
 
         if (!returnStatement) {
-            context.report(functionExpression, 'Expected test to handle a callback or return a promise.');
+            context.report(functionExpression, 'Unexpected synchronous test.');
         }
     }
 

--- a/test/rules/no-synchronous-tests.js
+++ b/test/rules/no-synchronous-tests.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var RuleTester = require('eslint').RuleTester;
+var rule = require('../../lib/rules/no-synchronous-tests');
+
+var ruleTester = new RuleTester();
+
+ruleTester.run('no-synchronous-tests', rule, {
+    valid: [
+        'it();',
+        'it("");',
+        'it("", function () { return promise(); });',
+        'it("", function () { return promise(); });',
+        'it("", function (done) { done(); });',
+        'it("", function (callback) { callback(); });',
+        'it("", function (done) { if (a) { done(); } });',
+        'it("", function (done) { function foo() { done(); } });',
+        'it("", function (done) { setTimeout(done, 300); });',
+        'it("", function (done) { done(new Error("foo")); });',
+        'it("", function (done) { promise.then(done).catch(done); });',
+        'it.only("", function (done) { done(); });',
+        'test("", function (done) { done(); });',
+        'test.only("", function (done) { done(); });',
+        'before(function (done) { done(); });',
+        'after(function (done) { done(); });',
+        'beforeEach(function (done) { done(); });',
+        'afterEach(function (done) { done(); });',
+        'ignoredFunction(function () { });',
+        'var foo = function () { };',
+        {
+            code: 'it("", (done) => { done(); });',
+            ecmaFeatures: { arrowFunctions: true }
+        },
+        {
+            code: 'it("", () => { return promise(); });',
+            ecmaFeatures: { arrowFunctions: true }
+        },
+        {
+            code: 'it("", () => promise() );',
+            ecmaFeatures: { arrowFunctions: true }
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'it("", function () {});',
+            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+        },
+        {
+            code: 'it("", function () { callback(); });',
+            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+        },
+        {
+            code: 'it(function () { return; });',
+            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 4, line: 1 } ]
+        },
+        {
+            code: 'it("", function () { return "a string" });',
+            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+        },
+        {
+            code: 'it("", () => "not-a-promise" );',
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+        }
+    ]
+});

--- a/test/rules/no-synchronous-tests.js
+++ b/test/rules/no-synchronous-tests.js
@@ -11,6 +11,8 @@ ruleTester.run('no-synchronous-tests', rule, {
         'it("");',
         'it("", function () { return promise(); });',
         'it("", function () { return promise(); });',
+        'it("", function () { var promise = myFn(); return promise; });',
+        'var someFn = function(){ }; it("", someFn);',
         'it("", function (done) { done(); });',
         'it("", function (callback) { callback(); });',
         'it("", function (done) { if (a) { done(); } });',

--- a/test/rules/no-synchronous-tests.js
+++ b/test/rules/no-synchronous-tests.js
@@ -13,6 +13,7 @@ ruleTester.run('no-synchronous-tests', rule, {
         'it("", function () { return promise(); });',
         'it("", function () { var promise = myFn(); return promise; });',
         'var someFn = function(){ }; it("", someFn);',
+        'it("", function (done) { });',
         'it("", function (done) { done(); });',
         'it("", function (callback) { callback(); });',
         'it("", function (done) { if (a) { done(); } });',
@@ -40,30 +41,34 @@ ruleTester.run('no-synchronous-tests', rule, {
         {
             code: 'it("", () => promise() );',
             ecmaFeatures: { arrowFunctions: true }
+        },
+        {
+            code: 'it("", () => promise.then() );',
+            ecmaFeatures: { arrowFunctions: true }
         }
     ],
 
     invalid: [
         {
             code: 'it("", function () {});',
-            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+            errors: [ { message: 'Unexpected synchronous test.', column: 8, line: 1 } ]
         },
         {
             code: 'it("", function () { callback(); });',
-            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+            errors: [ { message: 'Unexpected synchronous test.', column: 8, line: 1 } ]
         },
         {
             code: 'it(function () { return; });',
-            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 4, line: 1 } ]
+            errors: [ { message: 'Unexpected synchronous test.', column: 4, line: 1 } ]
         },
         {
             code: 'it("", function () { return "a string" });',
-            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+            errors: [ { message: 'Unexpected synchronous test.', column: 8, line: 1 } ]
         },
         {
             code: 'it("", () => "not-a-promise" );',
             ecmaFeatures: { arrowFunctions: true },
-            errors: [ { message: 'Expected test to handle a callback or return a promise.', column: 8, line: 1 } ]
+            errors: [ { message: 'Unexpected synchronous test.', column: 8, line: 1 } ]
         }
     ]
 });


### PR DESCRIPTION
I've had a need for a rule based on my experience writing a bunch of async tests within mocha. This rule checks that either a callback was specified or that a promise was returned in the test function.

Mocha dynamically determines whether a test is synchronous by whether the function includes a callback or returns a promise. Because of that, it's easy to end up in a situation where you intend to return a promise (and do not have a `done` callback) but accidentally omit the `return` statement. This leads to a false-positive where the test would automatically succeed regardless of the actual async result.

This rule works well side-by-side with `handle-done-callback`, as that rule will enforce whether or not a callback was actually called.

Let me know if you see any issues with this PR and I'll try to resolve them. Thanks in advance!