### PR TITLE
Improve exported plugin type

### DIFF
--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -37,14 +37,15 @@ describe('eslint-plugin-mocha', function () {
         const ruleFiles = await determineAllRuleFiles();
 
         for (const file of ruleFiles) {
-            const ruleName = path.basename(file, '.js');
+            const ruleName = path.basename(file, '.js') as keyof typeof plugin.rules;
+            assert.ok(ruleName in plugin.rules);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ok
             const importedRuleModule = await import(path.join(rulesDir, file));
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- ok
             const importedRule = importedRuleModule[`${camelCase(ruleName)}Rule`];
 
             assert.notStrictEqual(importedRule, undefined);
-            assert.strictEqual(plugin.rules?.[ruleName], importedRule);
+            assert.strictEqual(plugin.rules[ruleName], importedRule);
         }
     });
 

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -76,9 +76,9 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/valid-test-title': 'off',
     'mocha/no-empty-title': 'error',
     'mocha/consistent-spacing-between-blocks': 'error'
-} as const;
+};
 
-const mochaPlugin: ESLint.Plugin = {
+const mochaPlugin = {
     rules: {
         'handle-done-callback': handleDoneCallbackRule,
         'max-top-level-suites': maxTopLevelSuitesRule,
@@ -104,22 +104,24 @@ const mochaPlugin: ESLint.Plugin = {
         'valid-suite-title': validSuiteTitleRule,
         'valid-test-title': validTestTitleRule,
         'no-empty-title': noEmptyTitleRule
-    }
-};
-
-mochaPlugin.configs = {
-    all: {
-        name: 'mocha/all',
-        plugins: { mocha: mochaPlugin },
-        languageOptions: { globals: globals.mocha },
-        rules: allRules
     },
-    recommended: {
-        name: 'mocha/recommended',
-        plugins: { mocha: mochaPlugin },
-        languageOptions: { globals: globals.mocha },
-        rules: recommendedRules
+    configs: {
+        all: {
+            name: 'mocha/all',
+            plugins: { mocha: {} },
+            languageOptions: { globals: globals.mocha },
+            rules: allRules
+        },
+        recommended: {
+            name: 'mocha/recommended',
+            plugins: { mocha: {} },
+            languageOptions: { globals: globals.mocha },
+            rules: recommendedRules
+        }
     }
 };
 
-export default mochaPlugin;
+mochaPlugin.configs.all.plugins.mocha = mochaPlugin;
+mochaPlugin.configs.recommended.plugins.mocha = mochaPlugin;
+
+export default mochaPlugin satisfies ESLint.Plugin;


### PR DESCRIPTION
- Define the mocha plugin with a meaningful shape, including supported config keys. Use satisfies operator to ensure the final plugin adheres to type `ESLint.Plugin`. This will fix type errors when users attempt to use `mochaPlugin.configs.recommended` (and `.all`) in type checked eslint configs.
- Update test since `rules` is no longer possibly undefined.

Fixes #392