### PR TITLE
✉️ Send a webhook to Coveralls when the build completes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   path-to-lcov: ./build/lcov.info
                   parallel: true
+    coverage:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
             - name: Coveralls Finished
               uses: coverallsapp/github-action@master
               with:


### PR DESCRIPTION
This ensures that Coveralls will be notified about the build **after** the last matrix job is finished