### PR TITLE
chore: switch yarn command to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Install dependencies
               run: npm ci
             - name: Run linters
-              run: yarn lint
+              run: npm run lint
             - name: Run tests
               run: npm test
               timeout-minutes: 20


### PR DESCRIPTION
This repo uses npm, not yarn.