### PR TITLE
set env.mocha on recommended config

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     },
     configs: {
         recommended: {
+            env: { mocha: true },
             plugins: [ 'mocha' ],
             rules: {
                 'mocha/handle-done-callback': 'error',


### PR DESCRIPTION
set `env.mocha: true` on recommended config, so it's not necessary to explicitly set it when using this config.

eslint documents this being done for plugins (the example code includes env settings on each config): https://eslint.org/docs/developer-guide/working-with-plugins#configs-in-plugins