### PR TITLE
Add support for eslint flat config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This plugin requires ESLint `4.0.0` or later.
 npm install --save-dev eslint-plugin-mocha
 ```
 
+### `.eslintrc.json`
+
 Then add a reference to this plugin and selected rules in your eslint config:
 
 ```json
@@ -23,6 +25,19 @@ Then add a reference to this plugin and selected rules in your eslint config:
         "mocha"
     ]
 }
+```
+
+### `eslint.config.js` (requires eslint >= 8.23.0)
+
+To use this plugin with [the new eslint configuration format (flat config)](https://eslint.org/docs/latest/use/configure/configuration-files-new):
+
+```js
+import mochaPlugin from 'eslint-plugin-mocha';
+
+export default [
+    mochaPlugin.configs.flat.recommended // or `mochaPlugin.configs.flat.all` to enable all
+    // ... Your configurations here
+];
 ```
 
 ### Plugin Settings

--- a/index.js
+++ b/index.js
@@ -1,6 +1,62 @@
 'use strict';
 
-module.exports = {
+const globals = require('globals');
+
+const allRules = {
+    'mocha/handle-done-callback': 'error',
+    'mocha/max-top-level-suites': 'error',
+    'mocha/no-async-describe': 'error',
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-exports': 'error',
+    'mocha/no-global-tests': 'error',
+    'mocha/no-hooks': 'error',
+    'mocha/no-hooks-for-single-case': 'error',
+    'mocha/no-identical-title': 'error',
+    'mocha/no-mocha-arrows': 'error',
+    'mocha/no-nested-tests': 'error',
+    'mocha/no-pending-tests': 'error',
+    'mocha/no-return-and-callback': 'error',
+    'mocha/no-return-from-async': 'error',
+    'mocha/no-setup-in-describe': 'error',
+    'mocha/no-sibling-hooks': 'error',
+    'mocha/no-skipped-tests': 'error',
+    'mocha/no-synchronous-tests': 'error',
+    'mocha/no-top-level-hooks': 'error',
+    'mocha/prefer-arrow-callback': 'error',
+    'mocha/valid-suite-description': 'error',
+    'mocha/valid-test-description': 'error',
+    'mocha/no-empty-description': 'error',
+    'mocha/consistent-spacing-between-blocks': 'error'
+};
+
+const recommendedRules = {
+    'mocha/handle-done-callback': 'error',
+    'mocha/max-top-level-suites': [ 'error', { limit: 1 } ],
+    'mocha/no-async-describe': 'error',
+    'mocha/no-exclusive-tests': 'warn',
+    'mocha/no-exports': 'error',
+    'mocha/no-global-tests': 'error',
+    'mocha/no-hooks': 'off',
+    'mocha/no-hooks-for-single-case': 'off',
+    'mocha/no-identical-title': 'error',
+    'mocha/no-mocha-arrows': 'error',
+    'mocha/no-nested-tests': 'error',
+    'mocha/no-pending-tests': 'warn',
+    'mocha/no-return-and-callback': 'error',
+    'mocha/no-return-from-async': 'off',
+    'mocha/no-setup-in-describe': 'error',
+    'mocha/no-sibling-hooks': 'error',
+    'mocha/no-skipped-tests': 'warn',
+    'mocha/no-synchronous-tests': 'off',
+    'mocha/no-top-level-hooks': 'warn',
+    'mocha/prefer-arrow-callback': 'off',
+    'mocha/valid-suite-description': 'off',
+    'mocha/valid-test-description': 'off',
+    'mocha/no-empty-description': 'error',
+    'mocha/consistent-spacing-between-blocks': 'error'
+};
+
+const mod = {
     rules: {
         'handle-done-callback': require('./lib/rules/handle-done-callback'),
         'max-top-level-suites': require('./lib/rules/max-top-level-suites'),
@@ -31,63 +87,27 @@ module.exports = {
         all: {
             env: { mocha: true },
             plugins: [ 'mocha' ],
-            rules: {
-                'mocha/handle-done-callback': 'error',
-                'mocha/max-top-level-suites': 'error',
-                'mocha/no-async-describe': 'error',
-                'mocha/no-exclusive-tests': 'error',
-                'mocha/no-exports': 'error',
-                'mocha/no-global-tests': 'error',
-                'mocha/no-hooks': 'error',
-                'mocha/no-hooks-for-single-case': 'error',
-                'mocha/no-identical-title': 'error',
-                'mocha/no-mocha-arrows': 'error',
-                'mocha/no-nested-tests': 'error',
-                'mocha/no-pending-tests': 'error',
-                'mocha/no-return-and-callback': 'error',
-                'mocha/no-return-from-async': 'error',
-                'mocha/no-setup-in-describe': 'error',
-                'mocha/no-sibling-hooks': 'error',
-                'mocha/no-skipped-tests': 'error',
-                'mocha/no-synchronous-tests': 'error',
-                'mocha/no-top-level-hooks': 'error',
-                'mocha/prefer-arrow-callback': 'error',
-                'mocha/valid-suite-description': 'error',
-                'mocha/valid-test-description': 'error',
-                'mocha/no-empty-description': 'error',
-                'mocha/consistent-spacing-between-blocks': 'error'
-            }
+            rules: allRules
         },
-
         recommended: {
             env: { mocha: true },
             plugins: [ 'mocha' ],
-            rules: {
-                'mocha/handle-done-callback': 'error',
-                'mocha/max-top-level-suites': [ 'error', { limit: 1 } ],
-                'mocha/no-async-describe': 'error',
-                'mocha/no-exclusive-tests': 'warn',
-                'mocha/no-exports': 'error',
-                'mocha/no-global-tests': 'error',
-                'mocha/no-hooks': 'off',
-                'mocha/no-hooks-for-single-case': 'off',
-                'mocha/no-identical-title': 'error',
-                'mocha/no-mocha-arrows': 'error',
-                'mocha/no-nested-tests': 'error',
-                'mocha/no-pending-tests': 'warn',
-                'mocha/no-return-and-callback': 'error',
-                'mocha/no-return-from-async': 'off',
-                'mocha/no-setup-in-describe': 'error',
-                'mocha/no-sibling-hooks': 'error',
-                'mocha/no-skipped-tests': 'warn',
-                'mocha/no-synchronous-tests': 'off',
-                'mocha/no-top-level-hooks': 'warn',
-                'mocha/prefer-arrow-callback': 'off',
-                'mocha/valid-suite-description': 'off',
-                'mocha/valid-test-description': 'off',
-                'mocha/no-empty-description': 'error',
-                'mocha/consistent-spacing-between-blocks': 'error'
-            }
+            rules: recommendedRules
         }
     }
 };
+
+mod.configs.flat = {
+    all: {
+        plugins: { mocha: mod },
+        languageOptions: { globals: globals.mocha },
+        rules: allRules
+    },
+    recommended: {
+        plugins: { mocha: mod },
+        languageOptions: { globals: globals.mocha },
+        rules: recommendedRules
+    }
+};
+
+module.exports = mod;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "eslint-utils": "^3.0.0",
+                "globals": "^14.0.0",
                 "rambda": "^7.4.0"
             },
             "devDependencies": {
@@ -1048,6 +1049,33 @@
                 "globals": "13.24.0"
             }
         },
+        "node_modules/@enormora/eslint-config-node/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@enormora/eslint-config-node/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@enormora/eslint-config-typescript": {
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/@enormora/eslint-config-typescript/-/eslint-config-typescript-0.0.11.tgz",
@@ -1111,6 +1139,20 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1120,6 +1162,17 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@eslint/js": {
@@ -5243,6 +5296,33 @@
                 "eslint": ">=7.0.0"
             }
         },
+        "node_modules/eslint-plugin-n/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint-plugin-no-secrets": {
             "version": "0.8.9",
             "resolved": "https://registry.npmjs.org/eslint-plugin-no-secrets/-/eslint-plugin-no-secrets-0.8.9.tgz",
@@ -5452,6 +5532,20 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "node_modules/eslint/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint/node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -5461,6 +5555,17 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/eslint/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/espree": {
@@ -6240,25 +6345,11 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globals/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     },
     "dependencies": {
         "eslint-utils": "^3.0.0",
+        "globals": "^14.0.0",
         "rambda": "^7.4.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Fix #341

This PR adds support for [the eslint flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new). Now eslint-plugin-mocha can be used in `eslint.config.js`.

```js
import eslint from '@eslint/js';
import mocha from 'eslint-plugin-mocha';

export default [
    eslint.configs.recommended,
    mocha.configs.flat.recommended
];
```

Changes are as follows:

- Since the configuration format is different from legacy eslintrc config, new objects for `all` and `recommended` were added to `mochaPlugin.configs.flat` separately.
- `globals` package was added as dependency because `env` config was dropped at flat config. Globals such as `describe` need to be added in `languageOptions` and `globals` package provides the list of mocha's globals.
- Instruction for flat config was added to README.md document