### PR TITLE
Prohibit tests in beforeEach etc. hook calls

### DIFF
--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -17,16 +17,9 @@ module.exports = function noNestedTests(context) {
         });
     }
 
-    function isNestedTest(isTestCase, isDescribe) {
-        const isNested = testNestingLevel > 0;
+    function isNestedTest(isTestCase, isDescribe, nestingLevel) {
+        const isNested = nestingLevel > 0;
         const isTest = isTestCase || isDescribe;
-
-        return isNested && isTest;
-    }
-
-    function isTestInHookCall(isTestCase, isHookCall) {
-        const isNested = hookCallNestingLevel > 0;
-        const isTest = isTestCase || isHookCall;
 
         return isNested && isTest;
     }
@@ -37,12 +30,12 @@ module.exports = function noNestedTests(context) {
             const isHookCall = astUtils.isHookCall(node);
             const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
 
-            if (isNestedTest(isTestCase, isDescribe)) {
+            if (isNestedTest(isTestCase, isDescribe, testNestingLevel)) {
                 const message = isDescribe ?
                     'Unexpected suite nested within a test.' :
                     'Unexpected test nested within another test.';
                 report(node, message);
-            } else if (isTestInHookCall(isTestCase, isHookCall)) {
+            } else if (isNestedTest(isTestCase, isHookCall, hookCallNestingLevel)) {
                 report(node, 'Unexpected test nested within a test hook.');
             }
 

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -26,7 +26,7 @@ module.exports = function noNestedTests(context) {
 
     return {
         CallExpression(node) {
-            const isTestCase = astUtils.isTestCase(node);
+            const isTestCase = astUtils.isTestCase(node) || astUtils.isHookCall(node);
             const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
 
             if (isNestedTest(isTestCase, isDescribe)) {

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -6,11 +6,9 @@ const { additionalSuiteNames } = require('../util/settings');
 module.exports = function noNestedTests(context) {
     const settings = context.settings;
     let testNestingLevel = 0;
+    let hookCallNestingLevel = 0;
 
-    function report(callExpression, isTestCase) {
-        const message = isTestCase ? 'Unexpected test nested within another test.' :
-            'Unexpected suite nested within a test.';
-
+    function report(callExpression, message) {
         context.report({
             message,
             node: callExpression.callee
@@ -24,23 +22,40 @@ module.exports = function noNestedTests(context) {
         return isNested && isTest;
     }
 
+    function isTestInHookCall(isTestCase, isHookCall) {
+        const isNested = hookCallNestingLevel > 0;
+        const isTest = isTestCase || isHookCall;
+
+        return isNested && isTest;
+    }
+
     return {
         CallExpression(node) {
-            const isTestCase = astUtils.isTestCase(node) || astUtils.isHookCall(node);
+            const isTestCase = astUtils.isTestCase(node);
+            const isHookCall = astUtils.isHookCall(node);
             const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
 
             if (isNestedTest(isTestCase, isDescribe)) {
-                report(node, isTestCase);
+                const message = isDescribe ?
+                    'Unexpected suite nested within a test.' :
+                    'Unexpected test nested within another test.';
+                report(node, message);
+            } else if (isTestInHookCall(isTestCase, isHookCall)) {
+                report(node, 'Unexpected test nested within a test hook.');
             }
 
             if (isTestCase) {
                 testNestingLevel += 1;
+            } else if (isHookCall) {
+                hookCallNestingLevel += 1;
             }
         },
 
         'CallExpression:exit'(node) {
             if (astUtils.isTestCase(node)) {
                 testNestingLevel -= 1;
+            } else if (astUtils.isHookCall(node)) {
+                hookCallNestingLevel -= 1;
             }
         }
     };

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint "complexity": [ "error", 6 ] */
+
 const astUtils = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');
 

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint "complexity": [ "error", 6 ] */
+/* eslint "complexity": [ "error", 5 ] */
 
 const astUtils = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -24,20 +24,27 @@ module.exports = function noNestedTests(context) {
         return isNested && isTest;
     }
 
+    function checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall) {
+        if (isNestedTest(isTestCase, isDescribe, testNestingLevel)) {
+            const message = isDescribe ?
+                'Unexpected suite nested within a test.' :
+                'Unexpected test nested within another test.';
+            report(node, message);
+        } else if (isNestedTest(isTestCase, isHookCall, hookCallNestingLevel)) {
+            const message = isHookCall ?
+                'Unexpected test hook nested within a test hook.' :
+                'Unexpected test nested within a test hook.';
+            report(node, message);
+        }
+    }
+
     return {
         CallExpression(node) {
             const isTestCase = astUtils.isTestCase(node);
             const isHookCall = astUtils.isHookCall(node);
             const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
 
-            if (isNestedTest(isTestCase, isDescribe, testNestingLevel)) {
-                const message = isDescribe ?
-                    'Unexpected suite nested within a test.' :
-                    'Unexpected test nested within another test.';
-                report(node, message);
-            } else if (isNestedTest(isTestCase, isHookCall, hookCallNestingLevel)) {
-                report(node, 'Unexpected test nested within a test hook.');
-            }
+            checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall);
 
             if (isTestCase) {
                 testNestingLevel += 1;

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -10,7 +10,7 @@ const describeAliases = [
     'context', 'xcontext', 'context.only', 'context.skip',
     'suite', 'xsuite', 'suite.only', 'suite.skip'
 ];
-const hooks = [ 'before', 'after', 'beforeEach', 'afterEach' ];
+const hooks = [ 'before', 'after', 'beforeEach', 'afterEach', 'beforeAll', 'afterAll' ];
 const testCaseNames = [
     'it', 'it.only', 'it.skip', 'xit',
     'test', 'test.only', 'test.skip',

--- a/test/rules/no-nested-tests.js
+++ b/test/rules/no-nested-tests.js
@@ -141,6 +141,22 @@ ruleTester.run('no-nested-tests', rule, {
                 line: 1,
                 column: 22
             } ]
+        },
+        {
+            code: 'beforeEach(function () { it("foo", function () {}); });',
+            errors: [ {
+                message: 'Unexpected test nested within another test.',
+                line: 1,
+                column: 26
+            } ]
+        },
+        {
+            code: 'beforeEach(function () { beforeEach("foo", function () {}); });',
+            errors: [ {
+                message: 'Unexpected test nested within another test.',
+                line: 1,
+                column: 26
+            } ]
         }
     ]
 });

--- a/test/rules/no-nested-tests.js
+++ b/test/rules/no-nested-tests.js
@@ -145,7 +145,7 @@ ruleTester.run('no-nested-tests', rule, {
         {
             code: 'beforeEach(function () { it("foo", function () {}); });',
             errors: [ {
-                message: 'Unexpected test nested within another test.',
+                message: 'Unexpected test nested within a test hook.',
                 line: 1,
                 column: 26
             } ]
@@ -153,7 +153,7 @@ ruleTester.run('no-nested-tests', rule, {
         {
             code: 'beforeEach(function () { beforeEach("foo", function () {}); });',
             errors: [ {
-                message: 'Unexpected test nested within another test.',
+                message: 'Unexpected test nested within a test hook.',
                 line: 1,
                 column: 26
             } ]

--- a/test/rules/no-nested-tests.js
+++ b/test/rules/no-nested-tests.js
@@ -153,7 +153,7 @@ ruleTester.run('no-nested-tests', rule, {
         {
             code: 'beforeEach(function () { beforeEach("foo", function () {}); });',
             errors: [ {
-                message: 'Unexpected test nested within a test hook.',
+                message: 'Unexpected test hook nested within a test hook.',
                 line: 1,
                 column: 26
             } ]


### PR DESCRIPTION
This is just a quick implementation to see if there's any interest. And yes, this actually happened :)

Questions:
- [ ] Should this be a separate rule?
- [ ] Is it a requirement to make sure that the error messages say eg. `Unexpected test nested within a beforeEach hook.` rather than `Unexpected test nested within another test.`?