### PR TITLE
Support function calls as custom names (to stop false warnings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,46 @@ Then add a reference to this plugin and selected rules in your eslint config:
 
 This plugin supports the following settings, which are used by multiple rules:
 
-* `additionalCustomNames`: This allows rules to check additional function names when looking for suites or test cases. This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha)
-**Example:**
+* `additionalCustomNames`: This allows rules to check additional function names when looking for suites or test cases. This might be used with a custom Mocha extension, such as [`ember-mocha`](https://github.com/switchfly/ember-mocha) or [`mocha-each`](https://github.com/ryym/mocha-each).
 
-```json
-{
-    "rules": {
-        "mocha/no-skipped-tests": "error",
-        "mocha/no-exclusive-tests": "error"
-    },
-    "settings": {
-        "mocha/additionalCustomNames": [
-            { "name": "describeModule", "type": "suite", "interfaces": [ "BDD" ] },
-            { "name": "testModule", "type": "testCase", "interfaces": [ "TDD" ] }
-        ]
+   **Example:**
+
+    ```json
+    {
+        "rules": {
+            "mocha/no-skipped-tests": "error",
+            "mocha/no-exclusive-tests": "error"
+        },
+        "settings": {
+            "mocha/additionalCustomNames": [
+                { "name": "describeModule", "type": "suite", "interfaces": [ "BDD" ] },
+                { "name": "testModule", "type": "testCase", "interfaces": [ "TDD" ] }
+            ]
+        }
     }
-}
-```
+    ```
+    The `name` property can be in any of the following forms:
+    * A plain name e.g. `describeModule`, which allows:
+        ```
+        describeModule("example", function() { ... });
+        ```
+
+    * A dotted name, e.g. `describe.modifier`, which allows:
+      ```
+      describe.modifier("example", function() { ... });
+      ```
+
+    * A name with parentheses, e.g. `forEach().describe`, which allows:
+      ```
+      forEach([ 1, 2, 3 ])
+          .describe("example", function(n) { ... });
+      ```
+
+    * Any combination of the above, e.g. `forEach().describeModule.modifier`, which allows:
+      ```
+      forEach([ 1, 2, 3 ])
+          .describeModule.modifier("example", function(n) { ... });
+      ```
 
 ## Configs
 

--- a/README.md
+++ b/README.md
@@ -47,28 +47,33 @@ This plugin supports the following settings, which are used by multiple rules:
         }
     }
     ```
-    The `name` property can be in any of the following forms:
-    * A plain name e.g. `describeModule`, which allows:
-        ```
-        describeModule("example", function() { ... });
-        ```
 
-    * A dotted name, e.g. `describe.modifier`, which allows:
-      ```
-      describe.modifier("example", function() { ... });
-      ```
+  The `name` property can be in any of the following forms:
+  * A plain name e.g. `describeModule`, which allows:
 
-    * A name with parentheses, e.g. `forEach().describe`, which allows:
-      ```
-      forEach([ 1, 2, 3 ])
-          .describe("example", function(n) { ... });
-      ```
+    ```javascript
+    describeModule("example", function() { ... });
+    ```
 
-    * Any combination of the above, e.g. `forEach().describeModule.modifier`, which allows:
-      ```
-      forEach([ 1, 2, 3 ])
-          .describeModule.modifier("example", function(n) { ... });
-      ```
+  * A dotted name, e.g. `describe.modifier`, which allows:
+
+    ```javascript
+    describe.modifier("example", function() { ... });
+    ```
+
+  * A name with parentheses, e.g. `forEach().describe`, which allows:
+
+    ```javascript
+    forEach([ 1, 2, 3 ])
+        .describe("example", function(n) { ... });
+    ```
+
+  * Any combination of the above, e.g. `forEach().describeModule.modifier`, which allows:
+
+    ```javascript
+    forEach([ 1, 2, 3 ])
+        .describeModule.modifier("example", function(n) { ... });
+    ```
 
 ## Configs
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -31,6 +31,9 @@ function getNodeName(node) {
     if (node.type === 'ThisExpression') {
         return 'this';
     }
+    if (node.type === 'CallExpression') {
+        return getNodeName(node.callee);
+    }
     if (node.type === 'MemberExpression') {
         return `${getNodeName(node.object)}.${getPropertyName(node.property)}`;
     }

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -32,7 +32,7 @@ function getNodeName(node) {
         return 'this';
     }
     if (node.type === 'CallExpression') {
-        return getNodeName(node.callee);
+        return `${getNodeName(node.callee)}()`;
     }
     if (node.type === 'MemberExpression') {
         return `${getNodeName(node.object)}.${getPropertyName(node.property)}`;

--- a/test/rules/max-top-level-suites.js
+++ b/test/rules/max-top-level-suites.js
@@ -68,6 +68,40 @@ ruleTester.run('max-top-level-suites', rules['max-top-level-suites'], {
                 sourceType: 'module',
                 ecmaVersion: 2015
             }
+        },
+        {
+            code: [
+                'describe.foo("", function () {',
+                '    describe("", function () {});',
+                '    describe("", function () {});',
+                '});'
+            ].join('\n'),
+            parserOptions: {
+                sourceType: 'module',
+                ecmaVersion: 2015
+            },
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
+        },
+        {
+            code: [
+                'describe.foo("bar")("", function () {',
+                '    describe("", function () {});',
+                '    describe("", function () {});',
+                '});'
+            ].join('\n'),
+            parserOptions: {
+                sourceType: 'module',
+                ecmaVersion: 2015
+            },
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
         }
     ],
 
@@ -206,6 +240,34 @@ ruleTester.run('max-top-level-suites', rules['max-top-level-suites'], {
             settings: {
                 mocha: {
                     additionalCustomNames: [ { name: 'foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [
+                { message: 'The number of top-level suites is more than 1.' }
+            ]
+        }, {
+            code: 'describe.foo("bar")("this is a test", function () { });' +
+                  'context.foo("this is a different test", function () { });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'context.foo', type: 'suite', interfaces: [ 'BDD' ] }
+                    ]
+                }
+            },
+            errors: [
+                { message: 'The number of top-level suites is more than 1.' }
+            ]
+        }, {
+            code: 'forEach([ 1, 2, 3 ]).describe("this is a test", function () { });' +
+                  'context.foo("this is a different test", function () { });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'forEach().describe', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'context.foo', type: 'suite', interfaces: [ 'BDD' ] }
+                    ]
                 }
             },
             errors: [

--- a/test/rules/no-async-describe.js
+++ b/test/rules/no-async-describe.js
@@ -72,6 +72,40 @@ ruleTester.run('no-async-describe', rule, {
                 line: 1,
                 column: 19
             } ]
+        },
+        {
+            code: 'describe.foo("bar")("hello", async () => {})',
+            output: 'describe.foo("bar")("hello", () => {})',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] }
+                    ]
+                }
+            },
+            parserOptions: { ecmaVersion: 8 },
+            errors: [ {
+                message: 'Unexpected async function in describe.foo()()',
+                line: 1,
+                column: 30
+            } ]
+        },
+        {
+            code: 'forEach([ 1, 2, 3 ]).describe.foo("hello", async () => {})',
+            output: 'forEach([ 1, 2, 3 ]).describe.foo("hello", () => {})',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'forEach().describe.foo', type: 'suite', interfaces: [ 'BDD' ] }
+                    ]
+                }
+            },
+            parserOptions: { ecmaVersion: 8 },
+            errors: [ {
+                message: 'Unexpected async function in forEach().describe.foo()',
+                line: 1,
+                column: 44
+            } ]
         }
     ]
 });

--- a/test/rules/no-exclusive-tests.js
+++ b/test/rules/no-exclusive-tests.js
@@ -38,6 +38,14 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
                     additionalCustomNames: [ { name: 'a.b.c', type: 'testCase', interfaces: [ 'BDD' ] } ]
                 }
             }
+        },
+        {
+            code: 'a.b().c.skip()',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'a.b().c', type: 'testCase', interfaces: [ 'BDD' ] } ]
+                }
+            }
         }
     ],
 
@@ -175,6 +183,15 @@ ruleTester.run('no-exclusive-tests', rules['no-exclusive-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 9, line: 1 } ]
+        },
+        {
+            code: 'foo("bar").it.only()',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'foo().it', type: 'testCase', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 15, line: 1 } ]
         }
     ]
 });

--- a/test/rules/no-sibling-hooks.js
+++ b/test/rules/no-sibling-hooks.js
@@ -98,6 +98,72 @@ ruleTester.run('no-sibling-hooks', rules['no-sibling-hooks'], {
                     additionalCustomNames: [ { name: 'foo', type: 'suite', interfaces: [ 'BDD' ] } ]
                 }
             }
+        }, {
+            code: [
+                'describe(function() {',
+                '    before(function() {});',
+                '    describe.foo(function() {',
+                '        before(function() {});',
+                '    });',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
+        }, {
+            code: [
+                'describe(function() {',
+                '    before(function() {});',
+                '    describe.foo()(function() {',
+                '        before(function() {});',
+                '    });',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
+        }, {
+            code: [
+                'describe(function() {',
+                '    before(function() {});',
+                '    forEach([ 1, 2, 3 ]).describe(function() {',
+                '        before(function() {});',
+                '    });',
+                '    forEach([ 1, 2, 3 ]).context(function() {',
+                '        before(function() {});',
+                '    });',
+                '    forEach([ 1, 2, 3 ]).describe.only(function() {',
+                '        before(function() {});',
+                '    });',
+                '    forEach([ 1, 2, 3 ]).describe.skip(function() {',
+                '        before(function() {});',
+                '    });',
+                '    forEach([ 1, 2, 3 ]).describe.foo(function() {',
+                '        before(function() {});',
+                '    });',
+                '    forEach([ 1, 2, 3 ]).describe.bar([ 9, 8, 7 ])(function() {',
+                '        before(function() {});',
+                '    });',
+                '    deep.forEach({ a: [ 1, 2, 3 ], b: [ 4, 5, 6 ] }).describe(function() {',
+                '        before(function() {});',
+                '    });',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'forEach.describe', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach.context', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach.describe.foo', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach.describe.bar', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'deep.forEach.describe', type: 'suite', interfaces: [ 'BDD' ] }
+                    ]
+                }
+            }
         }
     ],
 

--- a/test/rules/no-sibling-hooks.js
+++ b/test/rules/no-sibling-hooks.js
@@ -123,7 +123,7 @@ ruleTester.run('no-sibling-hooks', rules['no-sibling-hooks'], {
             ].join('\n'),
             settings: {
                 mocha: {
-                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                    additionalCustomNames: [ { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] } ]
                 }
             }
         }, {
@@ -156,11 +156,11 @@ ruleTester.run('no-sibling-hooks', rules['no-sibling-hooks'], {
             settings: {
                 mocha: {
                     additionalCustomNames: [
-                        { name: 'forEach.describe', type: 'suite', interfaces: [ 'BDD' ] },
-                        { name: 'forEach.context', type: 'suite', interfaces: [ 'BDD' ] },
-                        { name: 'forEach.describe.foo', type: 'suite', interfaces: [ 'BDD' ] },
-                        { name: 'forEach.describe.bar', type: 'suite', interfaces: [ 'BDD' ] },
-                        { name: 'deep.forEach.describe', type: 'suite', interfaces: [ 'BDD' ] }
+                        { name: 'forEach().describe', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach().context', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach().describe.foo', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'forEach().describe.bar()', type: 'suite', interfaces: [ 'BDD' ] },
+                        { name: 'deep.forEach().describe', type: 'suite', interfaces: [ 'BDD' ] }
                     ]
                 }
             }
@@ -235,6 +235,54 @@ ruleTester.run('no-sibling-hooks', rules['no-sibling-hooks'], {
             settings: {
                 mocha: {
                     additionalCustomNames: [ { name: 'foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: 'Unexpected use of duplicate Mocha `before` hook', column: 5, line: 6 } ]
+        }, {
+            code: [
+                'describe.foo(function() {',
+                '    before(function() {});',
+                '    describe.foo(function() {',
+                '        before(function() {});',
+                '    });',
+                '    before(function() {});',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: 'Unexpected use of duplicate Mocha `before` hook', column: 5, line: 6 } ]
+        }, {
+            code: [
+                'describe.foo()(function() {',
+                '    before(function() {});',
+                '    describe.foo()(function() {',
+                '        before(function() {});',
+                '    });',
+                '    before(function() {});',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: 'Unexpected use of duplicate Mocha `before` hook', column: 5, line: 6 } ]
+        }, {
+            code: [
+                'forEach([ 1, 2, 3 ]).describe(function() {',
+                '    before(function() {});',
+                '    forEach([ 4, 5, 6 ]).describe(function() {',
+                '        before(function() {});',
+                '    });',
+                '    before(function() {});',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'forEach().describe', type: 'suite', interfaces: [ 'BDD' ] } ]
                 }
             },
             errors: [ { message: 'Unexpected use of duplicate Mocha `before` hook', column: 5, line: 6 } ]

--- a/test/rules/no-skipped-tests.js
+++ b/test/rules/no-skipped-tests.js
@@ -139,6 +139,15 @@ ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
                 }
             },
             errors: [ { message: expectedErrorMessage, column: 1, line: 1 } ]
+        },
+        {
+            code: 'custom("bar").it.skip()',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'custom().it', type: 'testCase', interfaces: [ 'BDD' ] } ]
+                }
+            },
+            errors: [ { message: expectedErrorMessage, column: 18, line: 1 } ]
         }
     ]
 

--- a/test/rules/no-top-level-hooks.js
+++ b/test/rules/no-top-level-hooks.js
@@ -34,6 +34,27 @@ ruleTester.run('no-top-level-hooks', rules['no-top-level-hooks'], {
                     additionalCustomNames: [ { name: 'foo', type: 'suite', interfaces: [ 'BDD' ] } ]
                 }
             }
+        }, {
+            code: 'describe.foo(function() { before(function() {}); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
+        }, {
+            code: 'describe.foo()(function() { before(function() {}); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'describe.foo()', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
+        }, {
+            code: 'forEach([ 1, 2, 3 ]).describe(function() { before(function() {}); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [ { name: 'forEach().describe', type: 'suite', interfaces: [ 'BDD' ] } ]
+                }
+            }
         }
     ],
     invalid: [
@@ -90,6 +111,30 @@ ruleTester.run('no-top-level-hooks', rules['no-top-level-hooks'], {
             errors: [ {
                 message: 'Unexpected use of Mocha `before` hook outside of a test suite',
                 column: 21,
+                line: 1
+            } ]
+        },
+        {
+            code: 'describe()(function() {}); before(function() {});',
+            errors: [ {
+                message: 'Unexpected use of Mocha `before` hook outside of a test suite',
+                column: 28,
+                line: 1
+            } ]
+        },
+        {
+            code: 'describe.foo()(function() {}); before(function() {});',
+            errors: [ {
+                message: 'Unexpected use of Mocha `before` hook outside of a test suite',
+                column: 32,
+                line: 1
+            } ]
+        },
+        {
+            code: 'forEach([ 1, 2, 3 ]).describe(function() {}); before(function() {});',
+            errors: [ {
+                message: 'Unexpected use of Mocha `before` hook outside of a test suite',
+                column: 47,
                 line: 1
             } ]
         }


### PR DESCRIPTION
Call expressions can have a name when getting the node. Fixes #335 

There might have been better ways to achieve this, but this looked like the most straightforward.