### PR TITLE
Add rule no-skipped-tests

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,7 @@
 # Rules
 
 * [no-exclusive-tests](no-exclusive-tests.md) - disallow exclusive mocha tests (fixable)
+* [no-skipped-tests](no-skipped-tests.md) - disallow skipped mocha tests (fixable)
 * [handle-done-callback](handle-done-callback.md) - enforces handling of callbacks for async tests
 * [no-synchronous-tests](no-synchronous-tests.md) - disallow synchronous tests
 * [no-global-tests](no-global-tests.md) - disallow global tests

--- a/docs/rules/no-skipped-tests.md
+++ b/docs/rules/no-skipped-tests.md
@@ -1,0 +1,54 @@
+# Disallow Skipped Tests (no-skipped-tests)
+
+Mocha has a feature that allows you to skip tests by appending `.skip` to a test-suite or a test-case, or by prepending it with an `x` (e.g., `xdescribe(...)` instead of `describe(...)`).
+Sometimes tests are skipped as part of a debugging process, and aren't intended to be committed.  This rule reminds you to remove `.skip` or the `x` prefix from your tests.
+
+**Fixable:** Problems detected by this rule are automatically fixable using the `--fix` flag on the command line.
+
+## Rule Details
+
+This rule looks for `describe.skip`, `it.skip`, `suite.skip`, `test.skip`, `context.skip`, `xdescribe`, `xit`, and `xcontext` occurrences within the source code.
+
+The following patterns are considered warnings:
+
+```js
+// bdd
+describe.skip("foo", function () {});
+it.skip("foo", function () {});
+describe["skip"]("bar", function () {});
+it["skip"]("bar", function () {});
+xdescribe("baz", function() {});
+xit("baz", function() {});
+
+// tdd
+suite.skip("foo", function () {});
+test.skip("foo", function () {});
+suite["skip"]("bar", function () {});
+test["skip"]("bar", function () {});
+
+```
+
+These patterns would not be considered warnings:
+
+```js
+// bdd
+describe("foo", function () {});
+it("foo", function () {});
+describe.only("bar", function () {});
+it.only("bar", function () {});
+
+// tdd
+suite("foo", function () {});
+test("foo", function () {});
+suite.only("bar", function () {});
+test.only("bar", function () {});
+```
+
+## When Not To Use It
+
+* If you really want to commit skipped tests to your repo, turn this rule off.
+* If you use another library which exposes a similar API to mocha (e.g. `describe.skip` or `xdescribe`), you should turn this rule off, because it would raise warnings.
+
+## Further Reading
+
+* [Exclusive Tests](http://mochajs.org/#inclusive-tests)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
     rules: {
         'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
+        'no-skipped-tests': require('./lib/rules/no-skipped-tests'),
         'handle-done-callback': require('./lib/rules/handle-done-callback'),
         'no-synchronous-tests': require('./lib/rules/no-synchronous-tests'),
         'no-global-tests': require('./lib/rules/no-global-tests')

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -1,0 +1,76 @@
+'use strict';
+
+module.exports = function (context) {
+    var mochaTestFunctions = [
+            'it',
+            'describe',
+            'suite',
+            'test',
+            'context'
+        ],
+        mochaXFunctions = [
+            'xit',
+            'xdescribe',
+            'xcontext'
+        ];
+
+    function matchesMochaTestFunction(object) {
+        return object && mochaTestFunctions.indexOf(object.name) !== -1;
+    }
+
+    function isPropertyNamedSkip(property) {
+        return property && (property.name === 'skip' || property.value === 'skip');
+    }
+
+    function isCallToMochasSkipFunction(callee) {
+        return callee.type === 'MemberExpression' &&
+           matchesMochaTestFunction(callee.object) &&
+           isPropertyNamedSkip(callee.property);
+    }
+
+    function isMochaXFunction(name) {
+        return mochaXFunctions.indexOf(name) !== -1;
+    }
+
+    function isCallToMochaXFunction(callee) {
+        return callee.type === 'Identifier' && isMochaXFunction(callee.name);
+    }
+
+    function createSkipAutofixFunction(callee) {
+        var endRangeOfMemberExpression = callee.range[1],
+            endRangeOfMemberExpressionObject = callee.object.range[1],
+            rangeToRemove = [ endRangeOfMemberExpressionObject, endRangeOfMemberExpression ];
+
+        return function removeSkipProperty(fixer) {
+            return fixer.removeRange(rangeToRemove);
+        };
+    }
+
+    function createXAutofixFunction(callee) {
+        var rangeToRemove = [ callee.range[0], callee.range[0] + 1 ];
+
+        return function removeXPrefix(fixer) {
+            return fixer.removeRange(rangeToRemove);
+        };
+    }
+
+    return {
+        CallExpression: function (node) {
+            var callee = node.callee;
+
+            if (callee && isCallToMochasSkipFunction(callee)) {
+                context.report({
+                    node: callee.property,
+                    message: 'Unexpected skipped mocha test.',
+                    fix: createSkipAutofixFunction(callee)
+                });
+            } else if (callee && isCallToMochaXFunction(callee)) {
+                context.report({
+                    node: callee,
+                    message: 'Unexpected skipped mocha test.',
+                    fix: createXAutofixFunction(callee)
+                });
+            }
+        }
+    };
+};

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var RuleTester = require('eslint').RuleTester,
+    rules = require('../../').rules,
+    ruleTester = new RuleTester(),
+    expectedErrorMessage = 'Unexpected skipped mocha test.';
+
+ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
+
+    valid: [
+        'describe()',
+        'it()',
+        'describe.only()',
+        'it.only()',
+        'suite()',
+        'test()',
+        'suite.only()',
+        'test.only()',
+        'context()',
+        'context.only()',
+        'var appliedOnly = describe.skip; appliedOnly.apply(describe)',
+        'var calledOnly = it.skip; calledOnly.call(it)',
+        'var dynamicOnly = "skip"; suite[dynamicOnly]()'
+    ],
+
+    invalid: [
+        {
+            code: 'describe.skip()',
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
+            output: 'describe()'
+        },
+        {
+            code: 'describe["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
+            output: 'describe()'
+        },
+        {
+            code: 'xdescribe()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'describe()'
+        },
+        {
+            code: 'it.skip()',
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
+            output: 'it()'
+        },
+        {
+            code: 'it["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
+            output: 'it()'
+        },
+        {
+            code: 'xit()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it()'
+        },
+        {
+            code: 'suite.skip()',
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
+            output: 'suite()'
+        },
+        {
+            code: 'suite["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
+            output: 'suite()'
+        },
+        {
+            code: 'test.skip()',
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
+            output: 'test()'
+        },
+        {
+            code: 'test["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
+            output: 'test()'
+        },
+        {
+            code: 'context.skip()',
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
+            output: 'context()'
+        },
+        {
+            code: 'context["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
+            output: 'context()'
+        },
+        {
+            code: 'xcontext()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'context()'
+        }
+    ]
+
+});
+


### PR DESCRIPTION
Add a rule to catch skipped tests (e.g. `describe.skip()` or `xdescribe`).