### PR TITLE
Remove support for ESLint versions < 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ESLint rules for [mocha](http://mochajs.org/).
 
 ## Install and configure
 
-This plugin requires ESLint `2.0.0` or later.
+This plugin requires ESLint `4.0.0` or later.
 
 `npm install --save-dev eslint-plugin-mocha`
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "coveralls": "^3.0.0"
     },
     "peerDependencies": {
-        "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "eslint": ">= 4.0.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
AFAIK there is nothing breaking with ESLint versions < 4.0.0 yet but I think it would make sense to get rid of supporting those versions in order to keep maintenance of this project easy.