### PR TITLE
Make no-mocha-arrows rule fixable

### DIFF
--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -41,6 +41,38 @@ module.exports = function (context) {
         return !R.find(R.propEq('name', name), scope.variables);
     }
 
+    function fixArrowFunction(fixer, fn) {
+        var sourceCode = context.getSourceCode(),
+            paramsLeftParen = sourceCode.getFirstToken(fn),
+            paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fn.body)),
+            paramsFullText =
+                sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]),
+            functionKeyword = 'function ',
+            bodyText;
+
+        if (fn.async) {
+            // When 'async' specified, take care about the keyword.
+            functionKeyword = 'async function';
+            // Strip 'async (...)' to ' (...)'
+            paramsFullText = paramsFullText.slice(5);
+        }
+
+        if (fn.body.type === 'BlockStatement') {
+            // When it((...) => { ... }),
+            // simply replace '(...) => ' with 'function () '
+            return fixer.replaceTextRange(
+                [ fn.start, fn.body.start ],
+                functionKeyword + paramsFullText + ' '
+            );
+        }
+
+        bodyText = sourceCode.text.slice(fn.body.range[0], fn.body.range[1]);
+        return fixer.replaceTextRange(
+            [ fn.start, fn.end ],
+            functionKeyword + paramsFullText + ' { return ' + bodyText + '; }'
+        );
+    }
+
     return {
         CallExpression: function (node) {
             var name = getCalleeName(node.callee),
@@ -54,35 +86,7 @@ module.exports = function (context) {
                             node: node,
                             message: 'Do not pass arrow functions to ' + name + '()',
                             fix: function (fixer) {
-                                var sourceCode = context.getSourceCode(),
-                                    paramsLeftParen = sourceCode.getFirstToken(fnArg),
-                                    paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fnArg.body)),
-                                    paramsFullText =
-                                        sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]),
-                                    functionKeyword = 'function ',
-                                    bodyText;
-
-                                if (fnArg.async) {
-                                    // When 'async' specified, take care about the keyword.
-                                    functionKeyword = 'async function';
-                                    // Strip 'async (...)' to ' (...)'
-                                    paramsFullText = paramsFullText.slice(5);
-                                }
-
-                                if (fnArg.body.type === 'BlockStatement') {
-                                    // When it((...) => { ... }),
-                                    // simply replace '(...) => ' with 'function () '
-                                    return fixer.replaceTextRange(
-                                        [ fnArg.start, fnArg.body.start ],
-                                        functionKeyword + paramsFullText + ' '
-                                    );
-                                }
-
-                                bodyText = sourceCode.text.slice(fnArg.body.range[0], fnArg.body.range[1]);
-                                return fixer.replaceTextRange(
-                                    [ fnArg.start, fnArg.end ],
-                                    functionKeyword + paramsFullText + ' { return ' + bodyText + '; }'
-                                );
+                                return fixArrowFunction(fixer, fnArg);
                             }
                         });
                     }

--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -59,21 +59,29 @@ module.exports = function (context) {
                                     paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fnArg.body)),
                                     paramsFullText =
                                         sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]),
+                                    functionKeyword = 'function ',
                                     bodyText;
+
+                                if (fnArg.async) {
+                                    // When 'async' specified, take care about the keyword.
+                                    functionKeyword = 'async ' + functionKeyword;
+                                    // Strip 'async (...)' to '(...)'
+                                    paramsFullText = paramsFullText.slice(6);
+                                }
 
                                 if (fnArg.body.type === 'BlockStatement') {
                                     // When it((...) => { ... }),
                                     // simply replace '(...) => ' with 'function () '
                                     return fixer.replaceTextRange(
                                         [ fnArg.start, fnArg.body.start ],
-                                        'function ' + paramsFullText + ' '
+                                        functionKeyword + paramsFullText + ' '
                                     );
                                 }
 
                                 bodyText = sourceCode.text.slice(fnArg.body.range[0], fnArg.body.range[1]);
                                 return fixer.replaceTextRange(
                                     [ fnArg.start, fnArg.end ],
-                                    'function ' + paramsFullText + ' { return ' + bodyText + '; }'
+                                    functionKeyword + paramsFullText + ' { return ' + bodyText + '; }'
                                 );
                             }
                         });

--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -73,7 +73,7 @@ module.exports = function (context) {
                                 bodyText = sourceCode.text.slice(fnArg.body.range[0], fnArg.body.range[1]);
                                 return fixer.replaceTextRange(
                                     [ fnArg.start, fnArg.end ],
-                                    'function ' + paramsFullText + ' { ' + bodyText + '; }'
+                                    'function ' + paramsFullText + ' { return ' + bodyText + '; }'
                                 );
                             }
                         });

--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -50,7 +50,33 @@ module.exports = function (context) {
                 fnArg = node.arguments.slice(-1)[0];
                 if (fnArg && fnArg.type === 'ArrowFunctionExpression') {
                     if (isLikelyMochaGlobal(context.getScope(), name)) {
-                        context.report(node, 'Do not pass arrow functions to ' + name + '()');
+                        context.report({
+                            node: node,
+                            message: 'Do not pass arrow functions to ' + name + '()',
+                            fix: function (fixer) {
+                                var sourceCode = context.getSourceCode(),
+                                    paramsLeftParen = sourceCode.getFirstToken(fnArg),
+                                    paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fnArg.body)),
+                                    paramsFullText =
+                                        sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]),
+                                    bodyText;
+
+                                if (fnArg.body.type === 'BlockStatement') {
+                                    // When it((...) => { ... }),
+                                    // simply replace '(...) => ' with 'function () '
+                                    return fixer.replaceTextRange(
+                                        [ fnArg.start, fnArg.body.start ],
+                                        'function ' + paramsFullText + ' '
+                                    );
+                                }
+
+                                bodyText = sourceCode.text.slice(fnArg.body.range[0], fnArg.body.range[1]);
+                                return fixer.replaceTextRange(
+                                    [ fnArg.start, fnArg.end ],
+                                    'function ' + paramsFullText + ' { ' + bodyText + '; }'
+                                );
+                            }
+                        });
                     }
                 }
             }

--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -64,9 +64,9 @@ module.exports = function (context) {
 
                                 if (fnArg.async) {
                                     // When 'async' specified, take care about the keyword.
-                                    functionKeyword = 'async ' + functionKeyword;
-                                    // Strip 'async (...)' to '(...)'
-                                    paramsFullText = paramsFullText.slice(6);
+                                    functionKeyword = 'async function';
+                                    // Strip 'async (...)' to ' (...)'
+                                    paramsFullText = paramsFullText.slice(5);
                                 }
 
                                 if (fnArg.body.type === 'BlockStatement') {

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -23,28 +23,39 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
         {
             code: 'it(() => { assert(something, false); })',
             parserOptions: { ecmaVersion: 6 },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => { assert(something, false); })',
             globals: [ 'it' ],
             parserOptions: { ecmaVersion: 6 },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => assert(something, false))',
             parserOptions: { ecmaVersion: 6 },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it("should be false", () => { assert(something, false); })',
             parserOptions: { ecmaVersion: 6 },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it("should be false", function () { assert(something, false); })'
         },
         {
             code: 'it.only(() => { assert(something, false); })',
             parserOptions: { ecmaVersion: 6 },
-            errors: [ { message: 'Do not pass arrow functions to it.only()', column: 1, line: 1 } ]
+            errors: [ { message: 'Do not pass arrow functions to it.only()', column: 1, line: 1 } ],
+            output: 'it.only(function () { assert(something, false); })'
+        },
+        {
+            code: 'it("should be false", () => {\n  assert(something, false);\n})',
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it("should be false", function () {\n  assert(something, false);\n})'
         }
     ]
 

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -77,6 +77,12 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             parserOptions: { ecmaVersion: 2017 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(async function () { assert(something, false) })'
+        },
+        {
+            code: 'it(async () => assert(something, false))',
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(async function () { return assert(something, false); })'
         }
     ]
 

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -83,6 +83,12 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             parserOptions: { ecmaVersion: 2017 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(async function () { return assert(something, false); })'
+        },
+        {
+            code: 'it(async() => assert(something, false))',
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(async function() { return assert(something, false); })'
         }
     ]
 

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -2,91 +2,87 @@
 
 var RuleTester = require('eslint').RuleTester,
     rules = require('../../').rules,
-    ruleTester = new RuleTester(),
-    expectedErrorMessage = 'Do not pass arrow functions to it()';
+    es6RuleTester = new RuleTester({
+        parserOptions: { ecmaVersion: 6 }
+    }),
+    expectedErrorMessage = 'Do not pass arrow functions to it()',
+    es2017RuleTester = new RuleTester({
+        parserOptions: { ecmaVersion: 2017 }
+    });
 
-ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
+es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
 
     valid: [
         'it()',
         'it(function() { assert(something, false); })',
         'it("should be false", function() { assert(something, false); })',
-        {
-            // In this example, `it` is not a global.
-            code: 'function it () {}; it(() => { console.log("okay") })',
-            parserOptions: { ecmaVersion: 6 }
-        },
+         // In this example, `it` is not a global.
+        'function it () {}; it(() => { console.log("okay") })',
         'it.only()',
         'it(function(done) { assert(something, false); done(); })',
-        {
-            code: 'it(function*() { assert(something, false) })',
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: 'it(async function () { assert(something, false) })',
-            parserOptions: { ecmaVersion: 2017 }
-        }
+        'it(function*() { assert(something, false) })'
     ],
 
     invalid: [
         {
             code: 'it(() => { assert(something, false); })',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => { assert(something, false); })',
             globals: [ 'it' ],
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => assert(something, false))',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(function () { return assert(something, false); })'
         },
         {
             code: 'it("should be false", () => { assert(something, false); })',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it("should be false", function () { assert(something, false); })'
         },
         {
             code: 'it.only(() => { assert(something, false); })',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: 'Do not pass arrow functions to it.only()', column: 1, line: 1 } ],
             output: 'it.only(function () { assert(something, false); })'
         },
         {
             code: 'it((done) => { assert(something, false); })',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(function (done) { assert(something, false); })'
         },
         {
             code: 'it("should be false", () => {\n assert(something, false);\n})',
-            parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it("should be false", function () {\n assert(something, false);\n})'
-        },
+        }
+    ]
+
+});
+
+es2017RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
+
+    valid: [
+        'it(async function () { assert(something, false) })'
+    ],
+
+    invalid: [
         {
             code: 'it(async () => { assert(something, false) })',
-            parserOptions: { ecmaVersion: 2017 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(async function () { assert(something, false) })'
         },
         {
             code: 'it(async () => assert(something, false))',
-            parserOptions: { ecmaVersion: 2017 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(async function () { return assert(something, false); })'
         },
         {
             code: 'it(async() => assert(something, false))',
-            parserOptions: { ecmaVersion: 2017 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it(async function() { return assert(something, false); })'
         }

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -37,7 +37,7 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             code: 'it(() => assert(something, false))',
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'it(function () { assert(something, false); })'
+            output: 'it(function () { return assert(something, false); })'
         },
         {
             code: 'it("should be false", () => { assert(something, false); })',
@@ -52,10 +52,10 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             output: 'it.only(function () { assert(something, false); })'
         },
         {
-            code: 'it("should be false", () => {\n  assert(something, false);\n})',
+            code: 'it("should be false", () => {\n assert(something, false);\n})',
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'it("should be false", function () {\n  assert(something, false);\n})'
+            output: 'it("should be false", function () {\n assert(something, false);\n})'
         }
     ]
 

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -2,16 +2,13 @@
 
 var RuleTester = require('eslint').RuleTester,
     rules = require('../../').rules,
-    es6RuleTester = new RuleTester({
-        parserOptions: { ecmaVersion: 6 }
-    }),
-    expectedErrorMessage = 'Do not pass arrow functions to it()',
-    es2017RuleTester = new RuleTester({
+    ruleTester = new RuleTester({
         parserOptions: { ecmaVersion: 2017 }
     }),
+    expectedErrorMessage = 'Do not pass arrow functions to it()',
     errors = [ { message: expectedErrorMessage, column: 1, line: 1 } ];
 
-es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
+ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
 
     valid: [
         'it()',
@@ -21,7 +18,8 @@ es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
         'function it () {}; it(() => { console.log("okay") })',
         'it.only()',
         'it(function(done) { assert(something, false); done(); })',
-        'it(function*() { assert(something, false) })'
+        'it(function*() { assert(something, false) })',
+        'it(async function () { assert(something, false) })'
     ],
 
     invalid: [
@@ -60,18 +58,7 @@ es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             code: 'it("should be false", () => {\n assert(something, false);\n})',
             errors: errors,
             output: 'it("should be false", function () {\n assert(something, false);\n})'
-        }
-    ]
-
-});
-
-es2017RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
-
-    valid: [
-        'it(async function () { assert(something, false) })'
-    ],
-
-    invalid: [
+        },
         {
             code: 'it(async () => { assert(something, false) })',
             errors: errors,

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -8,7 +8,8 @@ var RuleTester = require('eslint').RuleTester,
     expectedErrorMessage = 'Do not pass arrow functions to it()',
     es2017RuleTester = new RuleTester({
         parserOptions: { ecmaVersion: 2017 }
-    });
+    }),
+    errors = [ { message: expectedErrorMessage, column: 1, line: 1 } ];
 
 es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
 
@@ -26,23 +27,23 @@ es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
     invalid: [
         {
             code: 'it(() => { assert(something, false); })',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => { assert(something, false); })',
             globals: [ 'it' ],
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(function () { assert(something, false); })'
         },
         {
             code: 'it(() => assert(something, false))',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(function () { return assert(something, false); })'
         },
         {
             code: 'it("should be false", () => { assert(something, false); })',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it("should be false", function () { assert(something, false); })'
         },
         {
@@ -52,12 +53,12 @@ es6RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
         },
         {
             code: 'it((done) => { assert(something, false); })',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(function (done) { assert(something, false); })'
         },
         {
             code: 'it("should be false", () => {\n assert(something, false);\n})',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it("should be false", function () {\n assert(something, false);\n})'
         }
     ]
@@ -73,17 +74,17 @@ es2017RuleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
     invalid: [
         {
             code: 'it(async () => { assert(something, false) })',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(async function () { assert(something, false) })'
         },
         {
             code: 'it(async () => assert(something, false))',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(async function () { return assert(something, false); })'
         },
         {
             code: 'it(async() => assert(something, false))',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: errors,
             output: 'it(async function() { return assert(something, false); })'
         }
     ]

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -16,7 +16,16 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             code: 'function it () {}; it(() => { console.log("okay") })',
             parserOptions: { ecmaVersion: 6 }
         },
-        'it.only()'
+        'it.only()',
+        'it(function(done) { assert(something, false); done(); })',
+        {
+            code: 'it(function*() { assert(something, false) })',
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: 'it(async function () { assert(something, false) })',
+            parserOptions: { ecmaVersion: 2017 }
+        }
     ],
 
     invalid: [
@@ -52,10 +61,22 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             output: 'it.only(function () { assert(something, false); })'
         },
         {
+            code: 'it((done) => { assert(something, false); })',
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(function (done) { assert(something, false); })'
+        },
+        {
             code: 'it("should be false", () => {\n assert(something, false);\n})',
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
             output: 'it("should be false", function () {\n assert(something, false);\n})'
+        },
+        {
+            code: 'it(async () => { assert(something, false) })',
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            output: 'it(async function () { assert(something, false) })'
         }
     ]
 


### PR DESCRIPTION
## Summary

I make `no-mocha-arrows` rule fixable with `--fix` option of `eslint` command.
## Example
- Before

``` js
it("does something", () => { assert.ok(true); });
it("does something", () => assert.ok(true));
```
- After

``` js
it("does something", function () { assert.ok(true); });
it("does something", function () { return assert.ok(true); });
```

EDIT: Translation result of single expression body
