### PR TITLE
Fix invalid syntax in test case

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -28,17 +28,6 @@ function isFunctionName(variable) {
 }
 
 /**
- * Checks whether or not a given MetaProperty node equals to a given value.
- * @param {ASTNode} node - A MetaProperty node to check.
- * @param {string} metaName - The name of `MetaProperty.meta`.
- * @param {string} propertyName - The name of `MetaProperty.property`.
- * @returns {boolean} `true` if the node is the specific value.
- */
-function checkMetaProperty(node, metaName, propertyName) {
-    return node.meta.name === metaName && node.property.name === propertyName;
-}
-
-/**
  * Gets the variable object of `arguments` which is defined implicitly.
  * @param {eslint-scope.Scope} scope - A scope to get.
  * @returns {eslint-scope.Variable} The found variable object.
@@ -245,12 +234,10 @@ module.exports = {
                 }
             },
 
-            MetaProperty(node) {
+            MetaProperty() {
                 const info = stack[stack.length - 1];
 
-                if (info && checkMetaProperty(node, 'new', 'target')) {
-                    info.meta = true;
-                }
+                info.meta = true;
             },
 
             // To skip nested scopes.

--- a/test/rules/prefer-arrow-callback.js
+++ b/test/rules/prefer-arrow-callback.js
@@ -45,7 +45,6 @@ ruleTester.run('prefer-arrow-callback', rules['prefer-arrow-callback'], {
         '() => super()',
         'foo(function bar() { new.target; });',
         'foo(function bar() { new.target; }.bind(this));',
-        '() => new.target',
         'foo(function bar() { this; }.bind(this, somethingElse));',
         // mocha-specific valid test cases
         'before(function bar() {});',


### PR DESCRIPTION
`new.target` is only allowed in functions, when it’s used elsewhere we will get a parsing error.
I’ve also removed the unnecessary if statement in the rule as we can’t test the else branch because it is unreachable.