### PR TITLE
Fix handling of suites in no-synchronous-tests

### DIFF
--- a/source/rules/no-synchronous-tests.test.ts
+++ b/source/rules/no-synchronous-tests.test.ts
@@ -82,6 +82,11 @@ ruleTester.run('no-synchronous-tests', noSynchronousTestsRule, {
         {
             code: 'it("", function (done) { done(); });',
             options: [{}]
+        },
+        {
+            code:
+                'describe("Some tests", function () {it("should do something", async function () {await Promise.resolve(true);});});',
+            options: [{}]
         }
     ],
 

--- a/source/rules/no-synchronous-tests.ts
+++ b/source/rules/no-synchronous-tests.ts
@@ -72,9 +72,13 @@ export const noSynchronousTestsRule: Readonly<Rule.RuleModule> = {
             ? asyncMethods
             // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- we have json schema validation in place so we know this is a string
             : options.allowed as unknown as string[];
+        const asyncTypes = new Set(['testCase', 'hook']);
 
         return createMochaVisitors(context, {
             anyTestEntityCallback(visitorContext) {
+                if (!asyncTypes.has(visitorContext.type)) {
+                    return;
+                }
                 // For each allowed async test method, check if it is used in the test
                 const testAsyncMethods = allowedAsyncMethods.map((
                     method


### PR DESCRIPTION
The `no-synchronous-tests` rule should apply to tests and hooks, not suites.

This PR fixes the issue by checking the type of the context when visiting it within the rule.

Fixes #399