### PR TITLE
Add `u` flag in RegExp for `valid-test-description` and `valid-suite-description`

### DIFF
--- a/lib/rules/valid-suite-description.js
+++ b/lib/rules/valid-suite-description.js
@@ -9,7 +9,7 @@ const astUtils = require('../util/ast');
 const defaultSuiteNames = [ 'describe', 'context', 'suite' ];
 
 function inlineOptions(context) {
-    const pattern = new RegExp(context.options[0]);
+    const pattern = new RegExp(context.options[0], 'u');
     const suiteNames = context.options[1] ? context.options[1] : defaultSuiteNames;
     const message = context.options[2];
 
@@ -17,7 +17,7 @@ function inlineOptions(context) {
 }
 
 function objectOptions(options) {
-    const pattern = new RegExp(options.pattern);
+    const pattern = new RegExp(options.pattern, 'u');
     const suiteNames = options.suiteNames ? options.suiteNames : defaultSuiteNames;
     const message = options.message;
 

--- a/lib/rules/valid-test-description.js
+++ b/lib/rules/valid-test-description.js
@@ -10,7 +10,7 @@ const astUtils = require('../util/ast');
 const defaultTestNames = [ 'it', 'test', 'specify' ];
 
 function inlineOptions(context) {
-    const pattern = context.options[0] ? new RegExp(context.options[0]) : /^should/;
+    const pattern = context.options[0] ? new RegExp(context.options[0], 'u') : /^should/u;
     const testNames = context.options[1] ? context.options[1] : defaultTestNames;
     const message = context.options[2];
 
@@ -18,7 +18,7 @@ function inlineOptions(context) {
 }
 
 function objectOptions(options) {
-    const pattern = options.pattern ? new RegExp(options.pattern) : /^should/;
+    const pattern = options.pattern ? new RegExp(options.pattern, 'u') : /^should/u;
     const testNames = options.testNames ? options.testNames : defaultTestNames;
     const message = options.message;
 


### PR DESCRIPTION
The `u` flag is supported per the Node >= 8.0.0 targeted versions of your `engines`, so thought I'd just follow the growing practice of using this flag by default for Unicode friendliness. 

Could be a breaking change where someone had an unescaped opening curly bracket in a regex, but would presumably not affect most users/cases.