### PR TITLE
Replace `warning` with `warn`

### DIFF
--- a/docs/rules/max-top-level-suites.md
+++ b/docs/rules/max-top-level-suites.md
@@ -37,6 +37,6 @@ If you want to change the suite limit to, for instance, 2 suites per file:
 
 ```js
 rules: {
-   "mocha/max-top-level-suites": ["warning", {limit: 2}]
+   "mocha/max-top-level-suites": ["warn", {limit: 2}]
 },
 ```

--- a/docs/rules/no-synchronous-tests.md
+++ b/docs/rules/no-synchronous-tests.md
@@ -44,7 +44,7 @@ You can change the acceptable asynchronous test methods to only allow a combinat
 
 ```js
 rules: {
-   "mocha/no-synchronous-tests": ["warning", {allowed: ['async', 'callback', 'promise']}]
+   "mocha/no-synchronous-tests": ["warn", {allowed: ['async', 'callback', 'promise']}]
 },
 ```
 

--- a/docs/rules/valid-suite-description.md
+++ b/docs/rules/valid-suite-description.md
@@ -11,13 +11,13 @@ Example of a custom rule configuration:
 
 ```js
 rules: {
-   "mocha/valid-suite-description": ["warning", "^[A-Z]"]
+   "mocha/valid-suite-description": ["warn", "^[A-Z]"]
 },
 ```
 
 where:
 
- * `warning` is a rule error level (see [Configuring Rules](http://eslint.org/docs/user-guide/configuring#configuring-rules))
+ * `warn` is a rule error level (see [Configuring Rules](http://eslint.org/docs/user-guide/configuring#configuring-rules))
  * `^[A-Z]` is a custom regular expression pattern to match suite names against; `^[A-Z]` enforces a suite name to start with an upper-case letter
 
 The following patterns are considered warnings (with the example rule configuration posted above):
@@ -46,6 +46,6 @@ There is also possible to configure a custom list of suite names via the second 
 
 ```js
 rules: {
-   "mocha/valid-suite-description": ["warning", "^[A-Z]", ["describe", "context", "suite", "mysuitename"]]
+   "mocha/valid-suite-description": ["warn", "^[A-Z]", ["describe", "context", "suite", "mysuitename"]]
 },
 ```

--- a/docs/rules/valid-test-description.md
+++ b/docs/rules/valid-test-description.md
@@ -11,13 +11,13 @@ Example of a custom rule configuration:
 
 ```js
    rules: {
-       "mocha/valid-test-description": ["warning", "mypattern$", ["it", "specify", "test", "mytestname"]]
+       "mocha/valid-test-description": ["warn", "mypattern$", ["it", "specify", "test", "mytestname"]]
    },
 ```
 
 where:
 
- * `warning` is a rule error level (see [Configuring Rules](http://eslint.org/docs/user-guide/configuring#configuring-rules))
+ * `warn` is a rule error level (see [Configuring Rules](http://eslint.org/docs/user-guide/configuring#configuring-rules))
  * `mypattern$` is a custom regular expression pattern to match test names against
  * `["it", "specify", "test", "mytestname"]` is an array of custom test names 
 


### PR DESCRIPTION
```
Configuration for rule "mocha/valid-test-description" is invalid:
Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"warning"').
```