### PR TITLE
"Options" heading in doc files (and consistent level 2 heading)

### DIFF
--- a/docs/rules/max-top-level-suites.md
+++ b/docs/rules/max-top-level-suites.md
@@ -33,6 +33,8 @@ describe('foo', function () {
 });
 ```
 
+## Options
+
 If you want to change the suite limit to, for instance, 2 suites per file:
 
 ```js

--- a/docs/rules/no-exclusive-tests.md
+++ b/docs/rules/no-exclusive-tests.md
@@ -49,9 +49,9 @@ suite.skip("bar", function () {});
 test.skip("bar", function () {});
 ```
 
-# Options
+## Settings
 
-This rule supports the following shared configuration options:
+This rule supports the following shared configuration setting:
 
 * `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
 

--- a/docs/rules/no-hooks-for-single-case.md
+++ b/docs/rules/no-hooks-for-single-case.md
@@ -58,7 +58,7 @@ describe('foo', function () {
 });
 ```
 
-# Options
+## Options
 
 This rule supports the following options:
 

--- a/docs/rules/no-skipped-tests.md
+++ b/docs/rules/no-skipped-tests.md
@@ -44,9 +44,9 @@ suite.only("bar", function () {});
 test.only("bar", function () {});
 ```
 
-# Options
+## Settings
 
-This rule supports the following shared configuration options:
+This rule supports the following shared configuration settings:
 
 * `additionalTestFunctions`: An array of extra test functions to protect.  This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
 * `additionalXFunctions`: An array of extra x-function to protect

--- a/docs/rules/no-synchronous-tests.md
+++ b/docs/rules/no-synchronous-tests.md
@@ -10,7 +10,7 @@ By default, this rule looks for the presence of one of:
 - An async function provided to a mocha test statement.
 - A return statement within the function body of any mocha test statement.
 
-If none of these three options is used in a test method, the rule will raise a warning.
+If none of these three alternatives is used in a test method, the rule will raise a warning.
 
 The following patterns are considered warnings:
 
@@ -40,6 +40,8 @@ it('should do foo', function () {
 }
 ```
 
+## Options
+
 You can change the acceptable asynchronous test methods to only allow a combination of async functions/callbacks/promises:
 
 ```js
@@ -47,7 +49,6 @@ rules: {
    "mocha/no-synchronous-tests": ["warn", {allowed: ['async', 'callback', 'promise']}]
 },
 ```
-
 
 ### Caveats:
 

--- a/docs/rules/valid-suite-description.md
+++ b/docs/rules/valid-suite-description.md
@@ -42,6 +42,8 @@ context("Test suite", function() { });
 suite("Test suite", function() { });
 ```
 
+## Options
+
 There is also possible to configure a custom list of suite names and a custom error message via the second and third rule configuration option:
 
 ```js

--- a/docs/rules/valid-test-description.md
+++ b/docs/rules/valid-test-description.md
@@ -7,6 +7,8 @@ This rule enforces the test descriptions to follow the desired format.
 By default, the regular expression is configured to be "^should" which requires test descriptions to start with "should".
 By default, the rule supports "it", "specify" and "test" test function names, but it can be configured to look for different test names via rule configuration.
 
+## Options
+
 Example of a custom rule configuration:
 
 ```js


### PR DESCRIPTION
Add "Options" heading in each doc file where options are available (and ensure consistent level 2 heading)