### PR TITLE
Fix no-setup-in-describe to correctly detect describe calls

### DIFF
--- a/lib/rules/no-setup-in-describe.js
+++ b/lib/rules/no-setup-in-describe.js
@@ -49,14 +49,17 @@ module.exports = function noSetupInDescribe(context) {
         }
     }
 
+    function isDescribe(node) {
+        return astUtils.isDescribe(node, additionalSuiteNames(settings));
+    }
+
     function isParentDescribe(node) {
-        return astUtils.isDescribe(node.parent, additionalSuiteNames(settings));
+        return isDescribe(node.parent);
     }
 
     return {
         CallExpression(node) {
-            const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
-            if (isDescribe) {
+            if (isDescribe(node)) {
                 nesting.push(DESCRIBE);
                 return;
             }
@@ -68,7 +71,7 @@ module.exports = function noSetupInDescribe(context) {
         },
 
         'CallExpression:exit'(node) {
-            if (astUtils.isDescribe(node) || nesting.length && isPureNode(node)) {
+            if (isDescribe(node) || nesting.length && isPureNode(node)) {
                 nesting.pop();
             }
         },

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -28,7 +28,7 @@ function getNodeName(node) {
     return node.name;
 }
 
-function isDescribe(node, additionalSuiteNames) {
+function isDescribe(node, additionalSuiteNames = []) {
     return isCallExpression(node) &&
       describeAliases.concat(additionalSuiteNames).indexOf(getNodeName(node.callee)) > -1;
 }

--- a/test/rules/no-setup-in-describe.js
+++ b/test/rules/no-setup-in-describe.js
@@ -52,6 +52,16 @@ ruleTester.run('no-setup-in-describe', rule, {
                     additionalSuiteNames: [ 'foo' ]
                 }
             }
+        },
+        {
+            code: `describe('', () => {
+              it('', () =>{
+                  foo()();
+                  foo()();
+                  bar();
+              });
+            });`,
+            parserOptions: { ecmaVersion: 2015 }
         }
     ],
 


### PR DESCRIPTION
There was one call of `astUtils.isDescribe` which has been called without the second parameter which caused the function to accept `undefined` as a valid alias for suite function names. Additionally there are cases where we don’t get a node name for `CallExpressions` (e.g. `foo()()`). So in such cases the extracted node name is `undefined` and `isDescribe` will return true due to the above mentioned
bug.

Fixes: #172