### PR TITLE
Support this for additionalCustomNames

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -28,6 +28,9 @@ function getPropertyName(property) {
 }
 
 function getNodeName(node) {
+    if (node.type === 'ThisExpression') {
+        return 'this';
+    }
     if (node.type === 'MemberExpression') {
         return `${getNodeName(node.object)}.${getPropertyName(node.property)}`;
     }

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -166,6 +166,15 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 7, line: 1 } ]
+        },
+        {
+            code: 'this.it.only()',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'this.it', type: 'testCase', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
         }
     ]
 });


### PR DESCRIPTION
A `ThisExpression` doesn't have a name so effectively, `this.it` is parsed as `undefined.it` and that works but is obviously wrong since it would also catch literally `undefined.it` as well.