### PR TITLE
don't drop support for eslint 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "coveralls": "^2.11.6"
     },
     "peerDependencies": {
-        "eslint": "^2.0.0 || ^4.0.0"
+        "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
unless i'm missing something there's no reason to drop this?