### PR TITLE
Fix type of the plugin object's `configs` field

### DIFF
--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -37,7 +37,7 @@ describe('eslint-plugin-mocha', function () {
         const ruleFiles = await determineAllRuleFiles();
 
         for (const file of ruleFiles) {
-            const ruleName = path.basename(file, '.js') as keyof typeof plugin.rules;
+            const ruleName = path.basename(file, '.js');
             assert.ok(ruleName in plugin.rules);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ok
             const importedRuleModule = await import(path.join(rulesDir, file));

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -78,6 +78,13 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-spacing-between-blocks': 'error'
 };
 
+export type MochaPlugin = ESLint.Plugin & {
+    configs: {
+        all: Linter.Config;
+        recommended: Linter.Config;
+    };
+};
+
 const mochaPlugin = {
     rules: {
         'handle-done-callback': handleDoneCallbackRule,
@@ -121,7 +128,9 @@ const mochaPlugin = {
     }
 } satisfies ESLint.Plugin;
 
-mochaPlugin.configs.all.plugins.mocha = mochaPlugin;
-mochaPlugin.configs.recommended.plugins.mocha = mochaPlugin;
+const plugin: MochaPlugin = mochaPlugin;
 
-export default mochaPlugin;
+plugin.configs.all.plugins.mocha = plugin;
+plugin.configs.recommended.plugins.mocha = plugin;
+
+export default plugin;

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -78,57 +78,66 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-spacing-between-blocks': 'error'
 };
 
-export type MochaPlugin = ESLint.Plugin & {
-    configs: {
-        all: Linter.Config;
-        recommended: Linter.Config;
+const rules = {
+    'handle-done-callback': handleDoneCallbackRule,
+    'max-top-level-suites': maxTopLevelSuitesRule,
+    'no-async-suite': noAsyncSuiteRule,
+    'no-exclusive-tests': noExclusiveTestsRule,
+    'no-exports': noExportsRule,
+    'no-global-tests': noGlobalTestsRule,
+    'no-hooks': noHooksRule,
+    'no-hooks-for-single-case': noHooksForSingleCaseRule,
+    'no-identical-title': noIdenticalTitleRule,
+    'no-mocha-arrows': noMochaArrowsRule,
+    'no-nested-tests': noNestedTestsRule,
+    'no-pending-tests': noPendingTestsRule,
+    'no-return-and-callback': noReturnAndCallbackRule,
+    'no-return-from-async': noReturnFromAsyncRule,
+    'no-setup-in-describe': noSetupInDescribeRule,
+    'no-sibling-hooks': noSiblingHooksRule,
+    'no-synchronous-tests': noSynchronousTestsRule,
+    'no-top-level-hooks': noTopLevelHooksRule,
+    'prefer-arrow-callback': preferArrowCallbackRule,
+    'consistent-spacing-between-blocks': consistentSpacingBetweenBlocksRule,
+    'consistent-interface': consistentInterfaceRule,
+    'valid-suite-title': validSuiteTitleRule,
+    'valid-test-title': validTestTitleRule,
+    'no-empty-title': noEmptyTitleRule
+};
+
+type MochaConfig = Linter.Config & {
+    plugins: {
+        mocha: ESLint.Plugin;
     };
 };
 
-const mochaPlugin = {
-    rules: {
-        'handle-done-callback': handleDoneCallbackRule,
-        'max-top-level-suites': maxTopLevelSuitesRule,
-        'no-async-suite': noAsyncSuiteRule,
-        'no-exclusive-tests': noExclusiveTestsRule,
-        'no-exports': noExportsRule,
-        'no-global-tests': noGlobalTestsRule,
-        'no-hooks': noHooksRule,
-        'no-hooks-for-single-case': noHooksForSingleCaseRule,
-        'no-identical-title': noIdenticalTitleRule,
-        'no-mocha-arrows': noMochaArrowsRule,
-        'no-nested-tests': noNestedTestsRule,
-        'no-pending-tests': noPendingTestsRule,
-        'no-return-and-callback': noReturnAndCallbackRule,
-        'no-return-from-async': noReturnFromAsyncRule,
-        'no-setup-in-describe': noSetupInDescribeRule,
-        'no-sibling-hooks': noSiblingHooksRule,
-        'no-synchronous-tests': noSynchronousTestsRule,
-        'no-top-level-hooks': noTopLevelHooksRule,
-        'prefer-arrow-callback': preferArrowCallbackRule,
-        'consistent-spacing-between-blocks': consistentSpacingBetweenBlocksRule,
-        'consistent-interface': consistentInterfaceRule,
-        'valid-suite-title': validSuiteTitleRule,
-        'valid-test-title': validTestTitleRule,
-        'no-empty-title': noEmptyTitleRule
+const configs: {
+    all: MochaConfig;
+    recommended: MochaConfig;
+} = {
+    all: {
+        name: 'mocha/all',
+        plugins: { mocha: {} },
+        languageOptions: { globals: globals.mocha },
+        rules: allRules
     },
-    configs: {
-        all: {
-            name: 'mocha/all',
-            plugins: { mocha: {} },
-            languageOptions: { globals: globals.mocha },
-            rules: allRules
-        },
-        recommended: {
-            name: 'mocha/recommended',
-            plugins: { mocha: {} },
-            languageOptions: { globals: globals.mocha },
-            rules: recommendedRules
-        }
+    recommended: {
+        name: 'mocha/recommended',
+        plugins: { mocha: {} },
+        languageOptions: { globals: globals.mocha },
+        rules: recommendedRules
     }
-} satisfies ESLint.Plugin;
+};
 
-const plugin: MochaPlugin = mochaPlugin;
+export type MochaPlugin = ESLint.Plugin & {
+    rules: typeof rules;
+    configs: typeof configs;
+};
+
+const plugin: MochaPlugin = {
+    rules,
+    configs
+};
 
 plugin.configs.all.plugins.mocha = plugin;
 plugin.configs.recommended.plugins.mocha = plugin;


### PR DESCRIPTION
Fix #392

By this change `plugin.d.ts` looks like the following. `configs` field is no longer optional.

```typescript
import type { ESLint, Linter } from 'eslint';
export type MochaPlugin = ESLint.Plugin & {
    configs: {
        all: Linter.Config;
        recommended: Linter.Config;
    };
};
declare const mochaPlugin: MochaPlugin;
export default mochaPlugin;
//# sourceMappingURL=plugin.d.ts.map
```