### PR TITLE
remove autofix from no-skipped-tests rule fix

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -17,7 +17,7 @@
 ||| [no-return-from-async](no-return-from-async.md) | disallow returning from an async test or hook
 |:heavy_check_mark:|| [no-setup-in-describe](no-setup-in-describe.md) | disallow calling functions and dot operators directly in describe blocks
 |:heavy_check_mark:|| [no-sibling-hooks](no-sibling-hooks.md) | disallow duplicate uses of a hook at the same level inside a describe
-|:heavy_check_mark:|:wrench:| [no-skipped-tests](no-skipped-tests.md) | disallow skipped mocha tests
+|:heavy_check_mark:|| [no-skipped-tests](no-skipped-tests.md) | disallow skipped mocha tests
 ||| [no-synchronous-tests](no-synchronous-tests.md) | disallow synchronous tests
 |:heavy_check_mark:|| [no-top-level-hooks](no-top-level-hooks.md) | disallow top-level hooks
 ||:wrench:| [prefer-arrow-callback](prefer-arrow-callback.md) | prefer arrow function callbacks (mocha-aware)

--- a/docs/rules/no-skipped-tests.md
+++ b/docs/rules/no-skipped-tests.md
@@ -3,8 +3,6 @@
 Mocha has a feature that allows you to skip tests by appending `.skip` to a test-suite or a test-case, or by prepending it with an `x` (e.g., `xdescribe(...)` instead of `describe(...)`).
 Sometimes tests are skipped as part of a debugging process, and aren't intended to be committed.  This rule reminds you to remove `.skip` or the `x` prefix from your tests.
 
-**Fixable:** Problems detected by this rule are automatically fixable using the `--fix` flag on the command line.
-
 ## Rule Details
 
 This rule looks for `describe.skip`, `it.skip`, `suite.skip`, `test.skip`, `context.skip`, `specify.skip`, `xdescribe`, `xit`, `xcontext` and `xspecify` occurrences within the source code.

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -19,25 +19,6 @@ function isCallToMochasSkipFunction(callee) {
        isPropertyNamedSkip(callee.property);
 }
 
-function createSkipAutofixFunction(callee) {
-    const [ , endRangeOfMemberExpression ] = callee.range;
-    const [ , endRangeOfMemberExpressionObject ] = callee.object.range;
-
-    const rangeToRemove = [ endRangeOfMemberExpressionObject, endRangeOfMemberExpression ];
-
-    return function removeSkipProperty(fixer) {
-        return fixer.removeRange(rangeToRemove);
-    };
-}
-
-function createXAutofixFunction(callee) {
-    const rangeToRemove = [ callee.range[0], callee.range[0] + 1 ];
-
-    return function removeXPrefix(fixer) {
-        return fixer.removeRange(rangeToRemove);
-    };
-}
-
 function isMochaXFunction(name) {
     return mochaXFunctions.indexOf(name) !== -1;
 }
@@ -48,7 +29,6 @@ function isCallToMochaXFunction(callee) {
 
 module.exports = {
     meta: {
-        fixable: 'code',
         docs: {
             description: 'Disallow skipped tests'
         },
@@ -81,14 +61,12 @@ module.exports = {
                 if (isCallToMochasSkipFunction(callee)) {
                     context.report({
                         node: callee.property,
-                        message: 'Unexpected skipped mocha test.',
-                        fix: createSkipAutofixFunction(callee)
+                        message: 'Unexpected skipped mocha test.'
                     });
                 } else if (isCallToMochaXFunction(callee)) {
                     context.report({
                         node: callee,
-                        message: 'Unexpected skipped mocha test.',
-                        fix: createXAutofixFunction(callee)
+                        message: 'Unexpected skipped mocha test.'
                     });
                 }
             }

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -27,77 +27,62 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
         {
             code: 'describe.skip()',
             errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
-            output: 'describe()'
         },
         {
             code: 'describe["skip"]()',
             errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
-            output: 'describe()'
         },
         {
             code: 'xdescribe()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'describe()'
         },
         {
             code: 'it.skip()',
             errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
-            output: 'it()'
         },
         {
             code: 'it["skip"]()',
             errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
-            output: 'it()'
         },
         {
             code: 'xit()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'it()'
         },
         {
             code: 'suite.skip()',
             errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
-            output: 'suite()'
         },
         {
             code: 'suite["skip"]()',
             errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
-            output: 'suite()'
         },
         {
             code: 'test.skip()',
             errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
-            output: 'test()'
         },
         {
             code: 'test["skip"]()',
             errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
-            output: 'test()'
         },
         {
             code: 'context.skip()',
             errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'context()'
         },
         {
             code: 'context["skip"]()',
             errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'context()'
         },
         {
             code: 'xcontext()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'context()'
         },
         {
             code: 'specify.skip()',
             errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
-            output: 'specify()'
         },
         {
             code: 'xspecify()',
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'specify()'
         },
         {
             code: 'custom.skip()',
@@ -105,7 +90,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 'mocha/additionalTestFunctions': [ 'custom' ]
             },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
-            output: 'custom()'
         },
         {
             code: 'custom["skip"]()',
@@ -113,7 +97,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 'mocha/additionalTestFunctions': [ 'custom' ]
             },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
-            output: 'custom()'
         },
         {
             code: 'xcustom()',
@@ -121,7 +104,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 'mocha/additionalXFunctions': [ 'xcustom' ]
             },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'custom()'
         },
         {
             code: 'custom.skip()',
@@ -131,7 +113,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
-            output: 'custom()'
         },
         {
             code: 'custom["skip"]()',
@@ -141,7 +122,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
-            output: 'custom()'
         },
         {
             code: 'xcustom()',
@@ -151,7 +131,6 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
-            output: 'custom()'
         }
 
     ]

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -26,84 +26,84 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
     invalid: [
         {
             code: 'describe.skip()',
-            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
         },
         {
             code: 'describe["skip"]()',
-            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 10, line: 1 } ]
         },
         {
             code: 'xdescribe()',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         },
         {
             code: 'it.skip()',
-            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ]
         },
         {
             code: 'it["skip"]()',
-            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 4, line: 1 } ]
         },
         {
             code: 'xit()',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         },
         {
             code: 'suite.skip()',
-            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },
         {
             code: 'suite["skip"]()',
-            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
         },
         {
             code: 'test.skip()',
-            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ]
         },
         {
             code: 'test["skip"]()',
-            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 6, line: 1 } ]
         },
         {
             code: 'context.skip()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'context["skip"]()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'xcontext()',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         },
         {
             code: 'specify.skip()',
-            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         },
         {
             code: 'xspecify()',
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         },
         {
             code: 'custom.skip()',
             settings: {
                 'mocha/additionalTestFunctions': [ 'custom' ]
             },
-            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         },
         {
             code: 'custom["skip"]()',
             settings: {
                 'mocha/additionalTestFunctions': [ 'custom' ]
             },
-            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         },
         {
             code: 'xcustom()',
             settings: {
                 'mocha/additionalXFunctions': [ 'xcustom' ]
             },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         },
         {
             code: 'custom.skip()',
@@ -112,7 +112,7 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                     additionalTestFunctions: [ 'custom' ]
                 }
             },
-            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         },
         {
             code: 'custom["skip"]()',
@@ -121,7 +121,7 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                     additionalTestFunctions: [ 'custom' ]
                 }
             },
-            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 8, line: 1 } ]
         },
         {
             code: 'xcustom()',
@@ -130,7 +130,7 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                     additionalXFunctions: [ 'xcustom' ]
                 }
             },
-            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ],
+            errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
         }
 
     ]


### PR DESCRIPTION
Remove autofix from rule `no-skipped-tests` as it alters the test runtime, and makes it impossible to use this rule as a warning
resolves #242 