### PR TITLE
Adds rule "padding-between-test-functions"

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -15,5 +15,6 @@
 * [no-skipped-tests](no-skipped-tests.md) - disallow skipped mocha tests (fixable)
 * [no-synchronous-tests](no-synchronous-tests.md) - disallow synchronous tests
 * [no-top-level-hooks](no-top-level-hooks.md) - disallow top-level hooks
+* [padding-between-test-functions](padding-between-test-functions.md) - enforce padding between test functions
 * [valid-suite-description](valid-suite-description.md) - match suite descriptions against a pre-configured regular expression
 * [valid-test-description](valid-test-description.md) - match test descriptions against a pre-configured regular expression

--- a/docs/rules/padding-between-test-functions.md
+++ b/docs/rules/padding-between-test-functions.md
@@ -1,0 +1,72 @@
+# Padding Between Test Functions (padding-between-test-functions)
+
+This is a stylistic rule that enforces or disallows spaces between test functions.
+
+**Fixable:** Problems detected by this rule are automatically fixable using the `--fix` flag on the command line.
+
+## Rule Details
+
+This rule looks for every call to  `describe`, `context`, `it`, `specify`, `before`,  `after`, `beforeEach`, `afterEach`, `suite`, `test`, `suiteSetup`, `suiteTeardown`, `setup`, `teardown` and will ensure consistent spacing between the nearest token.
+
+## Options
+
+This rule has one option:
+
+* `"always"` (default) requires empty lines at the beginning and ending of test functions
+* `"never"` disallows empty lines at the beginning and ending of test functions
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```js
+describe(function() {
+    beforeEach(function(){});
+    afterEach(function(){});
+    it('', function() {});
+});
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```js
+describe(function() {
+
+    beforeEach(function(){});
+
+    afterEach(function(){});
+
+    it('', function() {});
+
+});
+```
+
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```js
+describe(function() {
+
+    beforeEach(function(){});
+
+    afterEach(function(){});
+
+    it('', function() {});
+
+});
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+describe(function() {
+    beforeEach(function(){});
+    afterEach(function(){});
+    it('', function() {});
+});
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of padding between test functions.

--- a/docs/rules/padding-between-test-functions.md
+++ b/docs/rules/padding-between-test-functions.md
@@ -1,12 +1,12 @@
 # Padding Between Test Functions (padding-between-test-functions)
 
-This is a stylistic rule that enforces or disallows spaces between test functions.
+This is a stylistic rule that enforces consistent empty line padding before and after mocha functions.
 
 **Fixable:** Problems detected by this rule are automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 
-This rule looks for every call to  `describe`, `context`, `it`, `specify`, `before`,  `after`, `beforeEach`, `afterEach`, `suite`, `test`, `suiteSetup`, `suiteTeardown`, `setup`, `teardown` and will ensure consistent spacing between the nearest token.
+This rule looks for every call to  `describe`, `context`, `it`, `specify`, `before`,  `after`, `beforeEach`, `afterEach`, `suite`, `test`, `suiteSetup`, `suiteTeardown`, `setup`, `teardown` and will ensure consistent spacing between it and the nearest token.
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
         'no-top-level-hooks': require('./lib/rules/no-top-level-hooks'),
         'no-identical-title': require('./lib/rules/no-identical-title'),
         'max-top-level-suites': require('./lib/rules/max-top-level-suites'),
-        'no-nested-tests': require('./lib/rules/no-nested-tests')
+        'no-nested-tests': require('./lib/rules/no-nested-tests'),
+        'padding-between-test-functions': require('./lib/rules/padding-between-test-functions')
     },
     configs: {
         recommended: {

--- a/lib/rules/padding-between-test-functions.js
+++ b/lib/rules/padding-between-test-functions.js
@@ -13,6 +13,90 @@ function isPaddingBetweenTokens(first, second) {
     return second.loc.start.line - first.loc.end.line >= 2;
 }
 
+/**
+ * Returns a fixer function for replacing multiple new lines with a single one.
+ * @param {Range} first first range to work against
+ * @param {Range} second second range to work against
+ * @returns {function} fixer function.
+ */
+function removeEmptyLinesBetweenTokens(first, second) {
+    return function (fixer) {
+        return fixer.replaceTextRange([ first.range[1], second.range[0] ], '\n');
+    };
+}
+
+/**
+ * Returns a function used to check top-padding.
+ * @param {*} sourceCode sourceCode from eslint plugin api.
+ * @param {string} opt always or never.
+ * @param {string} message message to use for error reporting.
+ * @returns {function} reporting function that returns array of errors.
+ */
+function getTopCheker(sourceCode, opt, message) {
+    return function (node) {
+        var firstToken = sourceCode.getFirstToken(node),
+        tokenBeforeFirst = sourceCode.getTokenBefore(firstToken, { includeComments: true }),
+        blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstToken),
+        errors = [];
+
+        if (blockHasTopPadding && opt === 'never') {
+            errors.push({
+                node: node,
+                message: message,
+                fix: removeEmptyLinesBetweenTokens(tokenBeforeFirst, firstToken)
+            });
+        }
+
+        if (!blockHasTopPadding && opt === 'always') {
+            errors.push({
+                node: node,
+                message: message,
+                fix: function (fixer) {
+                    return fixer.insertTextBefore(firstToken, '\n');
+                }
+            });
+        }
+
+        return errors;
+    };
+}
+
+/**
+ * Returns a function used to check top-padding.
+ * @param {*} sourceCode sourceCode from eslint plugin api.
+ * @param {string} opt always or never.
+ * @param {string} message message to use for error reporting.
+ * @returns {function} reporting function that returns array of errors.
+ */
+function getBottomCheker(sourceCode, opt, message) {
+    return function (node) {
+        var lastToken = sourceCode.getLastToken(node),
+        tokenAfterLast = sourceCode.getTokenAfter(lastToken, { includeComments: true }),
+        blockHasBottomPadding = isPaddingBetweenTokens(lastToken, tokenAfterLast),
+        errors = [];
+
+        if (blockHasBottomPadding && opt === 'never') {
+            errors.push({
+                node: node,
+                message: message,
+                fix: removeEmptyLinesBetweenTokens(lastToken, tokenAfterLast)
+            });
+        }
+
+        if (!blockHasBottomPadding && opt === 'always') {
+            errors.push({
+                node: node,
+                message: message,
+                fix: function (fixer) {
+                    return fixer.insertTextAfter(lastToken, '\n');
+                }
+            });
+        }
+
+        return errors;
+    };
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -28,83 +112,30 @@ module.exports = {
         } ]
     },
     create: function (context) {
-        var opt = context.options[0] || 'always',
-        message = opt === 'never'
-            ? 'Test functions must not be padded by blank lines.'
-            : 'Test functions must be padded by blank lines.',
-        sourceCode = context.getSourceCode();
+        var option = context.options[0] || 'always',
+            message = option === 'never'
+                ? 'Test functions must not be padded by blank lines.'
+                : 'Test functions must be padded by blank lines.',
+            sourceCode = context.getSourceCode(),
+            topChecker = getTopCheker(sourceCode, option, message),
+            bottomChecker = getBottomCheker(sourceCode, option, message);
 
         return {
             ExpressionStatement: function (node) {
-                var firstToken = sourceCode.getFirstToken(node),
-                    tokenBeforeFirst = sourceCode.getTokenBefore(firstToken, { includeComments: true }),
-                    lastToken = sourceCode.getLastToken(node),
-                    tokenAfterLast = sourceCode.getTokenAfter(lastToken, { includeComments: true });
+                var tokenBefore = sourceCode.getTokenBefore(node),
+                    tokenAfter = sourceCode.getTokenAfter(node),
+                    errors = [];
 
-                function shouldReturn() {
-                    return (
-                        !sourceCode.getTokenBefore(node) ||
-                        !sourceCode.getTokenAfter(node) ||
-                        astUtils.isTestFunction(node.expression)
-                    );
-                }
-
-                function always() {
-                    var blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstToken),
-                        blockHasBottomPadding = isPaddingBetweenTokens(lastToken, tokenAfterLast);
-                    if (!blockHasTopPadding) {
-                        context.report({
-                            node: node,
-                            message: message,
-                            fix: function (fixer) {
-                                return fixer.insertTextBefore(firstToken, '\n');
-                            }
-                        });
-                    }
-                    if (!blockHasBottomPadding) {
-                        context.report({
-                            node: node,
-                            message: message,
-                            fix: function (fixer) {
-                                return fixer.insertTextAfter(lastToken, '\n');
-                            }
-                        });
-                    }
-                }
-
-                function never() {
-                    var blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstToken),
-                        blockHasBottomPadding = isPaddingBetweenTokens(lastToken, tokenAfterLast);
-                    if (blockHasTopPadding) {
-                        context.report({
-                            node: node,
-                            message: message,
-                            fix: function (fixer) {
-                                return fixer.replaceTextRange([ tokenBeforeFirst.range[1], firstToken.range[0] ], '\n');
-                            }
-                        });
-                    }
-                    if (blockHasBottomPadding) {
-                        context.report({
-                            node: node,
-                            message: message,
-                            fix: function (fixer) {
-                                return fixer.replaceTextRange([ lastToken.range[1], tokenAfterLast.range[0] ], '\n');
-                            }
-                        });
-                    }
-                }
-
-                if (shouldReturn(node)) {
+                if (!tokenBefore || !tokenAfter || !astUtil.isTestFunction(node.expression)) {
                     return;
                 }
 
-                if (opt === 'never') {
-                    never();
-                }
-                if (opt === 'always') {
-                    always();
-                }
+                errors = errors.concat(topChecker(node));
+                errors = errors.concat(bottomChecker(node));
+
+                errors.forEach(function (error) {
+                    context.report(error);
+                });
             }
         };
     }

--- a/lib/rules/padding-between-test-functions.js
+++ b/lib/rules/padding-between-test-functions.js
@@ -1,7 +1,8 @@
 
 'use strict';
 
- var astUtil = require('../util/ast');
+var R = require('ramda'),
+    astUtil = require('../util/ast');
 
 /**
  * Checks if there is padding between two tokens
@@ -41,7 +42,8 @@ function getTopChecker(sourceCode, opt, message) {
 
         if (blockHasTopPadding && opt === 'never') {
             errors.push({
-                node: node,
+                start: tokenBeforeFirst,
+                end: firstToken,
                 message: message,
                 fix: removeEmptyLinesBetweenTokens(tokenBeforeFirst, firstToken)
             });
@@ -49,7 +51,8 @@ function getTopChecker(sourceCode, opt, message) {
 
         if (!blockHasTopPadding && opt === 'always') {
             errors.push({
-                node: node,
+                start: tokenBeforeFirst,
+                end: firstToken,
                 message: message,
                 fix: function (fixer) {
                     return fixer.insertTextBefore(firstToken, '\n');
@@ -77,7 +80,8 @@ function getBottomChecker(sourceCode, opt, message) {
 
         if (blockHasBottomPadding && opt === 'never') {
             errors.push({
-                node: node,
+                start: lastToken,
+                end: tokenAfterLast,
                 message: message,
                 fix: removeEmptyLinesBetweenTokens(lastToken, tokenAfterLast)
             });
@@ -85,7 +89,8 @@ function getBottomChecker(sourceCode, opt, message) {
 
         if (!blockHasBottomPadding && opt === 'always') {
             errors.push({
-                node: node,
+                start: lastToken,
+                end: tokenAfterLast,
                 message: message,
                 fix: function (fixer) {
                     return fixer.insertTextAfter(lastToken, '\n');
@@ -118,24 +123,43 @@ module.exports = {
                 : 'Test functions must be padded by blank lines.',
             sourceCode = context.getSourceCode(),
             topChecker = getTopChecker(sourceCode, option, message),
-            bottomChecker = getBottomChecker(sourceCode, option, message);
+            bottomChecker = getBottomChecker(sourceCode, option, message),
+            errors = [];
 
         return {
+            'Program:exit': function () {
+                R.pipe(
+                  R.uniqWith(function (a, b) {
+                      return a.start.start === b.start.start && a.end.end === b.end.end;
+                  }),
+                  R.map(function (error) {
+                      return {
+                          message: error.message,
+                          loc: {
+                              start: error.start.loc.end,
+                              end: error.end.loc.start
+                          },
+                          fix: error.fix
+                      };
+                  }),
+                  R.forEach(function (error) {
+                      context.report(error);
+                  })
+                )(errors);
+            },
             ExpressionStatement: function (node) {
                 var tokenBefore = sourceCode.getTokenBefore(node),
-                    tokenAfter = sourceCode.getTokenAfter(node),
-                    errors = [];
+                    tokenAfter = sourceCode.getTokenAfter(node);
 
                 if (!tokenBefore || !tokenAfter || !astUtil.isTestFunction(node.expression)) {
                     return;
                 }
 
-                errors = errors.concat(topChecker(node));
-                errors = errors.concat(bottomChecker(node));
-
-                errors.forEach(function (error) {
-                    context.report(error);
-                });
+                errors = R.reduce(
+                    R.concat,
+                    errors,
+                    [ topChecker(node), bottomChecker(node) ]
+                );
             }
         };
     }

--- a/lib/rules/padding-between-test-functions.js
+++ b/lib/rules/padding-between-test-functions.js
@@ -32,7 +32,7 @@ function removeEmptyLinesBetweenTokens(first, second) {
  * @param {string} message message to use for error reporting.
  * @returns {function} reporting function that returns array of errors.
  */
-function getTopCheker(sourceCode, opt, message) {
+function getTopChecker(sourceCode, opt, message) {
     return function (node) {
         var firstToken = sourceCode.getFirstToken(node),
         tokenBeforeFirst = sourceCode.getTokenBefore(firstToken, { includeComments: true }),
@@ -68,7 +68,7 @@ function getTopCheker(sourceCode, opt, message) {
  * @param {string} message message to use for error reporting.
  * @returns {function} reporting function that returns array of errors.
  */
-function getBottomCheker(sourceCode, opt, message) {
+function getBottomChecker(sourceCode, opt, message) {
     return function (node) {
         var lastToken = sourceCode.getLastToken(node),
         tokenAfterLast = sourceCode.getTokenAfter(lastToken, { includeComments: true }),
@@ -117,8 +117,8 @@ module.exports = {
                 ? 'Test functions must not be padded by blank lines.'
                 : 'Test functions must be padded by blank lines.',
             sourceCode = context.getSourceCode(),
-            topChecker = getTopCheker(sourceCode, option, message),
-            bottomChecker = getBottomCheker(sourceCode, option, message);
+            topChecker = getTopChecker(sourceCode, option, message),
+            bottomChecker = getBottomChecker(sourceCode, option, message);
 
         return {
             ExpressionStatement: function (node) {

--- a/lib/rules/padding-between-test-functions.js
+++ b/lib/rules/padding-between-test-functions.js
@@ -1,0 +1,142 @@
+
+'use strict';
+
+var names = [
+    'describe',
+    'context',
+    'it',
+    'specify',
+    'before',
+    'after',
+    'beforeEach',
+    'afterEach',
+    'suite',
+    'test',
+    'suiteSetup',
+    'suiteTeardown',
+    'setup',
+    'teardown'
+];
+
+/**
+ * Checks if a node is a test function expression, or object (e.g., it() or it.only())
+ * @param {Node} node node to check
+ * @returns {boolean} True if the node is a test function expression
+ */
+function isTestFunction(node) {
+  return (
+    node &&
+    node.expression &&
+    node.expression.callee && (
+        names.indexOf(node.expression.callee.name) > -1 ||
+        node.expression.callee.object && names.indexOf(node.expression.callee.object.name) > -1
+    )
+  );
+}
+
+/**
+ * Checks if there is padding between two tokens
+ * @param {Token} first The first token
+ * @param {Token} second The second token
+ * @returns {boolean} True if there is at least a line between the tokens
+ */
+function isPaddingBetweenTokens(first, second) {
+    return second.loc.start.line - first.loc.end.line >= 2;
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Enforce spacing between test functions',
+            category: 'Stylistic Issues',
+            recommended: false
+        },
+        fixable: 'whitespace',
+        schema: [ {
+            oneOf: [ {
+                enum: [ 'always', 'never' ]
+            } ]
+        } ]
+    },
+    create: function (context) {
+        var opt = context.options[0] || 'always',
+        message = opt === 'never'
+            ? 'Test functions must not be padded by blank lines.'
+            : 'Test functions must be padded by blank lines.',
+        sourceCode = context.getSourceCode();
+
+        return {
+            ExpressionStatement: function (node) {
+                var firstToken = sourceCode.getFirstToken(node),
+                    tokenBeforeFirst = sourceCode.getTokenBefore(firstToken, { includeComments: true }),
+                    lastToken = sourceCode.getLastToken(node),
+                    tokenAfterLast = sourceCode.getTokenAfter(lastToken, { includeComments: true });
+
+                function shouldReturn() {
+                    return (
+                        !sourceCode.getTokenBefore(node) ||
+                        !sourceCode.getTokenAfter(node) ||
+                        !isTestFunction(node)
+                    );
+                }
+
+                function always() {
+                    var blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstToken),
+                        blockHasBottomPadding = isPaddingBetweenTokens(lastToken, tokenAfterLast);
+                    if (!blockHasTopPadding) {
+                        context.report({
+                            node: node,
+                            message: message,
+                            fix: function (fixer) {
+                                return fixer.insertTextBefore(firstToken, '\n');
+                            }
+                        });
+                    }
+                    if (!blockHasBottomPadding) {
+                        context.report({
+                            node: node,
+                            message: message,
+                            fix: function (fixer) {
+                                return fixer.insertTextAfter(lastToken, '\n');
+                            }
+                        });
+                    }
+                }
+
+                function never() {
+                    var blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstToken),
+                        blockHasBottomPadding = isPaddingBetweenTokens(lastToken, tokenAfterLast);
+                    if (blockHasTopPadding) {
+                        context.report({
+                            node: node,
+                            message: message,
+                            fix: function (fixer) {
+                                return fixer.replaceTextRange([ tokenBeforeFirst.range[1], firstToken.range[0] ], '\n');
+                            }
+                        });
+                    }
+                    if (blockHasBottomPadding) {
+                        context.report({
+                            node: node,
+                            message: message,
+                            fix: function (fixer) {
+                                return fixer.replaceTextRange([ lastToken.range[1], tokenAfterLast.range[0] ], '\n');
+                            }
+                        });
+                    }
+                }
+
+                if (shouldReturn(node)) {
+                    return;
+                }
+
+                if (opt === 'never') {
+                    never();
+                }
+                if (opt === 'always') {
+                    always();
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/padding-between-test-functions.js
+++ b/lib/rules/padding-between-test-functions.js
@@ -1,38 +1,7 @@
 
 'use strict';
 
-var names = [
-    'describe',
-    'context',
-    'it',
-    'specify',
-    'before',
-    'after',
-    'beforeEach',
-    'afterEach',
-    'suite',
-    'test',
-    'suiteSetup',
-    'suiteTeardown',
-    'setup',
-    'teardown'
-];
-
-/**
- * Checks if a node is a test function expression, or object (e.g., it() or it.only())
- * @param {Node} node node to check
- * @returns {boolean} True if the node is a test function expression
- */
-function isTestFunction(node) {
-  return (
-    node &&
-    node.expression &&
-    node.expression.callee && (
-        names.indexOf(node.expression.callee.name) > -1 ||
-        node.expression.callee.object && names.indexOf(node.expression.callee.object.name) > -1
-    )
-  );
-}
+ var astUtil = require('../util/ast');
 
 /**
  * Checks if there is padding between two tokens
@@ -76,7 +45,7 @@ module.exports = {
                     return (
                         !sourceCode.getTokenBefore(node) ||
                         !sourceCode.getTokenAfter(node) ||
-                        !isTestFunction(node)
+                        astUtils.isTestFunction(node.expression)
                     );
                 }
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -5,7 +5,8 @@
 var describeAliases = [ 'describe', 'xdescribe', 'describe.only', 'describe.skip',
                         'context', 'xcontext', 'context.only', 'context.skip',
                         'suite', 'xsuite', 'suite.only', 'suite.skip' ],
-    hooks = [ 'before', 'after', 'beforeEach', 'afterEach' ],
+    hooks = [ 'before', 'after', 'beforeEach', 'afterEach', 'setup', 'tearDown',
+              'suiteSetup', 'suiteTeardown' ],
     testCaseNames = [ 'it', 'it.only', 'it.skip',
                       'test', 'test.only', 'test.skip',
                       'specify', 'specify.only', 'specify.skip' ];
@@ -39,10 +40,15 @@ function isTestCase(node) {
         && testCaseNames.indexOf(getNodeName(node.callee)) > -1;
 }
 
+function isTestFunction(node, additionalSuiteNames) {
+    return isDescribe(node, additionalSuiteNames) || isHookIdentifier(node.callee) || isTestCase(node);
+}
+
 module.exports = {
   isDescribe: isDescribe,
   isHookIdentifier: isHookIdentifier,
   isTestCase: isTestCase,
+  isTestFunction: isTestFunction,
   getPropertyName: getPropertyName,
   getNodeName: getNodeName
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     },
     "author": "Mathias Schreck <schreck.mathias@gmail.com>",
     "contributors": [
-        "Alexander Schmidt <alexanderschmidt1@gmail.com>"
+        "Alexander Schmidt <alexanderschmidt1@gmail.com>",
+        "Tyler Waters <tyler.waters@gmail.com>"
     ],
     "license": "MIT",
     "bugs": {

--- a/test/rules/padding-between-test-function.js
+++ b/test/rules/padding-between-test-function.js
@@ -11,38 +11,174 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
 
     valid: [
         {
-            code: 'describe(function(){\n\nit("", function () {})\n\n})'
+            code: [
+                'describe(function(){',
+                '',
+                'it("", function () {})',
+                '',
+                '})'
+            ].join('\n')
         },
         {
-            code: 'describe(function(){\n\nit("", function () {})\n\n})',
+            code: [
+                'describe(function(){',
+                '',
+                'it("", function () {})',
+                '',
+                '})'
+            ].join('\n'),
             options: [ 'always' ]
         },
         {
-            code: 'describe(function(){\n\nit.only("", function () {})\n\n})',
+            code: [
+                'describe(function(){',
+                '',
+                'it.only("", function () {})',
+                '',
+                '})'
+            ].join('\n'),
             options: [ 'always' ]
         },
         {
-            code: 'describe(function(){\nit("", function () {})\n})',
+            code: [
+                'describe(function(){',
+                'it("", function () {})',
+                '})'
+            ].join('\n'),
             options: [ 'never' ]
         },
         {
-            code: 'describe(function(){\nit.only("", function () {})\n})',
+            code: [
+                'describe(function(){',
+                'it.only("", function () {})',
+                '})'
+            ].join('\n'),
             options: [ 'never' ]
+        },
+        {
+            code: [
+                '[1,2,3].forEach(function () {',
+                'it("foo", function () {});',
+                '});'
+            ].join('\n'),
+            options: [ 'never' ]
+        },
+        {
+            code: [
+                '[1,2,3].forEach(function () {',
+                '',
+                'it("foo", function () {});',
+                '',
+                '});'
+            ].join('\n'),
+            options: [ 'always' ]
+        },
+        {
+            code: [
+                'describe("foo", {});',
+                'somethingElse();'
+            ].join('\n'),
+            options: [ 'never' ]
+        },
+        {
+            code: [
+                'describe("foo", {});',
+                '',
+                'somethingElse();'
+            ].join('\n'),
+            options: [ 'always' ]
         }
     ],
 
     invalid: [
         {
-            code: 'describe(function(){\n\nit("", function () {})\n\n})',
+            code: [
+                'describe(function(){',
+                '',
+                'it("", function () {})',
+                '',
+                '})'
+            ].join('\n'),
             options: [ 'never' ],
             errors: [ { message: NEVER_MESSAGE }, { message: NEVER_MESSAGE } ],
-            output: 'describe(function(){\nit("", function () {})\n})'
+            output: [
+                'describe(function(){',
+                'it("", function () {})',
+                '})'
+            ].join('\n')
         },
         {
-            code: 'describe(function(){\nit("", function () {})\n})',
+            code: [
+                'describe(function(){',
+                'it("", function () {})',
+                '})'
+            ].join('\n'),
             options: [ 'always' ],
             errors: [ { message: ALWAYS_MESSAGE }, { message: ALWAYS_MESSAGE } ],
-            output: 'describe(function(){\n\nit("", function () {})\n\n})'
+            output: [
+                'describe(function(){',
+                '',
+                'it("", function () {})',
+                '',
+                '})'
+            ].join('\n')
+        },
+        {
+            code: [
+                '[1,2,3].forEach(function () {',
+                '',
+                'it("foo", function () {});',
+                '',
+                '});'
+            ].join('\n'),
+            options: [ 'never' ],
+            errors: [ { message: NEVER_MESSAGE }, { message: NEVER_MESSAGE } ],
+            output: [
+                '[1,2,3].forEach(function () {',
+                'it("foo", function () {});',
+                '});'
+            ].join('\n')
+        },
+        {
+            code: [
+                '[1,2,3].forEach(function () {',
+                'it("foo", function () {});',
+                '});'
+            ].join('\n'),
+            options: [ 'always' ],
+            errors: [ { message: ALWAYS_MESSAGE }, { message: ALWAYS_MESSAGE } ],
+            output: [
+                '[1,2,3].forEach(function () {',
+                '',
+                'it("foo", function () {});',
+                '',
+                '});'
+            ].join('\n')
+        },
+        {
+            code: [
+                'describe(function(){',
+                'var someVar=null;',
+                'beforeEach(function(){someVar = "test"});',
+                'it("foo", function(){assert(someVar)});',
+                '})'
+            ].join('\n'),
+            options: [ 'always' ],
+            errors: [
+                { message: ALWAYS_MESSAGE },
+                { message: ALWAYS_MESSAGE },
+                { message: ALWAYS_MESSAGE }
+            ],
+            output: [
+                'describe(function(){',
+                'var someVar=null;',
+                '',
+                'beforeEach(function(){someVar = "test"});',
+                '',
+                'it("foo", function(){assert(someVar)});',
+                '',
+                '})'
+            ].join('\n')
         }
     ]
 

--- a/test/rules/padding-between-test-function.js
+++ b/test/rules/padding-between-test-function.js
@@ -14,6 +14,17 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
             code: [
                 'describe(function(){',
                 '',
+                '',
+                'it("", function () {})',
+                '',
+                '',
+                '})'
+            ].join('\n')
+        },
+        {
+            code: [
+                'describe(function(){',
+                '',
                 'it("", function () {})',
                 '',
                 '})'
@@ -100,7 +111,19 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
                 '})'
             ].join('\n'),
             options: [ 'never' ],
-            errors: [ { message: NEVER_MESSAGE }, { message: NEVER_MESSAGE } ],
+            errors: [ {
+                message: NEVER_MESSAGE,
+                line: 1,
+                column: 21,
+                endLine: 3,
+                endColumn: 1
+            }, {
+                message: NEVER_MESSAGE,
+                line: 3,
+                column: 23,
+                endLine: 5,
+                endColumn: 1
+            } ],
             output: [
                 'describe(function(){',
                 'it("", function () {})',
@@ -114,7 +137,19 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
                 '})'
             ].join('\n'),
             options: [ 'always' ],
-            errors: [ { message: ALWAYS_MESSAGE }, { message: ALWAYS_MESSAGE } ],
+            errors: [ {
+                message: ALWAYS_MESSAGE,
+                line: 1,
+                column: 21,
+                endLine: 2,
+                endColumn: 1
+            }, {
+                message: ALWAYS_MESSAGE,
+                line: 2,
+                column: 23,
+                endLine: 3,
+                endColumn: 1
+            } ],
             output: [
                 'describe(function(){',
                 '',
@@ -127,30 +162,54 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
             code: [
                 '[1,2,3].forEach(function () {',
                 '',
-                'it("foo", function () {});',
+                'it("", function () {})',
                 '',
                 '});'
             ].join('\n'),
             options: [ 'never' ],
-            errors: [ { message: NEVER_MESSAGE }, { message: NEVER_MESSAGE } ],
+            errors: [ {
+                message: NEVER_MESSAGE,
+                line: 1,
+                column: 30,
+                endLine: 3,
+                endColumn: 1
+            }, {
+                message: NEVER_MESSAGE,
+                line: 3,
+                column: 23,
+                endLine: 5,
+                endColumn: 1
+            } ],
             output: [
                 '[1,2,3].forEach(function () {',
-                'it("foo", function () {});',
+                'it("", function () {})',
                 '});'
             ].join('\n')
         },
         {
             code: [
                 '[1,2,3].forEach(function () {',
-                'it("foo", function () {});',
+                'it("", function () {})',
                 '});'
             ].join('\n'),
             options: [ 'always' ],
-            errors: [ { message: ALWAYS_MESSAGE }, { message: ALWAYS_MESSAGE } ],
+            errors: [ {
+                message: ALWAYS_MESSAGE,
+                line: 1,
+                column: 30,
+                endLine: 2,
+                endColumn: 1
+            }, {
+                message: ALWAYS_MESSAGE,
+                line: 2,
+                column: 23,
+                endLine: 3,
+                endColumn: 1
+            } ],
             output: [
                 '[1,2,3].forEach(function () {',
                 '',
-                'it("foo", function () {});',
+                'it("", function () {})',
                 '',
                 '});'
             ].join('\n')
@@ -164,11 +223,25 @@ ruleTester.run('padding-between-tests', rules['padding-between-test-functions'],
                 '})'
             ].join('\n'),
             options: [ 'always' ],
-            errors: [
-                { message: ALWAYS_MESSAGE },
-                { message: ALWAYS_MESSAGE },
-                { message: ALWAYS_MESSAGE }
-            ],
+            errors: [ {
+                message: ALWAYS_MESSAGE,
+                line: 2,
+                column: 18,
+                endLine: 3,
+                endColumn: 1
+            }, {
+                message: ALWAYS_MESSAGE,
+                line: 3,
+                column: 42,
+                endLine: 4,
+                endColumn: 1
+            }, {
+                message: ALWAYS_MESSAGE,
+                line: 4,
+                column: 40,
+                endLine: 5,
+                endColumn: 1
+            } ],
             output: [
                 'describe(function(){',
                 'var someVar=null;',

--- a/test/rules/padding-between-test-function.js
+++ b/test/rules/padding-between-test-function.js
@@ -1,0 +1,49 @@
+
+'use strict';
+
+var RuleTester = require('eslint').RuleTester,
+    rules = require('../../').rules,
+    ruleTester = new RuleTester(),
+    ALWAYS_MESSAGE = 'Test functions must be padded by blank lines.',
+    NEVER_MESSAGE = 'Test functions must not be padded by blank lines.';
+
+ruleTester.run('padding-between-tests', rules['padding-between-test-functions'], {
+
+    valid: [
+        {
+            code: 'describe(function(){\n\nit("", function () {})\n\n})'
+        },
+        {
+            code: 'describe(function(){\n\nit("", function () {})\n\n})',
+            options: [ 'always' ]
+        },
+        {
+            code: 'describe(function(){\n\nit.only("", function () {})\n\n})',
+            options: [ 'always' ]
+        },
+        {
+            code: 'describe(function(){\nit("", function () {})\n})',
+            options: [ 'never' ]
+        },
+        {
+            code: 'describe(function(){\nit.only("", function () {})\n})',
+            options: [ 'never' ]
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'describe(function(){\n\nit("", function () {})\n\n})',
+            options: [ 'never' ],
+            errors: [ { message: NEVER_MESSAGE }, { message: NEVER_MESSAGE } ],
+            output: 'describe(function(){\nit("", function () {})\n})'
+        },
+        {
+            code: 'describe(function(){\nit("", function () {})\n})',
+            options: [ 'always' ],
+            errors: [ { message: ALWAYS_MESSAGE }, { message: ALWAYS_MESSAGE } ],
+            output: 'describe(function(){\n\nit("", function () {})\n\n})'
+        }
+    ]
+
+});


### PR DESCRIPTION
Fixes #145 

--

As an aside, I had a heck of a time getting my plugin, as-written, to fit in the eslint ruleset of this project:

- complexity of 4 meant i needed to abuse nested functions a bit... the function really needs complexity of 5 to work properly (exit early if statement; each option has different reports/fixers for padding above/below)

- vars-on-top means I needed to split out the calls to `isPaddingBetweenTokens` into individual functions... it would normally exit early based on results of var declarations, and set up `hasTop/BottomPadding` afterwards.

It's passing the test suite / linting rules for the project, but I fear it has gotten more complex and harder to follow as a result.
