### PR TITLE
Fix rule name in CHANGELOG to match actual rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Features
 
-* Add 'one-suite-per-file' rule (#103) (#105)
+* Add 'max-top-level-suites' rule (#103) (#105)
 
 ## 4.5.1 (August 30, 2016)
 


### PR DESCRIPTION
Looks like `max-top-level-suites` was at one point named `one-suite-per-file`, but that was changed before release. The CHANGELOG was never updated, which makes it kind of hard to figure out what actually was changed. This PR just fixes the changelog to match the actual change that was made.