### PR TITLE
Remove support for nodejs 4, 5 and 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
 notifications:
    email: false


### PR DESCRIPTION
In order to use more modern language feature I’m going to plan removing nodejs 4 support with next major release.
Alongside we will also drop support for nodejs 5 and 7 which are end-of-life anyway.