### PR TITLE
Syntax highlighting for return in no-synchronous-tests-return

### DIFF
--- a/docs/rules/no-synchronous-tests.md
+++ b/docs/rules/no-synchronous-tests.md
@@ -12,7 +12,7 @@ By default, this rule looks for the presence of one of:
 
 - An asynchronous callback.
 - An async function provided to a mocha test statement.
-- A return statement within the function body of any mocha test statement.
+- A `return` statement within the function body of any mocha test statement.
 
 If none of these three alternatives is used in a test method, the rule will raise a warning.
 


### PR DESCRIPTION
Make the documentation for the no-synchronous-tests-return slightly easier to read by highlighting the "return" keyword as a syntactic element, as is done, e.g., in no-return-from-async's documentation.