### PR TITLE
no-hooks-for-single-case: fix false postive in nested suites

### DIFF
--- a/lib/rules/no-hooks-for-single-case.js
+++ b/lib/rules/no-hooks-for-single-case.js
@@ -31,7 +31,17 @@ module.exports = {
         const options = context.options[0] || {};
         const allowedHooks = options.allow || [];
         const settings = context.settings;
-        const layers = [];
+        let layers = [];
+
+        function increaseTestCount() {
+            layers = layers.map((layer) => {
+                return {
+                    describeNode: layer.describeNode,
+                    hookNodes: layer.hookNodes,
+                    testCount: layer.testCount + 1
+                };
+            });
+        }
 
         function popLayer(node) {
             const layer = layers[layers.length - 1];
@@ -59,13 +69,13 @@ module.exports = {
 
             CallExpression(node) {
                 if (astUtil.isDescribe(node, additionalSuiteNames(settings))) {
-                    layers[layers.length - 1].testCount += 1;
+                    increaseTestCount();
                     layers.push(newDescribeLayer(node));
                     return;
                 }
 
                 if (astUtil.isTestCase(node)) {
-                    layers[layers.length - 1].testCount += 1;
+                    increaseTestCount();
                 }
 
                 if (astUtil.isHookIdentifier(node.callee)) {

--- a/test/rules/no-hooks-for-single-case.js
+++ b/test/rules/no-hooks-for-single-case.js
@@ -84,6 +84,20 @@ ruleTester.run('no-hooks-for-single-case', rules['no-hooks-for-single-case'], {
             '    });',
             '});'
         ].join('\n'),
+        [
+            'describe(function() {',
+            '    describe(function() {',
+            '        it(function() {});',
+            '        it(function() {});',
+            '    });',
+            '    afterEach(function() {});',
+            '});'
+        ].join('\n'),
+        [
+            'it(function() {});',
+            'it(function() {});',
+            'afterEach(function() {});'
+        ].join('\n'),
         {
             code: [
                 'describe(function() {',
@@ -261,19 +275,6 @@ ruleTester.run('no-hooks-for-single-case', rules['no-hooks-for-single-case'], {
                 '});'
             ].join('\n'),
             errors: [ { message: 'Unexpected use of Mocha `before` hook for a single test case', column: 9, line: 5 } ]
-        },
-        {
-            code: [
-                'describe(function() {',
-                '    before(function() {});',
-                '    describe(function() {',
-                '        before(function() {});',
-                '        it(function() {});',
-                '        it(function() {});',
-                '    });',
-                '});'
-            ].join('\n'),
-            errors: [ { message: 'Unexpected use of Mocha `before` hook for a single test case', column: 5, line: 2 } ]
         },
         {
             code: [


### PR DESCRIPTION
Fixes: #177