### PR TITLE
Allow custom test functions

### DIFF
--- a/docs/rules/no-exclusive-tests.md
+++ b/docs/rules/no-exclusive-tests.md
@@ -51,18 +51,19 @@ test.skip("bar", function () {});
 
 # Options
 
-This rule supports the following configuration options, which can be passed in as a single object.  An example is below.
+This rule supports the following shared configuration options:
 
 * `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
 
 ```json
 {
     "rules": {
-        "mocha/no-exclusive-tests": ["error", {
-            "additionalTestFunctions": [
-                "describeModule"
-            ]
-        }]
+        "mocha/no-exclusive-tests": "error"
+    },
+    "settings": {
+       "mocha/additionalTestFunctions": [
+           "describeModule"
+       ]
     }
 }
 ```

--- a/docs/rules/no-exclusive-tests.md
+++ b/docs/rules/no-exclusive-tests.md
@@ -49,6 +49,24 @@ suite.skip("bar", function () {});
 test.skip("bar", function () {});
 ```
 
+# Options
+
+This rule supports the following configuration options, which can be passed in as a single object.  An example is below.
+
+* `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
+
+```json
+{
+    "rules": {
+        "mocha/no-exclusive-tests": ["error", {
+            "additionalTestFunctions": [
+                "describeModule"
+            ]
+        }]
+    }
+}
+```
+
 ## When Not To Use It
 
 * If you really want to execute only one test-suite or test-case because all other tests should not be executed, turn this rule off.

--- a/docs/rules/no-skipped-tests.md
+++ b/docs/rules/no-skipped-tests.md
@@ -46,22 +46,23 @@ test.only("bar", function () {});
 
 # Options
 
-This rule supports the following configuration options, which can be passed in as a single object.  An example is below.
+This rule supports the following shared configuration options:
 
 * `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
-* `additonalXFunctions`: An array of extra x-function to protect
+* `additionalXFunctions`: An array of extra x-function to protect
 
 ```json
 {
     "rules": {
-        "mocha/no-skipped-tests": ["error", {
-            "additionalTestFunctions": [
-                "describeModule"
-            ],
-            "additionalXFunctions": [
-                "xdescribeModule"
-            ]
-        }]
+        "mocha/no-skipped-tests": "error"
+    },
+    "settings": {
+       "mocha/additionalTestFunctions": [
+           "describeModule"
+       ],
+       "mocha/additionalXFunctions": [
+           "xdescribeModule"
+       ]
     }
 }
 ```

--- a/docs/rules/no-skipped-tests.md
+++ b/docs/rules/no-skipped-tests.md
@@ -44,6 +44,27 @@ suite.only("bar", function () {});
 test.only("bar", function () {});
 ```
 
+# Options
+
+This rule supports the following configuration options, which can be passed in as a single object.  An example is below.
+
+* `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
+* `additonalXFunctions`: An array of extra x-function to protect
+
+```json
+{
+    "rules": {
+        "mocha/no-skipped-tests": ["error", {
+            "additionalTestFunctions": [
+                "describeModule"
+            ],
+            "additionalXFunctions": [
+                "xdescribeModule"
+            ]
+        }]
+    }
+}
+```
 ## When Not To Use It
 
 * If you really want to commit skipped tests to your repo, turn this rule off.

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var getAdditionalTestFunctions = require('../util/settings').getAdditionalTestFunctions;
+
 module.exports = function (context) {
     var mochaTestFunctions = [
             'it',
@@ -9,12 +11,10 @@ module.exports = function (context) {
             'context',
             'specify'
         ],
-        optionsHash = context.options[0] || {},
-        additionalTestFunctions = optionsHash.additionalTestFunctions;
+        settings = context.settings,
+        additionalTestFunctions = getAdditionalTestFunctions(settings);
 
-    if (additionalTestFunctions && additionalTestFunctions.length) {
-        mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
-    }
+    mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
 
     function matchesMochaTestFunction(object) {
         return object && mochaTestFunctions.indexOf(object.name) !== -1;

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -2,13 +2,19 @@
 
 module.exports = function (context) {
     var mochaTestFunctions = [
-        'it',
-        'describe',
-        'suite',
-        'test',
-        'context',
-        'specify'
-    ];
+            'it',
+            'describe',
+            'suite',
+            'test',
+            'context',
+            'specify'
+        ],
+        optionsHash = context.options[0] || {},
+        additionalTestFunctions = optionsHash.additionalTestFunctions;
+
+    if (additionalTestFunctions && additionalTestFunctions.length) {
+        mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
+    }
 
     function matchesMochaTestFunction(object) {
         return object && mochaTestFunctions.indexOf(object.name) !== -1;
@@ -20,8 +26,8 @@ module.exports = function (context) {
 
     function isCallToMochasOnlyFunction(callee) {
         return callee.type === 'MemberExpression' &&
-           matchesMochaTestFunction(callee.object) &&
-           isPropertyNamedOnly(callee.property);
+            matchesMochaTestFunction(callee.object) &&
+            isPropertyNamedOnly(callee.property);
     }
 
     return {
@@ -37,3 +43,19 @@ module.exports = function (context) {
         }
     };
 };
+
+module.exports.schema = [
+    {
+        type: 'object',
+        properties: {
+            additionalTestFunctions: {
+                type: 'array',
+                items: {
+                    type: 'string'
+                },
+                minItems: 1,
+                uniqueItems: true
+            }
+        }
+    }
+];

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -1,19 +1,9 @@
 'use strict';
 
-var mochaTestFunctions = [
-        'it',
-        'describe',
-        'suite',
-        'test',
-        'context',
-        'specify'
-    ],
-    mochaXFunctions = [
-        'xit',
-        'xdescribe',
-        'xcontext',
-        'xspecify'
-    ];
+var getAdditionalTestFunctions = require('../util/settings').getAdditionalTestFunctions,
+    getAdditionalXFunctions = require('../util/settings').getAdditionalXFunctions,
+    mochaTestFunctions,
+    mochaXFunctions;
 
 function matchesMochaTestFunction(object) {
     return object && mochaTestFunctions.indexOf(object.name) !== -1;
@@ -47,26 +37,33 @@ function createXAutofixFunction(callee) {
     };
 }
 
+function isMochaXFunction(name) {
+    return mochaXFunctions.indexOf(name) !== -1;
+}
+
+function isCallToMochaXFunction(callee) {
+    return callee.type === 'Identifier' && isMochaXFunction(callee.name);
+}
+
 module.exports = function (context) {
-    var optionsHash = context.options[0] || {},
-        additionalTestFunctions = optionsHash.additionalTestFunctions,
-        additionalXFunctions = optionsHash.additionalXFunctions;
+    var settings = context.settings,
+        additionalTestFunctions = getAdditionalTestFunctions(settings),
+        additionalXFunctions = getAdditionalXFunctions(settings);
 
-    if (additionalTestFunctions && additionalTestFunctions.length) {
-        mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
-    }
-
-    if (additionalXFunctions && additionalXFunctions.length) {
-        mochaXFunctions = mochaXFunctions.concat(additionalXFunctions);
-    }
-
-    function isMochaXFunction(name) {
-        return mochaXFunctions.indexOf(name) !== -1;
-    }
-
-    function isCallToMochaXFunction(callee) {
-        return callee.type === 'Identifier' && isMochaXFunction(callee.name);
-    }
+    mochaTestFunctions = [
+        'it',
+        'describe',
+        'suite',
+        'test',
+        'context',
+        'specify'
+    ].concat(additionalTestFunctions);
+    mochaXFunctions = [
+        'xit',
+        'xdescribe',
+        'xcontext',
+        'xspecify'
+    ].concat(additionalXFunctions);
 
     return {
         CallExpression: function (node) {

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -1,33 +1,63 @@
 'use strict';
 
+var mochaTestFunctions = [
+        'it',
+        'describe',
+        'suite',
+        'test',
+        'context',
+        'specify'
+    ],
+    mochaXFunctions = [
+        'xit',
+        'xdescribe',
+        'xcontext',
+        'xspecify'
+    ];
+
+function matchesMochaTestFunction(object) {
+    return object && mochaTestFunctions.indexOf(object.name) !== -1;
+}
+
+function isPropertyNamedSkip(property) {
+    return property && (property.name === 'skip' || property.value === 'skip');
+}
+
+function isCallToMochasSkipFunction(callee) {
+    return callee.type === 'MemberExpression' &&
+       matchesMochaTestFunction(callee.object) &&
+       isPropertyNamedSkip(callee.property);
+}
+
+function createSkipAutofixFunction(callee) {
+    var endRangeOfMemberExpression = callee.range[1],
+        endRangeOfMemberExpressionObject = callee.object.range[1],
+        rangeToRemove = [ endRangeOfMemberExpressionObject, endRangeOfMemberExpression ];
+
+    return function removeSkipProperty(fixer) {
+        return fixer.removeRange(rangeToRemove);
+    };
+}
+
+function createXAutofixFunction(callee) {
+    var rangeToRemove = [ callee.range[0], callee.range[0] + 1 ];
+
+    return function removeXPrefix(fixer) {
+        return fixer.removeRange(rangeToRemove);
+    };
+}
+
 module.exports = function (context) {
-    var mochaTestFunctions = [
-            'it',
-            'describe',
-            'suite',
-            'test',
-            'context',
-            'specify'
-        ],
-        mochaXFunctions = [
-            'xit',
-            'xdescribe',
-            'xcontext',
-            'xspecify'
-        ];
+    var optionsHash = context.options[0] || {},
+        additionalTestFunctions = optionsHash.additionalTestFunctions,
+        additionalXFunctions = optionsHash.additionalXFunctions;
 
-    function matchesMochaTestFunction(object) {
-        return object && mochaTestFunctions.indexOf(object.name) !== -1;
+    if (additionalTestFunctions && additionalTestFunctions.length) {
+        mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
     }
 
-    function isPropertyNamedSkip(property) {
-        return property && (property.name === 'skip' || property.value === 'skip');
-    }
-
-    function isCallToMochasSkipFunction(callee) {
-        return callee.type === 'MemberExpression' &&
-           matchesMochaTestFunction(callee.object) &&
-           isPropertyNamedSkip(callee.property);
+    if (additionalXFunctions && additionalXFunctions.length) {
+        mochaXFunctions = mochaXFunctions.concat(additionalXFunctions);
     }
 
     function isMochaXFunction(name) {
@@ -36,24 +66,6 @@ module.exports = function (context) {
 
     function isCallToMochaXFunction(callee) {
         return callee.type === 'Identifier' && isMochaXFunction(callee.name);
-    }
-
-    function createSkipAutofixFunction(callee) {
-        var endRangeOfMemberExpression = callee.range[1],
-            endRangeOfMemberExpressionObject = callee.object.range[1],
-            rangeToRemove = [ endRangeOfMemberExpressionObject, endRangeOfMemberExpression ];
-
-        return function removeSkipProperty(fixer) {
-            return fixer.removeRange(rangeToRemove);
-        };
-    }
-
-    function createXAutofixFunction(callee) {
-        var rangeToRemove = [ callee.range[0], callee.range[0] + 1 ];
-
-        return function removeXPrefix(fixer) {
-            return fixer.removeRange(rangeToRemove);
-        };
     }
 
     return {
@@ -76,3 +88,27 @@ module.exports = function (context) {
         }
     };
 };
+
+module.exports.schema = [
+    {
+        type: 'object',
+        properties: {
+            additionalTestFunctions: {
+                type: 'array',
+                items: {
+                    type: 'string'
+                },
+                minItems: 1,
+                uniqueItems: true
+            },
+            additionalXFunctions: {
+                type: 'array',
+                items: {
+                    type: 'string'
+                },
+                minItems: 1,
+                uniqueItems: true
+            }
+        }
+    }
+];

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,0 +1,17 @@
+/* eslint-env node*/
+
+'use strict';
+
+function settingFor(propertyName) {
+  return function (settings) {
+    var value = settings['mocha/' + propertyName],
+        mochaSettings = settings.mocha || {};
+
+    return value || mochaSettings[propertyName] || [];
+  };
+}
+
+module.exports = {
+  getAdditionalTestFunctions: settingFor('additionalTestFunctions'),
+  getAdditionalXFunctions: settingFor('additionalXFunctions')
+};

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -76,12 +76,34 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
         },
         {
             code: 'custom.only()',
-            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            settings: {
+                'mocha/additionalTestFunctions': [ 'custom' ]
+            },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         },
         {
             code: 'custom["only"]()',
-            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            settings: {
+                'mocha/additionalTestFunctions': [ 'custom' ]
+            },
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
+        },
+        {
+            code: 'custom.only()',
+            settings: {
+                mocha: {
+                    additionalTestFunctions: [ 'custom' ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
+        },
+        {
+            code: 'custom["only"]()',
+            settings: {
+                mocha: {
+                    additionalTestFunctions: [ 'custom' ]
+                }
+            },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         }
     ]

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -73,6 +73,16 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
         {
             code: 'specify["only"]()',
             errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
+        },
+        {
+            code: 'custom.only()',
+            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
+        },
+        {
+            code: 'custom["only"]()',
+            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         }
     ]
 

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -98,6 +98,24 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
             code: 'xspecify()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'specify()'
+        },
+        {
+            code: 'custom.skip()',
+            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            output: 'custom()'
+        },
+        {
+            code: 'custom["skip"]()',
+            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            output: 'custom()'
+        },
+        {
+            code: 'xcustom()',
+            options: [ { additionalXFunctions: [ 'xcustom' ] } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'custom()'
         }
 
     ]

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -101,19 +101,55 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
         },
         {
             code: 'custom.skip()',
-            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            settings: {
+                'mocha/additionalTestFunctions': [ 'custom' ]
+            },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
             output: 'custom()'
         },
         {
             code: 'custom["skip"]()',
-            options: [ { additionalTestFunctions: [ 'custom' ] } ],
+            settings: {
+                'mocha/additionalTestFunctions': [ 'custom' ]
+            },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
             output: 'custom()'
         },
         {
             code: 'xcustom()',
-            options: [ { additionalXFunctions: [ 'xcustom' ] } ],
+            settings: {
+                'mocha/additionalXFunctions': [ 'xcustom' ]
+            },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'custom()'
+        },
+        {
+            code: 'custom.skip()',
+            settings: {
+                mocha: {
+                    additionalTestFunctions: [ 'custom' ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            output: 'custom()'
+        },
+        {
+            code: 'custom["skip"]()',
+            settings: {
+                mocha: {
+                    additionalTestFunctions: [ 'custom' ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            output: 'custom()'
+        },
+        {
+            code: 'xcustom()',
+            settings: {
+                mocha: {
+                    additionalXFunctions: [ 'xcustom' ]
+                }
+            },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'custom()'
         }


### PR DESCRIPTION
This feature is useful if using this plugin with a package like `ember-mocha`, which provides its own set of `describe` functions. A custom array can be provided so that those extensions can also be protected from having `only` called.

One thought about my changes is that it introduces a configuration object rather than an array.  We could make the option parameter just an array, but I kind of like the extra context provided by the named keys.  The difference is basically between this (how I have it right now)

```json
{
     "rules": {
         "mocha/no-exclusive-tests": ["error", {
             "additionalTestFunctions": [
                 "describeModule"
             ]
         }]
     }
 }
```

and this (which I think provides less context and it more confusing)

```json
{
     "rules": {
         "mocha/no-exclusive-tests": ["error", [
             "describeModule"
         ]]
     }
 }
```

Closes #80