### PR TITLE
Guard the no-async-suite fixer against await expressions

### DIFF
--- a/source/rules/no-async-suite.test.ts
+++ b/source/rules/no-async-suite.test.ts
@@ -163,13 +163,17 @@ ruleTester.run('no-async-suite', noAsyncSuiteRule, {
 
 describe('no-async-suite helpers', function () {
     it('containsDirectAwait() returns false for non-await expressions', function () {
-        const result = containsDirectAwait({ type: 'Identifier' } as never);
+        const sourceCode = asSourceCode({
+            visitorKeys: {}
+        });
+        const result = containsDirectAwait(sourceCode, { type: 'Identifier' } as never);
 
         assert.strictEqual(result, false);
     });
 
     it('fixAsyncFunction() returns null when the async token cannot be resolved', function () {
         const sourceCode = asSourceCode({
+            visitorKeys: {},
             getFirstTokens() {
                 return [];
             }

--- a/source/rules/no-async-suite.test.ts
+++ b/source/rules/no-async-suite.test.ts
@@ -92,6 +92,28 @@ ruleTester.run('no-async-suite', noAsyncSuiteRule, {
             }]
         },
         {
+            code: 'describe("hello", async () => {const bar = await foo;})',
+            // Do not offer a fix when await appears inside a declaration
+            output: null,
+            languageOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: 'Unexpected async function in describe()',
+                line: 1,
+                column: 19
+            }]
+        },
+        {
+            code: 'describe("hello", async () => {if (ready) {await foo;}})',
+            // Do not offer a fix when await appears inside control flow
+            output: null,
+            languageOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: 'Unexpected async function in describe()',
+                line: 1,
+                column: 19
+            }]
+        },
+        {
             code: 'describe("hello", async () => {async function bar() {await foo;}})',
             // Do offer a fix despite a nested async function containing await
             output: 'describe("hello", () => {async function bar() {await foo;}})',

--- a/source/rules/no-async-suite.ts
+++ b/source/rules/no-async-suite.ts
@@ -4,40 +4,66 @@ import { createMochaVisitors } from '../ast/mocha-visitors.js';
 import { type AnyFunction, isFunction } from '../ast/node-types.js';
 
 type TraversableNode = Except<Rule.Node, 'parent'>;
+type ContainsDirectAwait = (node: AnyFunction['body'] | TraversableNode) => boolean;
 
 function isNode(value: unknown): value is TraversableNode {
     return typeof value === 'object' && value !== null && 'type' in value;
 }
 
-function getChildNodes(node: TraversableNode): readonly unknown[] {
-    const childNodes: unknown[] = [];
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
 
-    for (const [key, value] of Object.entries(node) as readonly [string, unknown][]) {
-        if (key !== 'parent') {
-            childNodes.push(value);
+function containsDirectAwaitInValue(
+    containsAwait: ContainsDirectAwait,
+    value: unknown
+): boolean {
+    return isNode(value) && containsAwait(value);
+}
+
+function containsDirectAwaitInValues(
+    containsAwait: ContainsDirectAwait,
+    values: readonly unknown[]
+): boolean {
+    for (const value of values) {
+        if (containsDirectAwaitInValue(containsAwait, value)) {
+            return true;
         }
     }
 
-    return childNodes;
+    return false;
 }
 
-export function containsDirectAwait(node: AnyFunction['body'] | TraversableNode): boolean {
+function containsDirectAwaitInChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    containsAwait: ContainsDirectAwait
+): boolean {
+    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            if (containsDirectAwaitInValues(containsAwait, value)) {
+                return true;
+            }
+        } else if (containsDirectAwaitInValue(containsAwait, value)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function containsDirectAwait(
+    sourceCode: Readonly<SourceCode>,
+    node: AnyFunction['body'] | TraversableNode
+): boolean {
     if (node.type === 'AwaitExpression') {
         return true;
     }
 
-    if (isFunction(node)) {
-        return false;
-    }
-
-    const childNodes = getChildNodes(node);
-
-    return childNodes.some((value) => {
-        const containsAwaitInValue = (childValue: unknown): boolean => {
-            return isNode(childValue) && containsDirectAwait(childValue);
-        };
-
-        return Array.isArray(value) ? value.some(containsAwaitInValue) : containsAwaitInValue(value);
+    return !isFunction(node) && containsDirectAwaitInChildNodes(sourceCode, node, (childNode) => {
+        return containsDirectAwait(sourceCode, childNode);
     });
 }
 
@@ -52,7 +78,7 @@ export function fixAsyncFunction(
     fixer: Rule.RuleFixer,
     fn: Readonly<AnyFunction>
 ): Readonly<Rule.Fix | null> {
-    if (!containsDirectAwait(fn.body)) {
+    if (!containsDirectAwait(sourceCode, fn.body)) {
         // Remove the "async" token and all the whitespace before "function":
         const amountOfTokens = 2;
         const [asyncToken, functionToken] = sourceCode.getFirstTokens(fn, amountOfTokens);

--- a/source/rules/no-async-suite.ts
+++ b/source/rules/no-async-suite.ts
@@ -1,17 +1,44 @@
 import type { Rule, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type AnyFunction, isBlockStatement } from '../ast/node-types.js';
+import { type AnyFunction, isFunction } from '../ast/node-types.js';
 
-export function containsDirectAwait(node: AnyFunction['body']): boolean {
+type TraversableNode = Except<Rule.Node, 'parent'>;
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function getChildNodes(node: TraversableNode): readonly unknown[] {
+    const childNodes: unknown[] = [];
+
+    for (const [key, value] of Object.entries(node) as readonly [string, unknown][]) {
+        if (key !== 'parent') {
+            childNodes.push(value);
+        }
+    }
+
+    return childNodes;
+}
+
+export function containsDirectAwait(node: AnyFunction['body'] | TraversableNode): boolean {
     if (node.type === 'AwaitExpression') {
         return true;
     }
-    if (isBlockStatement(node)) {
-        return node.body.some((statement) => {
-            return statement.type === 'ExpressionStatement' ? containsDirectAwait(statement.expression) : false;
-        });
+
+    if (isFunction(node)) {
+        return false;
     }
-    return false;
+
+    const childNodes = getChildNodes(node);
+
+    return childNodes.some((value) => {
+        const containsAwaitInValue = (childValue: unknown): boolean => {
+            return isNode(childValue) && containsDirectAwait(childValue);
+        };
+
+        return Array.isArray(value) ? value.some(containsAwaitInValue) : containsAwaitInValue(value);
+    });
 }
 
 function isAsyncFunction(node: Rule.Node): node is AnyFunction {


### PR DESCRIPTION
## Summary
- make the fixer skip any suite callback that still contains an await expression
- continue allowing fixes when awaits are only inside nested functions
- reduce the helper overhead so unit coverage stays at 100% without the heavier traversal approach

## Testing
- npm run eslint -- source/rules/no-async-suite.ts source/rules/no-async-suite.test.ts
- npm run test:unit -- --grep no-async-suite
- npm run test:unit:with-coverage
