### PR TITLE
Use AST utils speed ups for more rules

### DIFF
--- a/lib/rules/no-identical-title.js
+++ b/lib/rules/no-identical-title.js
@@ -22,10 +22,12 @@ module.exports = {
     },
     create(context) {
         const astUtils = createAstUtils(context.settings);
+        const isDescribe = astUtils.buildIsDescribeAnswerer();
+        const isTestCase = astUtils.buildIsTestCaseAnswerer();
         const titleLayers = [ newLayer() ];
 
         function handlTestCaseTitles(titles, node, title) {
-            if (astUtils.isTestCase(node)) {
+            if (isTestCase(node)) {
                 if (titles.includes(title)) {
                     context.report({
                         node,
@@ -37,7 +39,7 @@ module.exports = {
         }
 
         function handlTestSuiteTitles(titles, node, title) {
-            if (!astUtils.isDescribe(node)) {
+            if (!isDescribe(node)) {
                 return;
             }
             if (titles.includes(title)) {
@@ -53,7 +55,7 @@ module.exports = {
             CallExpression(node) {
                 const currentLayer = titleLayers[titleLayers.length - 1];
 
-                if (astUtils.isDescribe(node)) {
+                if (isDescribe(node)) {
                     titleLayers.push(newLayer());
                 }
                 if (!isFirstArgLiteral(node)) {
@@ -65,7 +67,7 @@ module.exports = {
                 handlTestSuiteTitles(currentLayer.describeTitles, node, title);
             },
             'CallExpression:exit'(node) {
-                if (astUtils.isDescribe(node)) {
+                if (isDescribe(node)) {
                     titleLayers.pop();
                 }
             }

--- a/lib/rules/no-nested-tests.js
+++ b/lib/rules/no-nested-tests.js
@@ -13,6 +13,9 @@ module.exports = {
     },
     create(context) {
         const astUtils = createAstUtils(context.settings);
+        const isDescribeFn = astUtils.buildIsDescribeAnswerer();
+        const isTestCaseFn = astUtils.buildIsTestCaseAnswerer();
+
         let testNestingLevel = 0;
         let hookCallNestingLevel = 0;
 
@@ -46,9 +49,9 @@ module.exports = {
 
         return {
             CallExpression(node) {
-                const isTestCase = astUtils.isTestCase(node);
+                const isTestCase = isTestCaseFn(node);
                 const isHookCall = astUtils.isHookCall(node);
-                const isDescribe = astUtils.isDescribe(node);
+                const isDescribe = isDescribeFn(node);
 
                 checkForAndReportErrors(node, isTestCase, isDescribe, isHookCall);
 

--- a/lib/rules/no-setup-in-describe.js
+++ b/lib/rules/no-setup-in-describe.js
@@ -57,9 +57,7 @@ module.exports = {
             }
         }
 
-        function isDescribe(node) {
-            return astUtils.isDescribe(node);
-        }
+        const isDescribe = astUtils.buildIsDescribeAnswerer();
 
         function isParentDescribe(node) {
             return isDescribe(node.parent);

--- a/lib/rules/no-skipped-tests.js
+++ b/lib/rules/no-skipped-tests.js
@@ -11,12 +11,13 @@ module.exports = {
     },
     create(context) {
         const astUtils = createAstUtils(context.settings);
+        const options = { modifiers: [ 'skip' ], modifiersOnly: true };
+        const isDescribe = astUtils.buildIsDescribeAnswerer(options);
+        const isTestCase = astUtils.buildIsTestCaseAnswerer(options);
 
         return {
             CallExpression(node) {
-                const options = { modifiers: [ 'skip' ], modifiersOnly: true };
-
-                if (astUtils.isDescribe(node, options) || astUtils.isTestCase(node, options)) {
+                if (isDescribe(node) || isTestCase(node)) {
                     const callee = node.callee;
                     const nodeToReport = callee.type === 'MemberExpression' ? callee.property : callee;
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -67,7 +67,7 @@ function isFunctionCallWithName(node, names) {
 function createAstUtils(settings) {
     const additionalCustomNames = getAddtionalNames(settings);
 
-    function buildIsDescribeAnswerer(options) {
+    function buildIsDescribeAnswerer(options = {}) {
         const { modifiers = [ 'skip', 'only' ], modifiersOnly = false } = options;
         const describeAliases = getSuiteNames({ modifiersOnly, modifiers, additionalCustomNames });
 


### PR DESCRIPTION
This PR applies the speed ups from b8fd70be also for no-identical-title, no-nested-tests, no-setup-in-describe and no-skipped-tests.

Results of `time TIMING=1 npm run test:bench` on my machine:

Before:
```
  runtime
    ✓ should not take longer as the defined budget to lint many files with the recommended config (91358ms)
    ✓ should not consume more memory as the defined budget to lint many files with the recommended config (90222ms)

  startup / require time
    ✓ should not take longer as the defined budget to require the plugin (755ms)
    ✓ should not consume more memory as the defined budget (720ms)


  4 passing (3m)

Rule                     | Time (ms) | Relative
:------------------------|----------:|--------:
no-setup-in-describe     | 32175.428 |    18.3%
no-nested-tests          | 24344.778 |    13.8%
no-identical-title       | 23523.293 |    13.4%
no-skipped-tests         | 15623.341 |     8.9%
no-hooks-for-single-case | 15192.657 |     8.6%
no-mocha-arrows          |  9966.165 |     5.7%
no-exports               |  9830.196 |     5.6%
no-async-describe        |  8221.952 |     4.7%
max-top-level-suites     |  8184.667 |     4.6%
no-global-tests          |  8141.928 |     4.6%

real	3m3.575s
user	3m5.368s
sys	0m2.117s
```
After:
```
  runtime
    ✓ should not take longer as the defined budget to lint many files with the recommended config (54985ms)
    ✓ should not consume more memory as the defined budget to lint many files with the recommended config (53322ms)

  startup / require time
    ✓ should not take longer as the defined budget to require the plugin (750ms)
    ✓ should not consume more memory as the defined budget (671ms)


  4 passing (2m)

Rule                     | Time (ms) | Relative
:------------------------|----------:|--------:
no-hooks-for-single-case | 15248.055 |    15.1%
no-setup-in-describe     | 11357.625 |    11.2%
no-mocha-arrows          |  9935.791 |     9.8%
no-exports               |  9835.281 |     9.7%
no-nested-tests          |  8539.599 |     8.4%
no-async-describe        |  8248.724 |     8.2%
no-sibling-hooks         |  8248.574 |     8.2%
max-top-level-suites     |  8236.007 |     8.1%
no-global-tests          |  8189.408 |     8.1%
no-top-level-hooks       |  8165.616 |     8.1%

real	1m50.250s
user	1m52.427s
sys	0m1.755s
```