### PR TITLE
chore: use `requireindex` to export all rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,9 @@
 'use strict';
 
+const requireIndex = require('requireindex');
+
 module.exports = {
-    rules: {
-        'handle-done-callback': require('./lib/rules/handle-done-callback'),
-        'max-top-level-suites': require('./lib/rules/max-top-level-suites'),
-        'no-async-describe': require('./lib/rules/no-async-describe'),
-        'no-exclusive-tests': require('./lib/rules/no-exclusive-tests'),
-        'no-exports': require('./lib/rules/no-exports'),
-        'no-global-tests': require('./lib/rules/no-global-tests'),
-        'no-hooks': require('./lib/rules/no-hooks'),
-        'no-hooks-for-single-case': require('./lib/rules/no-hooks-for-single-case'),
-        'no-identical-title': require('./lib/rules/no-identical-title'),
-        'no-mocha-arrows': require('./lib/rules/no-mocha-arrows'),
-        'no-nested-tests': require('./lib/rules/no-nested-tests'),
-        'no-pending-tests': require('./lib/rules/no-pending-tests'),
-        'no-return-and-callback': require('./lib/rules/no-return-and-callback'),
-        'no-return-from-async': require('./lib/rules/no-return-from-async'),
-        'no-setup-in-describe': require('./lib/rules/no-setup-in-describe'),
-        'no-sibling-hooks': require('./lib/rules/no-sibling-hooks'),
-        'no-skipped-tests': require('./lib/rules/no-skipped-tests'),
-        'no-synchronous-tests': require('./lib/rules/no-synchronous-tests'),
-        'no-top-level-hooks': require('./lib/rules/no-top-level-hooks'),
-        'prefer-arrow-callback': require('./lib/rules/prefer-arrow-callback'),
-        'valid-suite-description': require('./lib/rules/valid-suite-description'),
-        'valid-test-description': require('./lib/rules/valid-test-description'),
-        'no-empty-description': require('./lib/rules/no-empty-description.js')
-    },
+    rules: requireIndex(`${__dirname}/lib/rules`),
     configs: {
         all: {
             env: { mocha: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,12 @@
     "packages": {
         "": {
             "name": "eslint-plugin-mocha",
-            "version": "10.0.0",
+            "version": "10.0.1",
             "license": "MIT",
             "dependencies": {
                 "eslint-utils": "^3.0.0",
-                "ramda": "^0.27.1"
+                "ramda": "^0.27.1",
+                "requireindex": "^1.2.0"
             },
             "devDependencies": {
                 "chai": "^4.3.4",
@@ -4859,6 +4860,14 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
+        "node_modules/requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+            "engines": {
+                "node": ">=0.10.5"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -9324,6 +9333,11 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
+        },
+        "requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
         },
         "resolve": {
             "version": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     },
     "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.27.1"
+        "ramda": "^0.27.1",
+        "requireindex": "^1.2.0"
     },
     "devDependencies": {
         "chai": "^4.3.4",


### PR DESCRIPTION
* No more need to maintain list of exported rules
  * Reduces barrier to creating/renaming lint rules
  * Less chance of typos/mistakes
* [requireindex](https://www.npmjs.com/package/requireindex) is commonly used by other linters for the same purpose, including the generator-eslint blueprint for eslint plugins:
  * https://github.com/eslint/generator-eslint/blob/main/plugin/templates/_plugin.js
  * https://github.com/ember-cli/eslint-plugin-ember/blob/master/lib/index.js
  * https://github.com/platinumazure/eslint-plugin-qunit/blob/master/index.js