### PR TITLE
Alphabetize rule lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,33 +2,34 @@
 
 module.exports = {
     rules: {
-        'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
-        'no-pending-tests': require('./lib/rules/no-pending-tests'),
-        'no-skipped-tests': require('./lib/rules/no-skipped-tests'),
         'handle-done-callback': require('./lib/rules/handle-done-callback'),
-        'no-synchronous-tests': require('./lib/rules/no-synchronous-tests'),
+        'max-top-level-suites': require('./lib/rules/max-top-level-suites'),
+        'no-async-describe': require('./lib/rules/no-async-describe'),
+        'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
         'no-global-tests': require('./lib/rules/no-global-tests'),
-        'no-return-and-callback': require('./lib/rules/no-return-and-callback'),
-        'no-return-from-async': require('./lib/rules/no-return-from-async'),
-        'valid-test-description': require('./lib/rules/valid-test-description'),
-        'valid-suite-description': require('./lib/rules/valid-suite-description'),
-        'no-mocha-arrows': require('./lib/rules/no-mocha-arrows'),
         'no-hooks': require('./lib/rules/no-hooks'),
         'no-hooks-for-single-case': require('./lib/rules/no-hooks-for-single-case'),
-        'no-sibling-hooks': require('./lib/rules/no-sibling-hooks'),
-        'no-top-level-hooks': require('./lib/rules/no-top-level-hooks'),
         'no-identical-title': require('./lib/rules/no-identical-title'),
-        'max-top-level-suites': require('./lib/rules/max-top-level-suites'),
+        'no-mocha-arrows': require('./lib/rules/no-mocha-arrows'),
         'no-nested-tests': require('./lib/rules/no-nested-tests'),
+        'no-pending-tests': require('./lib/rules/no-pending-tests'),
+        'no-return-and-callback': require('./lib/rules/no-return-and-callback'),
+        'no-return-from-async': require('./lib/rules/no-return-from-async'),
         'no-setup-in-describe': require('./lib/rules/no-setup-in-describe'),
+        'no-sibling-hooks': require('./lib/rules/no-sibling-hooks'),
+        'no-skipped-tests': require('./lib/rules/no-skipped-tests'),
+        'no-synchronous-tests': require('./lib/rules/no-synchronous-tests'),
+        'no-top-level-hooks': require('./lib/rules/no-top-level-hooks'),
         'prefer-arrow-callback': require('./lib/rules/prefer-arrow-callback'),
-        'no-async-describe': require('./lib/rules/no-async-describe')
+        'valid-suite-description': require('./lib/rules/valid-suite-description'),
+        'valid-test-description': require('./lib/rules/valid-test-description')
     },
     configs: {
         recommended: {
             rules: {
                 'mocha/handle-done-callback': 'error',
                 'mocha/max-top-level-suites': [ 'error', { limit: 1 } ],
+                'mocha/no-async-describe': 'error',
                 'mocha/no-exclusive-tests': 'warn',
                 'mocha/no-global-tests': 'error',
                 'mocha/no-hooks': 'off',
@@ -38,6 +39,7 @@ module.exports = {
                 'mocha/no-nested-tests': 'error',
                 'mocha/no-pending-tests': 'warn',
                 'mocha/no-return-and-callback': 'error',
+                'mocha/no-return-from-async': 'off',
                 'mocha/no-setup-in-describe': 'error',
                 'mocha/no-sibling-hooks': 'error',
                 'mocha/no-skipped-tests': 'warn',
@@ -45,8 +47,7 @@ module.exports = {
                 'mocha/no-top-level-hooks': 'warn',
                 'mocha/prefer-arrow-callback': 'off',
                 'mocha/valid-suite-description': 'off',
-                'mocha/valid-test-description': 'off',
-                'mocha/no-async-describe': 'error'
+                'mocha/valid-test-description': 'off'
             }
         }
     }


### PR DESCRIPTION
Fix alphabetization within config rule list and alphabetize rule list (for easier comparison to ensure no rules are missing in either list).

Also adds `'mocha/no-return-from-async': 'off',` to `recommended` config for consistency (since all other rules are included in the list).