### PR TITLE
ci: drop node 23, add node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ jobs:
     build:
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
-                node: [20, 22, 23]
+                node: [20, 22, 24]
         name: Node ${{ matrix.node }}
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
## Situation

CI workflow [.github/workflows/ci.yml](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/.github/workflows/ci.yml):

- tests using Node.js `23` that entered [end-of-life](https://github.com/nodejs/Release/blob/main/README.md#end-of-life-releases) on June 1, 2025
- does not test with current Node.js `24` that was released first with Node.js [v24.0.0](https://nodejs.org/en/blog/release/v24.0.0) on May 6, 2025
- stops testing if any matrix job fails

## Change

In CI workflow [.github/workflows/ci.yml](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/.github/workflows/ci.yml):

- remove Node.js `23` from testing
- add Node.js `24` to tests
- negate `fail-fast` to allow each Node.js to be tested independently