### PR TITLE
add plugin to recommended config

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
     },
     configs: {
         recommended: {
+            plugins: [ 'mocha' ],
             rules: {
                 'mocha/handle-done-callback': 'error',
                 'mocha/max-top-level-suites': [ 'error', { limit: 1 } ],


### PR DESCRIPTION
add plugin to recommended config, so it's not necessary to explicitly add the plugin when using this config.
this is the default for every major eslint plugin with recommended configs, ex:
- `eslint-plugin-node`
- `eslint-plugin-react`
- `eslint-plugin-import`
- `eslint-plugin-jsx-a11y`
- `eslint-plugin-jest`
- `eslint-plugin-promise`
- `eslint-plugin-vue`
- `eslint-plugin-prettier`
- and others.