### PR TITLE
Fix no-mocha-arrow fixer

### DIFF
--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -47,7 +47,7 @@ module.exports = function (context) {
             paramsRightParen = sourceCode.getTokenBefore(sourceCode.getTokenBefore(fn.body)),
             paramsFullText =
                 sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]),
-            functionKeyword = 'function ',
+            functionKeyword = 'function',
             bodyText;
 
         if (fn.async) {
@@ -55,6 +55,10 @@ module.exports = function (context) {
             functionKeyword = 'async function';
             // Strip 'async (...)' to ' (...)'
             paramsFullText = paramsFullText.slice(5);
+        }
+
+        if (fn.params.length > 0) {
+            paramsFullText = '(' + sourceCode.text.slice(fn.params[0].start, R.last(fn.params).end) + ')';
         }
 
         if (fn.body.type === 'BlockStatement') {

--- a/test/rules/no-mocha-arrows.js
+++ b/test/rules/no-mocha-arrows.js
@@ -26,38 +26,48 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
         {
             code: 'it(() => { assert(something, false); })',
             errors: errors,
-            output: 'it(function () { assert(something, false); })'
+            output: 'it(function() { assert(something, false); })'
         },
         {
             code: 'it(() => { assert(something, false); })',
             globals: [ 'it' ],
             errors: errors,
-            output: 'it(function () { assert(something, false); })'
+            output: 'it(function() { assert(something, false); })'
         },
         {
             code: 'it(() => assert(something, false))',
             errors: errors,
-            output: 'it(function () { return assert(something, false); })'
+            output: 'it(function() { return assert(something, false); })'
+        },
+        {
+            code: 'it(done => assert(something, false))',
+            errors: errors,
+            output: 'it(function(done) { return assert(something, false); })'
         },
         {
             code: 'it("should be false", () => { assert(something, false); })',
             errors: errors,
-            output: 'it("should be false", function () { assert(something, false); })'
+            output: 'it("should be false", function() { assert(something, false); })'
         },
         {
             code: 'it.only(() => { assert(something, false); })',
             errors: [ { message: 'Do not pass arrow functions to it.only()', column: 1, line: 1 } ],
-            output: 'it.only(function () { assert(something, false); })'
+            output: 'it.only(function() { assert(something, false); })'
         },
         {
             code: 'it((done) => { assert(something, false); })',
             errors: errors,
-            output: 'it(function (done) { assert(something, false); })'
+            output: 'it(function(done) { assert(something, false); })'
+        },
+        {
+            code: 'it(done => { assert(something, false); })',
+            errors: errors,
+            output: 'it(function(done) { assert(something, false); })'
         },
         {
             code: 'it("should be false", () => {\n assert(something, false);\n})',
             errors: errors,
-            output: 'it("should be false", function () {\n assert(something, false);\n})'
+            output: 'it("should be false", function() {\n assert(something, false);\n})'
         },
         {
             code: 'it(async () => { assert(something, false) })',
@@ -68,6 +78,16 @@ ruleTester.run('no-mocha-arrows', rules['no-mocha-arrows'], {
             code: 'it(async () => assert(something, false))',
             errors: errors,
             output: 'it(async function () { return assert(something, false); })'
+        },
+        {
+            code: 'it(async done => assert(something, false))',
+            errors: errors,
+            output: 'it(async function(done) { return assert(something, false); })'
+        },
+        {
+            code: 'it(async (done) => assert(something, false))',
+            errors: errors,
+            output: 'it(async function(done) { return assert(something, false); })'
         },
         {
             code: 'it(async() => assert(something, false))',


### PR DESCRIPTION
When a test implementation has parameters, the end result would have missing parens.

```js
it(done => {});
// -->
it(function done {});
```

This fixes it. I could not keep a consistent spacing for `function () {}` and `function() {}`, so I modified the current results, but when fixing, that will probably be taken care of the other rules' fixers anyway.

cc @rhysd if you feel like reviewing