### PR TITLE
add new rule to index.js and change tests to keep that from happening

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
     rules: {
         'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
-        'handle-done-callback': require('./lib/rules/handle-done-callback')
+        'handle-done-callback': require('./lib/rules/handle-done-callback'),
+        'no-synchronous-tests': require('./lib/rules/no-synchronous-tests')
     }
 };

--- a/test/rules/handle-done-callback.js
+++ b/test/rules/handle-done-callback.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var RuleTester = require('eslint').RuleTester;
-var rule = require('../../lib/rules/handle-done-callback');
+var rules = require('../../').rules;
 
 var ruleTester = new RuleTester();
 
-ruleTester.run('handle-done-callback', rule, {
+ruleTester.run('handle-done-callback', rules['handle-done-callback'], {
     valid: [
         'foo(function (done) { });',
         'var foo = function (done) { };',

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var RuleTester = require('eslint').RuleTester;
-var rule = require('../../lib/rules/no-exclusive-tests');
+var rules = require('../../').rules;
 
 var ruleTester = new RuleTester();
 
 var expectedErrorMessage = 'Unexpected exclusive mocha test.';
 
-ruleTester.run('no-exclusive-tests', rule, {
+ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
 
     valid: [
         'describe()',

--- a/test/rules/no-synchronous-tests.js
+++ b/test/rules/no-synchronous-tests.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var RuleTester = require('eslint').RuleTester;
-var rule = require('../../lib/rules/no-synchronous-tests');
+var rules = require('../../').rules;
 
 var ruleTester = new RuleTester();
 
-ruleTester.run('no-synchronous-tests', rule, {
+ruleTester.run('no-synchronous-tests', rules['no-synchronous-tests'], {
     valid: [
         'it();',
         'it("");',


### PR DESCRIPTION
Closes #27

Hopefully the test changes aren't disagreeable.  I think this is a good way to make sure `index.js` doesn't get missed.