### PR TITLE
Remove autofix on no-exclusive-tests rule. 

### DIFF
--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -24,16 +24,6 @@ module.exports = function (context) {
            isPropertyNamedOnly(callee.property);
     }
 
-    function createAutofixFunction(callee) {
-        var endRangeOfMemberExpression = callee.range[1],
-            endRangeOfMemberExpressionObject = callee.object.range[1],
-            rangeToRemove = [ endRangeOfMemberExpressionObject, endRangeOfMemberExpression ];
-
-        return function removeOnlyProperty(fixer) {
-            return fixer.removeRange(rangeToRemove);
-        };
-    }
-
     return {
         CallExpression: function (node) {
             var callee = node.callee;
@@ -41,8 +31,7 @@ module.exports = function (context) {
             if (callee && isCallToMochasOnlyFunction(callee)) {
                 context.report({
                     node: callee.property,
-                    message: 'Unexpected exclusive mocha test.',
-                    fix: createAutofixFunction(callee)
+                    message: 'Unexpected exclusive mocha test.'
                 });
             }
         }

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -28,63 +28,51 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
     invalid: [
         {
             code: 'describe.only()',
-            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
-            output: 'describe()'
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
         },
         {
             code: 'describe["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
-            output: 'describe()'
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
         },
         {
             code: 'it.only()',
-            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
-            output: 'it()'
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ]
         },
         {
             code: 'it["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
-            output: 'it()'
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ]
         },
         {
             code: 'suite.only()',
-            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
-            output: 'suite()'
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },
         {
             code: 'suite["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
-            output: 'suite()'
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },
         {
             code: 'test.only()',
-            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
-            output: 'test()'
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ]
         },
         {
             code: 'test["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
-            output: 'test()'
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ]
         },
         {
             code: 'context.only()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'context()'
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'context["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'context()'
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'specify.only()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'specify()'
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'specify["only"]()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'specify()'
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         }
     ]
 


### PR DESCRIPTION
Thanks for this project! 

I would like to suggest an improvement that is relevant to me: I have setup my editor to auto-fix eslint errors on save. When the exclusive tests rule is auto-fixable, I lose the ability to single out tests. 

Fixes #60 