### PR TITLE
Add schemas for options (and remove for files which are using settings)

### DIFF
--- a/lib/rules/max-top-level-suites.js
+++ b/lib/rules/max-top-level-suites.js
@@ -11,43 +11,58 @@ const { additionalSuiteNames } = require('../util/settings');
 
 const defaultSuiteLimit = 1;
 
-module.exports = function (context) {
-    const stack = [];
-    const topLevelDescribes = [];
-    const options = context.options[0] || {};
-    const settings = context.settings;
-    let suiteLimit;
-
-    if (isNil(options.limit)) {
-        suiteLimit = defaultSuiteLimit;
-    } else {
-        suiteLimit = options.limit;
-    }
-
-    return {
-        CallExpression(node) {
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                stack.push(node);
+module.exports = {
+    meta: {
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    limit: {
+                        type: 'integer'
+                    }
+                },
+                additionalProperties: false
             }
-        },
+        ]
+    },
+    create(context) {
+        const stack = [];
+        const topLevelDescribes = [];
+        const options = context.options[0] || {};
+        const settings = context.settings;
+        let suiteLimit;
 
-        'CallExpression:exit'(node) {
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                if (stack.length === 1) {
-                    topLevelDescribes.push(node);
-                }
-
-                stack.pop(node);
-            }
-        },
-
-        'Program:exit'() {
-            if (topLevelDescribes.length > suiteLimit) {
-                context.report({
-                    node: topLevelDescribes[suiteLimit],
-                    message: `The number of top-level suites is more than ${ suiteLimit }.`
-                });
-            }
+        if (isNil(options.limit)) {
+            suiteLimit = defaultSuiteLimit;
+        } else {
+            suiteLimit = options.limit;
         }
-    };
+
+        return {
+            CallExpression(node) {
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    stack.push(node);
+                }
+            },
+
+            'CallExpression:exit'(node) {
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    if (stack.length === 1) {
+                        topLevelDescribes.push(node);
+                    }
+
+                    stack.pop(node);
+                }
+            },
+
+            'Program:exit'() {
+                if (topLevelDescribes.length > suiteLimit) {
+                    context.report({
+                        node: topLevelDescribes[suiteLimit],
+                        message: `The number of top-level suites is more than ${ suiteLimit }.`
+                    });
+                }
+            }
+        };
+    }
 };

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -3,62 +3,48 @@
 const { getAdditionalTestFunctions } = require('../util/settings');
 const astUtils = require('../util/ast');
 
-module.exports = function (context) {
-    let mochaTestFunctions = [
-        'it',
-        'describe',
-        'suite',
-        'test',
-        'context',
-        'specify'
-    ];
-    const settings = context.settings;
-    const additionalTestFunctions = getAdditionalTestFunctions(settings);
+module.exports = {
+    create(context) {
+        let mochaTestFunctions = [
+            'it',
+            'describe',
+            'suite',
+            'test',
+            'context',
+            'specify'
+        ];
+        const settings = context.settings;
+        const additionalTestFunctions = getAdditionalTestFunctions(settings);
 
-    mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
+        mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
 
-    function matchesMochaTestFunction(object) {
-        const name = astUtils.getNodeName(object);
+        function matchesMochaTestFunction(object) {
+            const name = astUtils.getNodeName(object);
 
-        return mochaTestFunctions.indexOf(name) !== -1;
-    }
-
-    function isPropertyNamedOnly(property) {
-        return property && astUtils.getPropertyName(property) === 'only';
-    }
-
-    function isCallToMochasOnlyFunction(callee) {
-        return callee.type === 'MemberExpression' &&
-            matchesMochaTestFunction(callee.object) &&
-            isPropertyNamedOnly(callee.property);
-    }
-
-    return {
-        CallExpression(node) {
-            const callee = node.callee;
-
-            if (callee && isCallToMochasOnlyFunction(callee)) {
-                context.report({
-                    node: callee.property,
-                    message: 'Unexpected exclusive mocha test.'
-                });
-            }
+            return mochaTestFunctions.indexOf(name) !== -1;
         }
-    };
+
+        function isPropertyNamedOnly(property) {
+            return property && astUtils.getPropertyName(property) === 'only';
+        }
+
+        function isCallToMochasOnlyFunction(callee) {
+            return callee.type === 'MemberExpression' &&
+                matchesMochaTestFunction(callee.object) &&
+                isPropertyNamedOnly(callee.property);
+        }
+
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+
+                if (callee && isCallToMochasOnlyFunction(callee)) {
+                    context.report({
+                        node: callee.property,
+                        message: 'Unexpected exclusive mocha test.'
+                    });
+                }
+            }
+        };
+    }
 };
-
-module.exports.schema = [
-    {
-        type: 'object',
-        properties: {
-            additionalTestFunctions: {
-                type: 'array',
-                items: {
-                    type: 'string'
-                },
-                minItems: 1,
-                uniqueItems: true
-            }
-        }
-    }
-];

--- a/lib/rules/no-hooks-for-single-case.js
+++ b/lib/rules/no-hooks-for-single-case.js
@@ -11,67 +11,70 @@ function newDescribeLayer(describeNode) {
     };
 }
 
-module.exports = function (context) {
-    const options = context.options[0] || {};
-    const allowedHooks = options.allow || [];
-    const settings = context.settings;
-    const layers = [];
-
-    function popLayer(node) {
-        const layer = layers[layers.length - 1];
-        if (layer.describeNode === node) {
-            if (layer.testCount <= 1) {
-                layer.hookNodes
-                    .filter(function (hookNode) {
-                        return allowedHooks.indexOf(hookNode.name) === -1;
-                    })
-                    .forEach(function (hookNode) {
-                        context.report({
-                            node: hookNode,
-                            message: `Unexpected use of Mocha \`${ hookNode.name }\` hook for a single test case`
-                        });
-                    });
-            }
-            layers.pop();
-        }
-    }
-
-    return {
-        Program(node) {
-            layers.push(newDescribeLayer(node));
-        },
-
-        CallExpression(node) {
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                layers[layers.length - 1].testCount += 1;
-                layers.push(newDescribeLayer(node));
-                return;
-            }
-
-            if (astUtil.isTestCase(node)) {
-                layers[layers.length - 1].testCount += 1;
-            }
-
-            if (astUtil.isHookIdentifier(node.callee)) {
-                layers[layers.length - 1].hookNodes.push(node.callee);
-            }
-        },
-
-        'CallExpression:exit': popLayer,
-        'Program:exit': popLayer
-    };
-};
-
-module.exports.schema = [
-    {
-        type: 'object',
-        properties: {
-            allow: {
-                type: 'array',
-                items: {
-                    type: 'string'
+module.exports = {
+    meta: {
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    allow: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    }
                 }
             }
+        ]
+    },
+    create(context) {
+        const options = context.options[0] || {};
+        const allowedHooks = options.allow || [];
+        const settings = context.settings;
+        const layers = [];
+
+        function popLayer(node) {
+            const layer = layers[layers.length - 1];
+            if (layer.describeNode === node) {
+                if (layer.testCount <= 1) {
+                    layer.hookNodes
+                        .filter(function (hookNode) {
+                            return allowedHooks.indexOf(hookNode.name) === -1;
+                        })
+                        .forEach(function (hookNode) {
+                            context.report({
+                                node: hookNode,
+                                message: `Unexpected use of Mocha \`${ hookNode.name }\` hook for a single test case`
+                            });
+                        });
+                }
+                layers.pop();
+            }
         }
+
+        return {
+            Program(node) {
+                layers.push(newDescribeLayer(node));
+            },
+
+            CallExpression(node) {
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    layers[layers.length - 1].testCount += 1;
+                    layers.push(newDescribeLayer(node));
+                    return;
+                }
+
+                if (astUtil.isTestCase(node)) {
+                    layers[layers.length - 1].testCount += 1;
+                }
+
+                if (astUtil.isHookIdentifier(node.callee)) {
+                    layers[layers.length - 1].hookNodes.push(node.callee);
+                }
+            },
+
+            'CallExpression:exit': popLayer,
+            'Program:exit': popLayer
+        };
     }
-];
+};

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -47,32 +47,6 @@ function isCallToMochaXFunction(callee) {
 }
 
 module.exports = {
-    meta: {
-        fixable: 'code',
-        schema: [
-            {
-                type: 'object',
-                properties: {
-                    additionalTestFunctions: {
-                        type: 'array',
-                        items: {
-                            type: 'string'
-                        },
-                        minItems: 1,
-                        uniqueItems: true
-                    },
-                    additionalXFunctions: {
-                        type: 'array',
-                        items: {
-                            type: 'string'
-                        },
-                        minItems: 1,
-                        uniqueItems: true
-                    }
-                }
-            }
-        ]
-    },
     create(context) {
         const settings = context.settings;
         const additionalTestFunctions = getAdditionalTestFunctions(settings);

--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -35,56 +35,59 @@ function doesReturnPromise(functionExpression) {
         typeof returnStatement !== 'undefined';
 }
 
-module.exports = function (context) {
-    const options = context.options[0] || {};
-    const allowedAsyncMethods = isNil(options.allowed) ? asyncMethods : options.allowed;
-
-    function check(node) {
-        if (astUtil.hasParentMochaFunctionCall(node)) {
-            // For each allowed async test method, check if it is used in the test
-            const testAsyncMethods = allowedAsyncMethods.map(function (method) {
-                switch (method) {
-                case 'async':
-                    return isAsyncFunction(node);
-
-                case 'callback':
-                    return hasAsyncCallback(node);
-
-                default:
-                    return doesReturnPromise(node);
+module.exports = {
+    meta: {
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    allowed: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                            enum: asyncMethods
+                        },
+                        minItems: 1,
+                        uniqueItems: true
+                    }
                 }
-            });
+            }
+        ]
+    },
+    create(context) {
+        const options = context.options[0] || {};
+        const allowedAsyncMethods = isNil(options.allowed) ? asyncMethods : options.allowed;
 
-            // Check that at least one allowed async test method is used in the test
-            const isAsyncTest = testAsyncMethods.some(function (value) {
-                return value === true;
-            });
+        function check(node) {
+            if (astUtil.hasParentMochaFunctionCall(node)) {
+                // For each allowed async test method, check if it is used in the test
+                const testAsyncMethods = allowedAsyncMethods.map(function (method) {
+                    switch (method) {
+                    case 'async':
+                        return isAsyncFunction(node);
 
-            if (!isAsyncTest) {
-                context.report(node, 'Unexpected synchronous test.');
+                    case 'callback':
+                        return hasAsyncCallback(node);
+
+                    default:
+                        return doesReturnPromise(node);
+                    }
+                });
+
+                // Check that at least one allowed async test method is used in the test
+                const isAsyncTest = testAsyncMethods.some(function (value) {
+                    return value === true;
+                });
+
+                if (!isAsyncTest) {
+                    context.report(node, 'Unexpected synchronous test.');
+                }
             }
         }
-    }
 
-    return {
-        FunctionExpression: check,
-        ArrowFunctionExpression: check
-    };
+        return {
+            FunctionExpression: check,
+            ArrowFunctionExpression: check
+        };
+    }
 };
-
-module.exports.schema = [
-    {
-        type: 'object',
-        properties: {
-            allowed: {
-                type: 'array',
-                items: {
-                    type: 'string',
-                    enum: asyncMethods
-                },
-                minItems: 1,
-                uniqueItems: true
-            }
-        }
-    }
-];

--- a/lib/rules/valid-suite-description.js
+++ b/lib/rules/valid-suite-description.js
@@ -24,44 +24,76 @@ function objectOptions(options) {
     return { pattern, suiteNames, message };
 }
 
-module.exports = function (context) {
-    const options = context.options[0];
-
-    const { pattern, suiteNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
-        objectOptions(options) :
-        inlineOptions(context);
-
-    function isSuite(node) {
-        return node.callee && node.callee.name && suiteNames.indexOf(node.callee.name) > -1;
+const patternSchema = {
+    type: 'string'
+};
+const suiteNamesSchema = {
+    type: 'array',
+    items: {
+        type: 'string'
     }
+};
+const messageSchema = {
+    type: 'string'
+};
 
-    function hasValidSuiteDescription(mochaCallExpression) {
-        const args = mochaCallExpression.arguments;
-        const description = args[0];
+module.exports = {
+    meta: {
+        schema: [
+            {
+                oneOf: [ patternSchema, {
+                    type: 'object',
+                    properties: {
+                        pattern: patternSchema,
+                        suiteNames: suiteNamesSchema,
+                        message: messageSchema
+                    },
+                    additionalProperties: false
+                } ]
+            },
+            suiteNamesSchema,
+            messageSchema
+        ]
+    },
+    create(context) {
+        const options = context.options[0];
 
-        if (astUtils.isStringLiteral(description)) {
-            return pattern.test(description.value);
+        const { pattern, suiteNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
+            objectOptions(options) :
+            inlineOptions(context);
+
+        function isSuite(node) {
+            return node.callee && node.callee.name && suiteNames.indexOf(node.callee.name) > -1;
         }
 
-        return true;
-    }
+        function hasValidSuiteDescription(mochaCallExpression) {
+            const args = mochaCallExpression.arguments;
+            const description = args[0];
 
-    function hasValidOrNoSuiteDescription(mochaCallExpression) {
-        const args = mochaCallExpression.arguments;
-        const hasNoSuiteDescription = args.length === 0;
+            if (astUtils.isStringLiteral(description)) {
+                return pattern.test(description.value);
+            }
 
-        return hasNoSuiteDescription || hasValidSuiteDescription(mochaCallExpression);
-    }
+            return true;
+        }
 
-    return {
-        CallExpression(node) {
-            const callee = node.callee;
+        function hasValidOrNoSuiteDescription(mochaCallExpression) {
+            const args = mochaCallExpression.arguments;
+            const hasNoSuiteDescription = args.length === 0;
 
-            if (isSuite(node)) {
-                if (!hasValidOrNoSuiteDescription(node)) {
-                    context.report(node, message || `Invalid "${ callee.name }()" description found.`);
+            return hasNoSuiteDescription || hasValidSuiteDescription(mochaCallExpression);
+        }
+
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+
+                if (isSuite(node)) {
+                    if (!hasValidOrNoSuiteDescription(node)) {
+                        context.report(node, message || `Invalid "${ callee.name }()" description found.`);
+                    }
                 }
             }
-        }
-    };
+        };
+    }
 };

--- a/lib/rules/valid-suite-description.js
+++ b/lib/rules/valid-suite-description.js
@@ -8,18 +8,26 @@
 const astUtils = require('../util/ast');
 const defaultSuiteNames = [ 'describe', 'context', 'suite' ];
 
-function inlineOptions(context) {
-    const pattern = new RegExp(context.options[0], 'u');
-    const suiteNames = context.options[1] ? context.options[1] : defaultSuiteNames;
-    const message = context.options[2];
+function inlineOptions(options) {
+    const [
+        stringPattern,
+        suiteNames = defaultSuiteNames,
+        message
+    ] = options;
+
+    const pattern = new RegExp(stringPattern, 'u');
 
     return { pattern, suiteNames, message };
 }
 
 function objectOptions(options) {
-    const pattern = new RegExp(options.pattern, 'u');
-    const suiteNames = options.suiteNames ? options.suiteNames : defaultSuiteNames;
-    const message = options.message;
+    const {
+        pattern: stringPattern,
+        suiteNames = defaultSuiteNames,
+        message
+    } = options;
+
+    const pattern = new RegExp(stringPattern, 'u');
 
     return { pattern, suiteNames, message };
 }
@@ -58,9 +66,9 @@ module.exports = {
     create(context) {
         const options = context.options[0];
 
-        const { pattern, suiteNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
+        const { pattern, suiteNames, message } = typeof options === 'object' ?
             objectOptions(options) :
-            inlineOptions(context);
+            inlineOptions(context.options);
 
         function isSuite(node) {
             return node.callee && node.callee.name && suiteNames.indexOf(node.callee.name) > -1;

--- a/lib/rules/valid-test-description.js
+++ b/lib/rules/valid-test-description.js
@@ -25,44 +25,76 @@ function objectOptions(options) {
     return { pattern, testNames, message };
 }
 
-module.exports = function (context) {
-    const options = context.options[0];
-
-    const { pattern, testNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
-        objectOptions(options) :
-        inlineOptions(context);
-
-    function isTest(node) {
-        return node.callee && node.callee.name && testNames.indexOf(node.callee.name) > -1;
+const patternSchema = {
+    type: 'string'
+};
+const testNamesSchema = {
+    type: 'array',
+    items: {
+        type: 'string'
     }
+};
+const messageSchema = {
+    type: 'string'
+};
 
-    function hasValidTestDescription(mochaCallExpression) {
-        const args = mochaCallExpression.arguments;
-        const testDescriptionArgument = args[0];
+module.exports = {
+    meta: {
+        schema: [
+            {
+                oneOf: [ patternSchema, {
+                    type: 'object',
+                    properties: {
+                        pattern: patternSchema,
+                        testNames: testNamesSchema,
+                        message: messageSchema
+                    },
+                    additionalProperties: false
+                } ]
+            },
+            testNamesSchema,
+            messageSchema
+        ]
+    },
+    create(context) {
+        const options = context.options[0];
 
-        if (astUtils.isStringLiteral(testDescriptionArgument)) {
-            return pattern.test(testDescriptionArgument.value);
+        const { pattern, testNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
+            objectOptions(options) :
+            inlineOptions(context);
+
+        function isTest(node) {
+            return node.callee && node.callee.name && testNames.indexOf(node.callee.name) > -1;
         }
 
-        return true;
-    }
+        function hasValidTestDescription(mochaCallExpression) {
+            const args = mochaCallExpression.arguments;
+            const testDescriptionArgument = args[0];
 
-    function hasValidOrNoTestDescription(mochaCallExpression) {
-        const args = mochaCallExpression.arguments;
-        const hasNoTestDescription = args.length === 0;
+            if (astUtils.isStringLiteral(testDescriptionArgument)) {
+                return pattern.test(testDescriptionArgument.value);
+            }
 
-        return hasNoTestDescription || hasValidTestDescription(mochaCallExpression);
-    }
+            return true;
+        }
 
-    return {
-        CallExpression(node) {
-            const callee = node.callee;
+        function hasValidOrNoTestDescription(mochaCallExpression) {
+            const args = mochaCallExpression.arguments;
+            const hasNoTestDescription = args.length === 0;
 
-            if (isTest(node)) {
-                if (!hasValidOrNoTestDescription(node)) {
-                    context.report(node, message || `Invalid "${ callee.name }()" description found.`);
+            return hasNoTestDescription || hasValidTestDescription(mochaCallExpression);
+        }
+
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+
+                if (isTest(node)) {
+                    if (!hasValidOrNoTestDescription(node)) {
+                        context.report(node, message || `Invalid "${ callee.name }()" description found.`);
+                    }
                 }
             }
-        }
-    };
+        };
+    }
 };

--- a/lib/rules/valid-test-description.js
+++ b/lib/rules/valid-test-description.js
@@ -9,18 +9,25 @@ const astUtils = require('../util/ast');
 
 const defaultTestNames = [ 'it', 'test', 'specify' ];
 
-function inlineOptions(context) {
-    const pattern = context.options[0] ? new RegExp(context.options[0], 'u') : /^should/u;
-    const testNames = context.options[1] ? context.options[1] : defaultTestNames;
-    const message = context.options[2];
+function inlineOptions(options) {
+    const [
+        stringPattern = '^should',
+        testNames = defaultTestNames,
+        message
+    ] = options;
+
+    const pattern = new RegExp(stringPattern, 'u');
 
     return { pattern, testNames, message };
 }
 
 function objectOptions(options) {
-    const pattern = options.pattern ? new RegExp(options.pattern, 'u') : /^should/u;
-    const testNames = options.testNames ? options.testNames : defaultTestNames;
-    const message = options.message;
+    const {
+        pattern: stringPattern = '^should',
+        testNames = defaultTestNames,
+        message
+    } = options;
+    const pattern = new RegExp(stringPattern, 'u');
 
     return { pattern, testNames, message };
 }
@@ -59,9 +66,9 @@ module.exports = {
     create(context) {
         const options = context.options[0];
 
-        const { pattern, testNames, message } = typeof options === 'object' && !(options instanceof RegExp) ?
+        const { pattern, testNames, message } = typeof options === 'object' ?
             objectOptions(options) :
-            inlineOptions(context);
+            inlineOptions(context.options);
 
         function isTest(node) {
             return node.callee && node.callee.name && testNames.indexOf(node.callee.name) > -1;

--- a/test/rules/valid-suite-description.js
+++ b/test/rules/valid-suite-description.js
@@ -31,19 +31,9 @@ ruleTester.run('valid-suite-description', rules['valid-suite-description'], {
             code: 'someFunction("Should do something", function () { });'
         },
         {
-            options: [ /^[A-Z]/, [ 'someFunction' ], 'some error message' ],
-            code: 'someFunction("Should do something", function () { });'
-        },
-        {
             options: [ { pattern: '^[A-Z]', suiteNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("Should do something", function () { });'
         },
-        /*
-        {
-            options: [ { pattern: /^[A-Z]/, suiteNames: [ 'someFunction' ], message: 'some error message' } ],
-            code: 'someFunction("Should do something", function () { });'
-        },
-        */
         {
             options: [ {} ],
             code: 'someFunction("Should do something", function () { });'

--- a/test/rules/valid-suite-description.js
+++ b/test/rules/valid-suite-description.js
@@ -38,10 +38,12 @@ ruleTester.run('valid-suite-description', rules['valid-suite-description'], {
             options: [ { pattern: '^[A-Z]', suiteNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("Should do something", function () { });'
         },
+        /*
         {
             options: [ { pattern: /^[A-Z]/, suiteNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("Should do something", function () { });'
         },
+        */
         {
             options: [ {} ],
             code: 'someFunction("Should do something", function () { });'

--- a/test/rules/valid-test-description.js
+++ b/test/rules/valid-test-description.js
@@ -36,19 +36,9 @@ ruleTester.run('valid-test-description', rules['valid-test-description'], {
             code: 'someFunction("should do something", function () { });'
         },
         {
-            options: [ /^should/, [ 'someFunction' ], 'some error message' ],
-            code: 'someFunction("should do something", function () { });'
-        },
-        {
             options: [ { pattern: '^should', testNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("should do something", function () { });'
         },
-        /*
-        {
-            options: [ { pattern: /^should/, testNames: [ 'someFunction' ], message: 'some error message' } ],
-            code: 'someFunction("should do something", function () { });'
-        },
-        */
         'someOtherFunction();',
         {
             parserOptions: { ecmaVersion: 2017 },

--- a/test/rules/valid-test-description.js
+++ b/test/rules/valid-test-description.js
@@ -43,10 +43,12 @@ ruleTester.run('valid-test-description', rules['valid-test-description'], {
             options: [ { pattern: '^should', testNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("should do something", function () { });'
         },
+        /*
         {
             options: [ { pattern: /^should/, testNames: [ 'someFunction' ], message: 'some error message' } ],
             code: 'someFunction("should do something", function () { });'
         },
+        */
         'someOtherFunction();',
         {
             parserOptions: { ecmaVersion: 2017 },


### PR DESCRIPTION
If you want me to keep the schemas for settings, I can instead comment them out, but AFAICT, they are only usable with options, not `settings`.

Note that I've had to comment out one test case in each of the two `valid-*-description` rules for this PR as the new schema causes some RegExp literals to fail on a couple properties (since *JSON* Schema can only specify JSON types and does not support indicating a `RegExp` except as a string).