### PR TITLE
Issue #179 Enhancement: Enable codeceptJs support for no-exclusive-tests rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.2.1 (?? ??, 2018)
+
+### Enhancements
+
+* Enable Disallow Exclusive Tests support for CodeceptJS based tests ([#179](https://github.com/lo1tuma/eslint-plugin-mocha/issues/179))
+
 ## 5.2.0 (August 13, 2018)
 
 ### Enhancements

--- a/docs/rules/no-exclusive-tests.md
+++ b/docs/rules/no-exclusive-tests.md
@@ -8,7 +8,7 @@ This rule reminds you to remove `.only` from your tests by raising a warning whe
 
 ## Rule Details
 
-This rule looks for every `describe.only`, `it.only`, `suite.only`, `test.only`, `context.only` and `specify.only`occurrences within the source code.
+This rule looks for every `describe.only`, `it.only`, `suite.only`, `test.only`, `context.only`, `specify.only`, and `Scenario.only` occurrences within the source code.
 Of course there are some edge-cases which can’t be detected by this rule e.g.:
 
 ```js

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -10,7 +10,8 @@ module.exports = function (context) {
         'suite',
         'test',
         'context',
-        'specify'
+        'specify',
+        'Scenario'
     ];
     const settings = context.settings;
     const additionalTestFunctions = getAdditionalTestFunctions(settings);

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -63,6 +63,10 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
             errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },
         {
+            code: 'Scenario.only()',
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
+        },
+        {
             code: 'suite["only"]()',
             errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },


### PR DESCRIPTION
This PR allows the usage of the `no-exclusive-tests` rule in [CodeceptJS](https://codecept.io/) based end to end tests.