### PR TITLE
Add custom message for valid-test-description rule

### DIFF
--- a/docs/rules/valid-test-description.md
+++ b/docs/rules/valid-test-description.md
@@ -1,17 +1,21 @@
 # Match test descriptions against a pre-configured regular expression (valid-test-description)
 
-This rule enforces the test descriptions to follow the desired format. 
+This rule enforces the test descriptions to follow the desired format.
 
 ## Rule Details
 
-By default, the regular expression is configured to be "^should" which requires test descriptions to start with "should". 
+By default, the regular expression is configured to be "^should" which requires test descriptions to start with "should".
 By default, the rule supports "it", "specify" and "test" test function names, but it can be configured to look for different test names via rule configuration.
 
 Example of a custom rule configuration:
 
 ```js
    rules: {
-       "mocha/valid-test-description": ["warn", "mypattern$", ["it", "specify", "test", "mytestname"]]
+       "mocha/valid-test-description": ["warn", "mypattern$", ["it", "specify", "test", "mytestname"], "custom error message"]
+   },
+   // OR
+   rules: {
+       "mocha/valid-test-description": ["warn", { pattern: "mypattern$", testNames: ["it", "specify", "test", "mytestname"], message: 'custom error message' }]
    },
 ```
 
@@ -19,7 +23,8 @@ where:
 
  * `warn` is a rule error level (see [Configuring Rules](http://eslint.org/docs/user-guide/configuring#configuring-rules))
  * `mypattern$` is a custom regular expression pattern to match test names against
- * `["it", "specify", "test", "mytestname"]` is an array of custom test names 
+ * `["it", "specify", "test", "mytestname"]` is an array of custom test names
+ * `custom error message` a custom error message to describe your pattern
 
 The following patterns are considered warnings (with the default rule configuration):
 

--- a/lib/rules/valid-test-description.js
+++ b/lib/rules/valid-test-description.js
@@ -9,9 +9,28 @@ const astUtils = require('../util/ast');
 
 const defaultTestNames = [ 'it', 'test', 'specify' ];
 
-module.exports = function (context) {
+function inlineOptions(context) {
     const pattern = context.options[0] ? new RegExp(context.options[0]) : /^should/;
     const testNames = context.options[1] ? context.options[1] : defaultTestNames;
+    const message = context.options[2];
+
+    return { pattern, testNames, message };
+}
+
+function objectOptions(options) {
+    const pattern = options.pattern ? new RegExp(options.pattern) : /^should/;
+    const testNames = options.testNames ? options.testNames : defaultTestNames;
+    const message = options.message;
+
+    return { pattern, testNames, message };
+}
+
+module.exports = function (context) {
+    const options = context.options[0];
+
+    const { pattern, testNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
+        objectOptions(options) :
+        inlineOptions(context);
 
     function isTest(node) {
         return node.callee && node.callee.name && testNames.indexOf(node.callee.name) > -1;
@@ -41,7 +60,7 @@ module.exports = function (context) {
 
             if (isTest(node)) {
                 if (!hasValidOrNoTestDescription(node)) {
-                    context.report(node, `Invalid "${ callee.name }()" description found.`);
+                    context.report(node, message || `Invalid "${ callee.name }()" description found.`);
                 }
             }
         }

--- a/test/rules/valid-test-description.js
+++ b/test/rules/valid-test-description.js
@@ -31,6 +31,22 @@ ruleTester.run('valid-test-description', rules['valid-test-description'], {
             options: [ '^should', [ 'someFunction' ] ],
             code: 'someFunction("should do something", function () { });'
         },
+        {
+            options: [ '^should', [ 'someFunction' ], 'some error message' ],
+            code: 'someFunction("should do something", function () { });'
+        },
+        {
+            options: [ /^should/, [ 'someFunction' ], 'some error message' ],
+            code: 'someFunction("should do something", function () { });'
+        },
+        {
+            options: [ { pattern: '^should', testNames: [ 'someFunction' ], message: 'some error message' } ],
+            code: 'someFunction("should do something", function () { });'
+        },
+        {
+            options: [ { pattern: /^should/, testNames: [ 'someFunction' ], message: 'some error message' } ],
+            code: 'someFunction("should do something", function () { });'
+        },
         'someOtherFunction();',
         {
             parserOptions: { ecmaVersion: 2017 },
@@ -83,6 +99,27 @@ ruleTester.run('valid-test-description', rules['valid-test-description'], {
             code: 'customFunction("this is a test", function () { });',
             errors: [
                 { message: 'Invalid "customFunction()" description found.' }
+            ]
+        },
+        {
+            options: [ 'required', [ 'customFunction' ], 'some error message' ],
+            code: 'customFunction("this is a test", function () { });',
+            errors: [
+                { message: 'some error message' }
+            ]
+        },
+        {
+            options: [ { pattern: 'required', testNames: [ 'customFunction' ], message: 'some error message' } ],
+            code: 'customFunction("this is a test", function () { });',
+            errors: [
+                { message: 'some error message' }
+            ]
+        },
+        {
+            options: [ {} ],
+            code: 'it("this is a test", function () { });',
+            errors: [
+                { message: 'Invalid "it()" description found.' }
             ]
         }
     ]


### PR DESCRIPTION
Add the possibility to define a custom error message to explain the pattern. There is two ways to define this message, sending it inline after `testNames` or by providing an object with the property `message`.

If this PR passes, I'll do the same for `valid-suite-description`

Fixes #204 