### PR TITLE
Add `meta.type` and missing `fixable: 'code'`

### DIFF
--- a/docs/rules/no-nested-tests.md
+++ b/docs/rules/no-nested-tests.md
@@ -9,7 +9,7 @@ it('something', function () {
     });
 });
 ```
-Something like this could be easily happen by accident where the outer test case was actually meant to be a suite instead of a test.
+Something like this could easily happen by accident where the outer test case was actually meant to be a suite instead of a test.
 This rule reports such nested test cases in order to prevent problems where those nested tests are skipped silently.
 
 ## Rule Details

--- a/lib/rules/handle-done-callback.js
+++ b/lib/rules/handle-done-callback.js
@@ -4,6 +4,9 @@ const find = require('ramda/src/find');
 const astUtils = require('../util/ast');
 
 module.exports = {
+    meta: {
+        type: 'problem'
+    },
     create(context) {
         function isAsyncFunction(functionExpression) {
             return functionExpression.params.length === 1;

--- a/lib/rules/max-top-level-suites.js
+++ b/lib/rules/max-top-level-suites.js
@@ -13,6 +13,7 @@ const defaultSuiteLimit = 1;
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 type: 'object',

--- a/lib/rules/no-async-describe.js
+++ b/lib/rules/no-async-describe.js
@@ -11,6 +11,7 @@ const { additionalSuiteNames } = require('../util/settings');
 
 module.exports = {
     meta: {
+        type: 'problem',
         fixable: 'code'
     },
     create(context) {

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -4,6 +4,9 @@ const { getAdditionalTestFunctions } = require('../util/settings');
 const astUtils = require('../util/ast');
 
 module.exports = {
+    meta: {
+        type: 'problem'
+    },
     create(context) {
         let mochaTestFunctions = [
             'it',

--- a/lib/rules/no-global-tests.js
+++ b/lib/rules/no-global-tests.js
@@ -3,6 +3,9 @@
 const astUtils = require('../util/ast');
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         function isGlobalScope(scope) {
             return scope.type === 'global' || scope.type === 'module';

--- a/lib/rules/no-hooks-for-single-case.js
+++ b/lib/rules/no-hooks-for-single-case.js
@@ -13,6 +13,7 @@ function newDescribeLayer(describeNode) {
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 type: 'object',

--- a/lib/rules/no-hooks.js
+++ b/lib/rules/no-hooks.js
@@ -4,6 +4,7 @@ const astUtil = require('../util/ast');
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 type: 'object',

--- a/lib/rules/no-identical-title.js
+++ b/lib/rules/no-identical-title.js
@@ -42,6 +42,9 @@ function isFirstArgLiteral(node) {
 }
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         const titleLayers = [ newLayer() ];
         const settings = context.settings;

--- a/lib/rules/no-mocha-arrows.js
+++ b/lib/rules/no-mocha-arrows.js
@@ -10,6 +10,7 @@ const astUtils = require('../util/ast');
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         fixable: 'code'
     },
     create(context) {

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -6,6 +6,9 @@ const astUtils = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');
 
 module.exports = {
+    meta: {
+        type: 'problem'
+    },
     create(context) {
         const settings = context.settings;
         let testNestingLevel = 0;

--- a/lib/rules/no-pending-tests.js
+++ b/lib/rules/no-pending-tests.js
@@ -3,6 +3,9 @@
 const astUtils = require('../util/ast');
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         function isPendingMochaTest(node) {
             return astUtils.isTestCase(node) &&

--- a/lib/rules/no-return-and-callback.js
+++ b/lib/rules/no-return-and-callback.js
@@ -40,6 +40,9 @@ function reportIfFunctionWithBlock(context, node, doneName) {
 }
 
 module.exports = {
+    meta: {
+        type: 'problem'
+    },
     create(context) {
         function check(node) {
             if (node.params.length === 0 || !astUtils.hasParentMochaFunctionCall(node)) {

--- a/lib/rules/no-return-from-async.js
+++ b/lib/rules/no-return-from-async.js
@@ -34,6 +34,9 @@ function reportIfFunctionWithBlock(context, node) {
 }
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         function check(node) {
             if (!node.async || !astUtils.hasParentMochaFunctionCall(node)) {

--- a/lib/rules/no-setup-in-describe.js
+++ b/lib/rules/no-setup-in-describe.js
@@ -9,6 +9,9 @@ const DESCRIBE = 2;
 const PURE = 3;
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         const nesting = [];
         const settings = context.settings;

--- a/lib/rules/no-sibling-hooks.js
+++ b/lib/rules/no-sibling-hooks.js
@@ -14,6 +14,9 @@ function newDescribeLayer(describeNode) {
 }
 
 module.exports = {
+    meta: {
+        type: 'suggestion'
+    },
     create(context) {
         const isUsed = [];
         const settings = context.settings;

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -47,6 +47,10 @@ function isCallToMochaXFunction(callee) {
 }
 
 module.exports = {
+    meta: {
+        fixable: 'code',
+        type: 'problem'
+    },
     create(context) {
         const settings = context.settings;
         const additionalTestFunctions = getAdditionalTestFunctions(settings);

--- a/lib/rules/no-synchronous-tests.js
+++ b/lib/rules/no-synchronous-tests.js
@@ -37,6 +37,7 @@ function doesReturnPromise(functionExpression) {
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 type: 'object',

--- a/lib/rules/no-top-level-hooks.js
+++ b/lib/rules/no-top-level-hooks.js
@@ -4,6 +4,9 @@ const astUtil = require('../util/ast');
 const { additionalSuiteNames } = require('../util/settings');
 
 module.exports = {
+    meta: {
+        type: 'problem'
+    },
     create(context) {
         const settings = context.settings;
         const testSuiteStack = [];

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -153,6 +153,8 @@ function hasDuplicateParams(paramsList) {
 
 module.exports = {
     meta: {
+        type: 'suggestion',
+
         docs: {
             description: 'require using arrow functions for callbacks',
             category: 'ECMAScript 6',

--- a/lib/rules/valid-suite-description.js
+++ b/lib/rules/valid-suite-description.js
@@ -48,6 +48,7 @@ const messageSchema = {
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 oneOf: [ patternSchema, {

--- a/lib/rules/valid-test-description.js
+++ b/lib/rules/valid-test-description.js
@@ -47,6 +47,7 @@ const messageSchema = {
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         schema: [
             {
                 oneOf: [ patternSchema, {


### PR DESCRIPTION
add `meta.type` ("problem" or "suggestion") for use by `eslint --fix-type` or formatters and add missing "fixable: code" to `no-skipped-tests`