### PR TITLE
Add support for ember-mocha methods

### DIFF
--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -4,6 +4,9 @@ module.exports = function (context) {
     var mochaTestFunctions = [
         'it',
         'describe',
+        'describeComponent',
+        'describeModel',
+        'describeModule',
         'suite',
         'test',
         'context',

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -4,6 +4,9 @@ module.exports = function (context) {
     var mochaTestFunctions = [
             'it',
             'describe',
+            'describeComponent',
+            'describeModel',
+            'describeModule',
             'suite',
             'test',
             'context',
@@ -12,6 +15,9 @@ module.exports = function (context) {
         mochaXFunctions = [
             'xit',
             'xdescribe',
+            'xdescribeComponent',
+            'xdescribeModel',
+            'xdescribeModule',
             'xcontext',
             'xspecify'
         ];

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -9,8 +9,14 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
 
     valid: [
         'describe()',
+        'describeComponent()',
+        'describeModel()',
+        'describeModule()',
         'it()',
         'describe.skip()',
+        'describeComponent.skip()',
+        'describeModel.skip()',
+        'describeModule.skip()',
         'it.skip()',
         'suite()',
         'test()',
@@ -33,6 +39,30 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
         {
             code: 'describe["only"]()',
             errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
+        },
+        {
+            code: 'describeComponent.only()',
+            errors: [ { message: expectedErrorMessage, column: 19, line: 1 } ]
+        },
+        {
+            code: 'describeComponent["only"]()',
+            errors: [ { message: expectedErrorMessage, column: 19, line: 1 } ]
+        },
+        {
+            code: 'describeModel.only()',
+            errors: [ { message: expectedErrorMessage, column: 15, line: 1 } ]
+        },
+        {
+            code: 'describeModel["only"]()',
+            errors: [ { message: expectedErrorMessage, column: 15, line: 1 } ]
+        },
+        {
+            code: 'describeModule.only()',
+            errors: [ { message: expectedErrorMessage, column: 16, line: 1 } ]
+        },
+        {
+            code: 'describeModule["only"]()',
+            errors: [ { message: expectedErrorMessage, column: 16, line: 1 } ]
         },
         {
             code: 'it.only()',

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -9,8 +9,14 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
 
     valid: [
         'describe()',
+        'describeComponent()',
+        'describeModel()',
+        'describeModule()',
         'it()',
         'describe.only()',
+        'describeComponent.only()',
+        'describeModel.only()',
+        'describeModule.only()',
         'it.only()',
         'suite()',
         'test()',
@@ -38,6 +44,51 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
             code: 'xdescribe()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'describe()'
+        },
+        {
+            code: 'describeComponent.skip()',
+            errors: [ { message: expectedErrorMessage, column: 19, line: 1 } ],
+            output: 'describeComponent()'
+        },
+        {
+            code: 'describeComponent["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 19, line: 1 } ],
+            output: 'describeComponent()'
+        },
+        {
+            code: 'xdescribeComponent()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'describeComponent()'
+        },
+        {
+            code: 'describeModel.skip()',
+            errors: [ { message: expectedErrorMessage, column: 15, line: 1 } ],
+            output: 'describeModel()'
+        },
+        {
+            code: 'describeModel["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 15, line: 1 } ],
+            output: 'describeModel()'
+        },
+        {
+            code: 'xdescribeModel()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'describeModel()'
+        },
+        {
+            code: 'describeModule.skip()',
+            errors: [ { message: expectedErrorMessage, column: 16, line: 1 } ],
+            output: 'describeModule()'
+        },
+        {
+            code: 'describeModule["skip"]()',
+            errors: [ { message: expectedErrorMessage, column: 16, line: 1 } ],
+            output: 'describeModule()'
+        },
+        {
+            code: 'xdescribeModule()',
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'describeModule()'
         },
         {
             code: 'it.skip()',
@@ -103,4 +154,3 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
     ]
 
 });
-


### PR DESCRIPTION
The `ember-mocha` project adds a few new `describe()` methods:
 * `describeComponent()`
 * `describeModel()`
 * `describeModule()`

This change makes the lint rules aware of these functions as well.