### PR TITLE
Add `mocha` prefix to "no-empty-description" rule name in rec config

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = {
                 'mocha/prefer-arrow-callback': 'off',
                 'mocha/valid-suite-description': 'off',
                 'mocha/valid-test-description': 'off',
-                'no-empty-description': 'error'
+                'mocha/no-empty-description': 'error'
             }
         }
     }


### PR DESCRIPTION
Fixes: Definition for rule 'no-empty-description' was not found