### PR TITLE
Adds rule name to title for `valid-suite-description` documentation.

### DIFF
--- a/docs/rules/valid-suite-description.md
+++ b/docs/rules/valid-suite-description.md
@@ -1,4 +1,4 @@
-# Match suite descriptions against a pre-configured regular expression
+# Match suite descriptions against a pre-configured regular expression (valid-suite-description)
 
 This rule enforces the suite descriptions to follow the desired format. 
 


### PR DESCRIPTION
Like most other rules do.