### PR TITLE
Improve benchmark test reliability

### DIFF
--- a/benchmarks/measure.js
+++ b/benchmarks/measure.js
@@ -6,8 +6,23 @@ const times = require('ramda/src/times');
 const median = require('ramda/src/median');
 const map = require('ramda/src/map');
 const prop = require('ramda/src/prop');
+const semver = require('semver');
 
 const [ { speed: cpuSpeed } ] = os.cpus();
+
+function getNodeVersionMultiplier() {
+    const currentNodeVersion = process.version;
+
+    if (semver.lt(currentNodeVersion, '14.0.0') && semver.gte(currentNodeVersion, '12.0.0')) {
+        return 1.5;
+    }
+
+    if (semver.lt(currentNodeVersion, '12.0.0')) {
+        return 2;
+    }
+
+    return 1;
+}
 
 function clearRequireCache() {
     Object.keys(require.cache).forEach(function (key) {
@@ -36,4 +51,4 @@ function runBenchmark(fn, count) {
     return { medianDuration, medianMemory };
 }
 
-module.exports = { runBenchmark, clearRequireCache, cpuSpeed };
+module.exports = { runBenchmark, clearRequireCache, cpuSpeed, getNodeVersionMultiplier };

--- a/benchmarks/runtime.bench.js
+++ b/benchmarks/runtime.bench.js
@@ -5,7 +5,7 @@ const { Linter } = require('eslint');
 const times = require('ramda/src/times');
 const toPairs = require('ramda/src/toPairs');
 const fromPairs = require('ramda/src/fromPairs');
-const { runBenchmark, cpuSpeed } = require('./measure');
+const { runBenchmark, cpuSpeed, getNodeVersionMultiplier } = require('./measure');
 const mochaPlugin = require('../');
 
 const recommendedRules = mochaPlugin.configs.recommended.rules;
@@ -85,7 +85,8 @@ function lintManyFilesWithAllRecommendedRules({ numberOfFiles }) {
 
 describe('runtime', () => {
     it('should not take longer as the defined budget to lint many files with the recommended config', () => {
-        const budget = 80000000 / cpuSpeed;
+        const nodeVersionMultiplier = getNodeVersionMultiplier();
+        const budget = 80000000 / cpuSpeed * nodeVersionMultiplier;
 
         const { medianDuration } = runBenchmark(() => {
             lintManyFilesWithAllRecommendedRules({ numberOfFiles: 350 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,6 +2215,15 @@
                 }
             }
         },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
         "macos-release": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
@@ -3107,10 +3116,13 @@
             "dev": true
         },
         "semver": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-            "dev": true
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "serialize-javascript": {
             "version": "4.0.0",
@@ -3616,6 +3628,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
             "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "eslint-plugin-unicorn": "^21.0.0",
         "mocha": "^8.1.0",
         "nyc": "^15.1.0",
-        "pr-log": "^4.0.0"
+        "pr-log": "^4.0.0",
+        "semver": "^7.3.4"
     },
     "peerDependencies": {
         "eslint": ">=7.0.0"


### PR DESCRIPTION
Since older node versions are not as fast as the latest node version we should take that into account and increase the performance budget for older node versions.

cc: @szuend