### PR TITLE
Nondeprecated rule format

### DIFF
--- a/lib/rules/handle-done-callback.js
+++ b/lib/rules/handle-done-callback.js
@@ -3,46 +3,48 @@
 const find = require('ramda/src/find');
 const astUtils = require('../util/ast');
 
-module.exports = function (context) {
-    function isAsyncFunction(functionExpression) {
-        return functionExpression.params.length === 1;
-    }
-
-    function findParamInScope(paramName, scope) {
-        return find(function (variable) {
-            return variable.name === paramName && variable.defs[0].type === 'Parameter';
-        }, scope.variables);
-    }
-
-    function isReferenceHandled(reference) {
-        const parent = context.getNodeByRangeIndex(reference.identifier.range[0]).parent;
-
-        return parent.type === 'CallExpression';
-    }
-
-    function hasHandledReferences(references) {
-        return references.some(isReferenceHandled);
-    }
-
-    function checkAsyncMochaFunction(functionExpression) {
-        const scope = context.getScope();
-        const callback = functionExpression.params[0];
-        const callbackName = callback.name;
-        const callbackVariable = findParamInScope(callbackName, scope);
-
-        if (callbackVariable && !hasHandledReferences(callbackVariable.references)) {
-            context.report(callback, 'Expected "{{name}}" callback to be handled.', { name: callbackName });
+module.exports = {
+    create(context) {
+        function isAsyncFunction(functionExpression) {
+            return functionExpression.params.length === 1;
         }
-    }
 
-    function check(node) {
-        if (astUtils.hasParentMochaFunctionCall(node) && isAsyncFunction(node)) {
-            checkAsyncMochaFunction(node);
+        function findParamInScope(paramName, scope) {
+            return find(function (variable) {
+                return variable.name === paramName && variable.defs[0].type === 'Parameter';
+            }, scope.variables);
         }
-    }
 
-    return {
-        FunctionExpression: check,
-        ArrowFunctionExpression: check
-    };
+        function isReferenceHandled(reference) {
+            const parent = context.getNodeByRangeIndex(reference.identifier.range[0]).parent;
+
+            return parent.type === 'CallExpression';
+        }
+
+        function hasHandledReferences(references) {
+            return references.some(isReferenceHandled);
+        }
+
+        function checkAsyncMochaFunction(functionExpression) {
+            const scope = context.getScope();
+            const callback = functionExpression.params[0];
+            const callbackName = callback.name;
+            const callbackVariable = findParamInScope(callbackName, scope);
+
+            if (callbackVariable && !hasHandledReferences(callbackVariable.references)) {
+                context.report(callback, 'Expected "{{name}}" callback to be handled.', { name: callbackName });
+            }
+        }
+
+        function check(node) {
+            if (astUtils.hasParentMochaFunctionCall(node) && isAsyncFunction(node)) {
+                checkAsyncMochaFunction(node);
+            }
+        }
+
+        return {
+            FunctionExpression: check,
+            ArrowFunctionExpression: check
+        };
+    }
 };

--- a/lib/rules/no-global-tests.js
+++ b/lib/rules/no-global-tests.js
@@ -2,19 +2,21 @@
 
 const astUtils = require('../util/ast');
 
-module.exports = function (context) {
-    function isGlobalScope(scope) {
-        return scope.type === 'global' || scope.type === 'module';
-    }
-
-    return {
-        CallExpression(node) {
-            const callee = node.callee;
-            const scope = context.getScope();
-
-            if (astUtils.isTestCase(node) && isGlobalScope(scope)) {
-                context.report(callee, 'Unexpected global mocha test.');
-            }
+module.exports = {
+    create(context) {
+        function isGlobalScope(scope) {
+            return scope.type === 'global' || scope.type === 'module';
         }
-    };
+
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+                const scope = context.getScope();
+
+                if (astUtils.isTestCase(node) && isGlobalScope(scope)) {
+                    context.report(callee, 'Unexpected global mocha test.');
+                }
+            }
+        };
+    }
 };

--- a/lib/rules/no-hooks.js
+++ b/lib/rules/no-hooks.js
@@ -2,15 +2,17 @@
 
 const astUtil = require('../util/ast');
 
-module.exports = function (context) {
-    return {
-        CallExpression(node) {
-            if (astUtil.isHookIdentifier(node.callee)) {
-                context.report({
-                    node: node.callee,
-                    message: `Unexpected use of Mocha \`${ node.callee.name }\` hook`
-                });
+module.exports = {
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (astUtil.isHookIdentifier(node.callee)) {
+                    context.report({
+                        node: node.callee,
+                        message: `Unexpected use of Mocha \`${ node.callee.name }\` hook`
+                    });
+                }
             }
-        }
-    };
+        };
+    }
 };

--- a/lib/rules/no-identical-title.js
+++ b/lib/rules/no-identical-title.js
@@ -41,29 +41,31 @@ function isFirstArgLiteral(node) {
     return node.arguments && node.arguments[0] && node.arguments[0].type === 'Literal';
 }
 
-module.exports = function (context) {
-    const titleLayers = [ newLayer() ];
-    const settings = context.settings;
+module.exports = {
+    create(context) {
+        const titleLayers = [ newLayer() ];
+        const settings = context.settings;
 
-    return {
-        CallExpression(node) {
-            const currentLayer = titleLayers[titleLayers.length - 1];
+        return {
+            CallExpression(node) {
+                const currentLayer = titleLayers[titleLayers.length - 1];
 
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                titleLayers.push(newLayer());
-            }
-            if (!isFirstArgLiteral(node)) {
-                return;
-            }
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    titleLayers.push(newLayer());
+                }
+                if (!isFirstArgLiteral(node)) {
+                    return;
+                }
 
-            const title = node.arguments[0].value;
-            handlTestCaseTitles(context, currentLayer.testTitles, node, title);
-            handlTestSuiteTitles(context, currentLayer.describeTitles, node, title);
-        },
-        'CallExpression:exit'(node) {
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                titleLayers.pop();
+                const title = node.arguments[0].value;
+                handlTestCaseTitles(context, currentLayer.testTitles, node, title);
+                handlTestSuiteTitles(context, currentLayer.describeTitles, node, title);
+            },
+            'CallExpression:exit'(node) {
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    titleLayers.pop();
+                }
             }
-        }
-    };
+        };
+    }
 };

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -5,60 +5,62 @@
 const astUtils = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');
 
-module.exports = function noNestedTests(context) {
-    const settings = context.settings;
-    let testNestingLevel = 0;
-    let hookCallNestingLevel = 0;
+module.exports = {
+    create(context) {
+        const settings = context.settings;
+        let testNestingLevel = 0;
+        let hookCallNestingLevel = 0;
 
-    function report(callExpression, message) {
-        context.report({
-            message,
-            node: callExpression.callee
-        });
-    }
-
-    function isNestedTest(isTestCase, isDescribe, nestingLevel) {
-        const isNested = nestingLevel > 0;
-        const isTest = isTestCase || isDescribe;
-
-        return isNested && isTest;
-    }
-
-    function checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall) {
-        if (isNestedTest(isTestCase, isDescribe, testNestingLevel)) {
-            const message = isDescribe ?
-                'Unexpected suite nested within a test.' :
-                'Unexpected test nested within another test.';
-            report(node, message);
-        } else if (isNestedTest(isTestCase, isHookCall, hookCallNestingLevel)) {
-            const message = isHookCall ?
-                'Unexpected test hook nested within a test hook.' :
-                'Unexpected test nested within a test hook.';
-            report(node, message);
+        function report(callExpression, message) {
+            context.report({
+                message,
+                node: callExpression.callee
+            });
         }
-    }
 
-    return {
-        CallExpression(node) {
-            const isTestCase = astUtils.isTestCase(node);
-            const isHookCall = astUtils.isHookCall(node);
-            const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
+        function isNestedTest(isTestCase, isDescribe, nestingLevel) {
+            const isNested = nestingLevel > 0;
+            const isTest = isTestCase || isDescribe;
 
-            checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall);
+            return isNested && isTest;
+        }
 
-            if (isTestCase) {
-                testNestingLevel += 1;
-            } else if (isHookCall) {
-                hookCallNestingLevel += 1;
-            }
-        },
-
-        'CallExpression:exit'(node) {
-            if (astUtils.isTestCase(node)) {
-                testNestingLevel -= 1;
-            } else if (astUtils.isHookCall(node)) {
-                hookCallNestingLevel -= 1;
+        function checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall) {
+            if (isNestedTest(isTestCase, isDescribe, testNestingLevel)) {
+                const message = isDescribe ?
+                    'Unexpected suite nested within a test.' :
+                    'Unexpected test nested within another test.';
+                report(node, message);
+            } else if (isNestedTest(isTestCase, isHookCall, hookCallNestingLevel)) {
+                const message = isHookCall ?
+                    'Unexpected test hook nested within a test hook.' :
+                    'Unexpected test nested within a test hook.';
+                report(node, message);
             }
         }
-    };
+
+        return {
+            CallExpression(node) {
+                const isTestCase = astUtils.isTestCase(node);
+                const isHookCall = astUtils.isHookCall(node);
+                const isDescribe = astUtils.isDescribe(node, additionalSuiteNames(settings));
+
+                checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall);
+
+                if (isTestCase) {
+                    testNestingLevel += 1;
+                } else if (isHookCall) {
+                    hookCallNestingLevel += 1;
+                }
+            },
+
+            'CallExpression:exit'(node) {
+                if (astUtils.isTestCase(node)) {
+                    testNestingLevel -= 1;
+                } else if (astUtils.isHookCall(node)) {
+                    hookCallNestingLevel -= 1;
+                }
+            }
+        };
+    }
 };

--- a/lib/rules/no-pending-tests.js
+++ b/lib/rules/no-pending-tests.js
@@ -2,21 +2,23 @@
 
 const astUtils = require('../util/ast');
 
-module.exports = function (context) {
-    function isPendingMochaTest(node) {
-        return astUtils.isTestCase(node) &&
-            node.arguments.length === 1 &&
-            node.arguments[0].type === 'Literal';
-    }
-
-    return {
-        CallExpression(node) {
-            if (node.callee && isPendingMochaTest(node)) {
-                context.report({
-                    node,
-                    message: 'Unexpected pending mocha test.'
-                });
-            }
+module.exports = {
+    create(context) {
+        function isPendingMochaTest(node) {
+            return astUtils.isTestCase(node) &&
+                node.arguments.length === 1 &&
+                node.arguments[0].type === 'Literal';
         }
-    };
+
+        return {
+            CallExpression(node) {
+                if (node.callee && isPendingMochaTest(node)) {
+                    context.report({
+                        node,
+                        message: 'Unexpected pending mocha test.'
+                    });
+                }
+            }
+        };
+    }
 };

--- a/lib/rules/no-return-and-callback.js
+++ b/lib/rules/no-return-and-callback.js
@@ -39,19 +39,21 @@ function reportIfFunctionWithBlock(context, node, doneName) {
     }
 }
 
-module.exports = function (context) {
-    function check(node) {
-        if (node.params.length === 0 || !astUtils.hasParentMochaFunctionCall(node)) {
-            return;
+module.exports = {
+    create(context) {
+        function check(node) {
+            if (node.params.length === 0 || !astUtils.hasParentMochaFunctionCall(node)) {
+                return;
+            }
+
+            if (!reportIfShortArrowFunction(context, node)) {
+                reportIfFunctionWithBlock(context, node, node.params[0].name);
+            }
         }
 
-        if (!reportIfShortArrowFunction(context, node)) {
-            reportIfFunctionWithBlock(context, node, node.params[0].name);
-        }
+        return {
+            FunctionExpression: check,
+            ArrowFunctionExpression: check
+        };
     }
-
-    return {
-        FunctionExpression: check,
-        ArrowFunctionExpression: check
-    };
 };

--- a/lib/rules/no-return-from-async.js
+++ b/lib/rules/no-return-from-async.js
@@ -33,19 +33,21 @@ function reportIfFunctionWithBlock(context, node) {
     }
 }
 
-module.exports = function (context) {
-    function check(node) {
-        if (!node.async || !astUtils.hasParentMochaFunctionCall(node)) {
-            return;
+module.exports = {
+    create(context) {
+        function check(node) {
+            if (!node.async || !astUtils.hasParentMochaFunctionCall(node)) {
+                return;
+            }
+
+            if (!reportIfShortArrowFunction(context, node)) {
+                reportIfFunctionWithBlock(context, node);
+            }
         }
 
-        if (!reportIfShortArrowFunction(context, node)) {
-            reportIfFunctionWithBlock(context, node);
-        }
+        return {
+            FunctionExpression: check,
+            ArrowFunctionExpression: check
+        };
     }
-
-    return {
-        FunctionExpression: check,
-        ArrowFunctionExpression: check
-    };
 };

--- a/lib/rules/no-setup-in-describe.js
+++ b/lib/rules/no-setup-in-describe.js
@@ -8,102 +8,104 @@ const DESCRIBE = 2;
 // "Pure" nodes are hooks (like `beforeEach`) or `it` calls
 const PURE = 3;
 
-module.exports = function noSetupInDescribe(context) {
-    const nesting = [];
-    const settings = context.settings;
+module.exports = {
+    create(context) {
+        const nesting = [];
+        const settings = context.settings;
 
-    function isPureNode(node) {
-        return astUtils.isHookCall(node) ||
-          astUtils.isTestCase(node) ||
-          astUtils.isSuiteConfigCall(node);
-    }
-
-    function reportCallExpression(callExpression) {
-        const message = 'Unexpected function call in describe block.';
-
-        context.report({
-            message,
-            node: callExpression.callee
-        });
-    }
-
-    function reportMemberExpression(memberExpression) {
-        const message = 'Unexpected member expression in describe block. ' +
-            'Member expressions may call functions via getters.';
-
-        context.report({
-            message,
-            node: memberExpression
-        });
-    }
-
-    function isNestedInDescribeBlock() {
-        return nesting.length &&
-                nesting.indexOf(PURE) === -1 &&
-                nesting.lastIndexOf(FUNCTION) < nesting.lastIndexOf(DESCRIBE);
-    }
-
-    function handleCallExpressionInDescribe(node) {
-        if (isPureNode(node)) {
-            nesting.push(PURE);
-        } else if (isNestedInDescribeBlock()) {
-            reportCallExpression(node);
+        function isPureNode(node) {
+            return astUtils.isHookCall(node) ||
+              astUtils.isTestCase(node) ||
+              astUtils.isSuiteConfigCall(node);
         }
-    }
 
-    function isDescribe(node) {
-        return astUtils.isDescribe(node, additionalSuiteNames(settings));
-    }
+        function reportCallExpression(callExpression) {
+            const message = 'Unexpected function call in describe block.';
 
-    function isParentDescribe(node) {
-        return isDescribe(node.parent);
-    }
+            context.report({
+                message,
+                node: callExpression.callee
+            });
+        }
 
-    return {
-        CallExpression(node) {
-            if (isDescribe(node)) {
-                nesting.push(DESCRIBE);
-                return;
-            }
-            // don't process anything else if the first describe hasn't been processed
-            if (!nesting.length) {
-                return;
-            }
-            handleCallExpressionInDescribe(node);
-        },
+        function reportMemberExpression(memberExpression) {
+            const message = 'Unexpected member expression in describe block. ' +
+                'Member expressions may call functions via getters.';
 
-        'CallExpression:exit'(node) {
-            if (isDescribe(node) || nesting.length && isPureNode(node)) {
-                nesting.pop();
-            }
-        },
+            context.report({
+                message,
+                node: memberExpression
+            });
+        }
 
-        MemberExpression(node) {
-            if (isNestedInDescribeBlock()) {
-                reportMemberExpression(node);
-            }
-        },
+        function isNestedInDescribeBlock() {
+            return nesting.length &&
+                    nesting.indexOf(PURE) === -1 &&
+                    nesting.lastIndexOf(FUNCTION) < nesting.lastIndexOf(DESCRIBE);
+        }
 
-        FunctionDeclaration() {
-            if (nesting.length) {
-                nesting.push(FUNCTION);
-            }
-        },
-        'FunctionDeclaration:exit'() {
-            if (nesting.length) {
-                nesting.pop();
-            }
-        },
-
-        ArrowFunctionExpression(node) {
-            if (nesting.length && !isParentDescribe(node)) {
-                nesting.push(FUNCTION);
-            }
-        },
-        'ArrowFunctionExpression:exit'(node) {
-            if (nesting.length && !isParentDescribe(node)) {
-                nesting.pop();
+        function handleCallExpressionInDescribe(node) {
+            if (isPureNode(node)) {
+                nesting.push(PURE);
+            } else if (isNestedInDescribeBlock()) {
+                reportCallExpression(node);
             }
         }
-    };
+
+        function isDescribe(node) {
+            return astUtils.isDescribe(node, additionalSuiteNames(settings));
+        }
+
+        function isParentDescribe(node) {
+            return isDescribe(node.parent);
+        }
+
+        return {
+            CallExpression(node) {
+                if (isDescribe(node)) {
+                    nesting.push(DESCRIBE);
+                    return;
+                }
+                // don't process anything else if the first describe hasn't been processed
+                if (!nesting.length) {
+                    return;
+                }
+                handleCallExpressionInDescribe(node);
+            },
+
+            'CallExpression:exit'(node) {
+                if (isDescribe(node) || nesting.length && isPureNode(node)) {
+                    nesting.pop();
+                }
+            },
+
+            MemberExpression(node) {
+                if (isNestedInDescribeBlock()) {
+                    reportMemberExpression(node);
+                }
+            },
+
+            FunctionDeclaration() {
+                if (nesting.length) {
+                    nesting.push(FUNCTION);
+                }
+            },
+            'FunctionDeclaration:exit'() {
+                if (nesting.length) {
+                    nesting.pop();
+                }
+            },
+
+            ArrowFunctionExpression(node) {
+                if (nesting.length && !isParentDescribe(node)) {
+                    nesting.push(FUNCTION);
+                }
+            },
+            'ArrowFunctionExpression:exit'(node) {
+                if (nesting.length && !isParentDescribe(node)) {
+                    nesting.pop();
+                }
+            }
+        };
+    }
 };

--- a/lib/rules/no-sibling-hooks.js
+++ b/lib/rules/no-sibling-hooks.js
@@ -13,41 +13,43 @@ function newDescribeLayer(describeNode) {
     };
 }
 
-module.exports = function (context) {
-    const isUsed = [];
-    const settings = context.settings;
+module.exports = {
+    create(context) {
+        const isUsed = [];
+        const settings = context.settings;
 
-    return {
-        Program(node) {
-            isUsed.push(newDescribeLayer(node));
-        },
-
-        CallExpression(node) {
-            const name = astUtil.getNodeName(node.callee);
-
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+        return {
+            Program(node) {
                 isUsed.push(newDescribeLayer(node));
-                return;
-            }
+            },
 
-            if (!astUtil.isHookIdentifier(node.callee)) {
-                return;
-            }
+            CallExpression(node) {
+                const name = astUtil.getNodeName(node.callee);
 
-            if (isUsed[isUsed.length - 1][name]) {
-                context.report({
-                    node: node.callee,
-                    message: `Unexpected use of duplicate Mocha \`${ name }\` hook`
-                });
-            }
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    isUsed.push(newDescribeLayer(node));
+                    return;
+                }
 
-            isUsed[isUsed.length - 1][name] = true;
-        },
+                if (!astUtil.isHookIdentifier(node.callee)) {
+                    return;
+                }
 
-        'CallExpression:exit'(node) {
-            if (isUsed[isUsed.length - 1].describeNode === node) {
-                isUsed.pop();
+                if (isUsed[isUsed.length - 1][name]) {
+                    context.report({
+                        node: node.callee,
+                        message: `Unexpected use of duplicate Mocha \`${ name }\` hook`
+                    });
+                }
+
+                isUsed[isUsed.length - 1][name] = true;
+            },
+
+            'CallExpression:exit'(node) {
+                if (isUsed[isUsed.length - 1].describeNode === node) {
+                    isUsed.pop();
+                }
             }
-        }
-    };
+        };
+    }
 };

--- a/lib/rules/no-top-level-hooks.js
+++ b/lib/rules/no-top-level-hooks.js
@@ -3,33 +3,35 @@
 const astUtil = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');
 
-module.exports = function (context) {
-    const settings = context.settings;
-    const testSuiteStack = [];
+module.exports = {
+    create(context) {
+        const settings = context.settings;
+        const testSuiteStack = [];
 
-    return {
-        CallExpression(node) {
-            if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                testSuiteStack.push(node);
-                return;
-            }
+        return {
+            CallExpression(node) {
+                if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
+                    testSuiteStack.push(node);
+                    return;
+                }
 
-            if (!astUtil.isHookIdentifier(node.callee)) {
-                return;
-            }
+                if (!astUtil.isHookIdentifier(node.callee)) {
+                    return;
+                }
 
-            if (testSuiteStack.length === 0) {
-                context.report({
-                    node: node.callee,
-                    message: `Unexpected use of Mocha \`${ node.callee.name }\` hook outside of a test suite`
-                });
-            }
-        },
+                if (testSuiteStack.length === 0) {
+                    context.report({
+                        node: node.callee,
+                        message: `Unexpected use of Mocha \`${ node.callee.name }\` hook outside of a test suite`
+                    });
+                }
+            },
 
-        'CallExpression:exit'(node) {
-            if (testSuiteStack[testSuiteStack.length - 1] === node) {
-                testSuiteStack.pop();
+            'CallExpression:exit'(node) {
+                if (testSuiteStack[testSuiteStack.length - 1] === node) {
+                    testSuiteStack.pop();
+                }
             }
-        }
-    };
+        };
+    }
 };


### PR DESCRIPTION
Builds on #228 and #234.

Completes move to [non-deprecated](https://eslint.org/blog/2016/07/eslint-new-rule-format) eslint rule format (mentioned first in #228).
