### PR TITLE
switch to lodash/fp

### DIFF
--- a/lib/rules/handle-done-callback.js
+++ b/lib/rules/handle-done-callback.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var R = require('ramda');
+var L = require('lodash/fp');
 
 module.exports = function (context) {
     var possibleAsyncFunctionNames = [
@@ -38,7 +38,7 @@ module.exports = function (context) {
     }
 
     function findParamInScope(paramName, scope) {
-        return R.find(function (variable) {
+        return L.find(function (variable) {
             return variable.name === paramName && variable.defs[0].type === 'Parameter';
         }, scope.variables);
     }

--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var R = require('ramda');
+var L = require('lodash/fp');
 
 module.exports = function (context) {
     var possibleAsyncFunctionNames = [
@@ -38,7 +38,7 @@ module.exports = function (context) {
     }
 
     function findPromiseReturnStatement(nodes) {
-      return R.find(function (node) {
+      return L.find(function (node) {
         return node.type === 'ReturnStatement' && node.argument && node.argument.type !== 'Literal';
       }, nodes);
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "changelog": "pr-log"
     },
     "dependencies": {
-        "ramda": "^0.19.1"
+        "lodash": "^4.5.1"
     },
     "devDependencies": {
         "chai": "^3.5.0",


### PR DESCRIPTION
lodash now ships with it's functional counterpart, how would you feel about switching back?

Also, lodash ships with it's modular build so I could switch this to `var find = require('lodash/fp/find')` if you think that looks better.