### PR TITLE
Fix: disallow extra properties in rule options

### DIFF
--- a/source/rules/no-hooks-for-single-case.ts
+++ b/source/rules/no-hooks-for-single-case.ts
@@ -46,7 +46,8 @@ export const noHooksForSingleCaseRule: Readonly<Rule.RuleModule> = {
                             type: 'string'
                         }
                     }
-                }
+                },
+                additionalProperties: false
             }
         ]
     },

--- a/source/rules/no-synchronous-tests.ts
+++ b/source/rules/no-synchronous-tests.ts
@@ -61,7 +61,8 @@ export const noSynchronousTestsRule: Readonly<Rule.RuleModule> = {
                         minItems: 1,
                         uniqueItems: true
                     }
-                }
+                },
+                additionalProperties: false
             }
         ]
     },


### PR DESCRIPTION
Some rules, for example [no-hooks-for-single-case](https://github.com/lo1tuma/eslint-plugin-mocha/blob/1e5a3a1a9597ab54e5cc3d3fc58071009d0335d3/source/rules/no-hooks-for-single-case.ts#L40) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.