### PR TITLE
Relax no-synchronous-tests to allow non literals from concise arrows

### DIFF
--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -26,7 +26,7 @@ function doesReturnPromise(functionExpression) {
 
     if (bodyStatement.type === 'BlockStatement') {
         returnStatement = findPromiseReturnStatement(functionExpression.body.body);
-    } else if (bodyStatement.type === 'CallExpression') {
+    } else if (bodyStatement.type !== 'Literal') {
         //  allow arrow statements calling a promise with implicit return.
         returnStatement = bodyStatement;
     }

--- a/test/rules/no-synchronous-tests.js
+++ b/test/rules/no-synchronous-tests.js
@@ -42,6 +42,10 @@ ruleTester.run('no-synchronous-tests', rules['no-synchronous-tests'], {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: 'it("", () => promise );',
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: 'it("", () => promise.then() );',
             parserOptions: { ecmaVersion: 6 }
         },


### PR DESCRIPTION
Fixes #100 