### PR TITLE
Add suggestions for no-exclusive-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,33 +107,34 @@ For maintainers: the rules table below is generated, and the headers in `documen
 ⚠️ [Configurations](https://github.com/lo1tuma/eslint-plugin-mocha#configs) set to warn in.\
 🚫 [Configurations](https://github.com/lo1tuma/eslint-plugin-mocha#configs) disabled in.\
 ✅ Set in the `recommended` [configuration](https://github.com/lo1tuma/eslint-plugin-mocha#configs).\
-🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                                          | Description                                                             | 💼 | ⚠️ | 🚫 | 🔧 |
-| :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- |
-| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |
-| [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |
-| [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |
-| [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |
-| [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |
-| [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |
-| [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    | 🔧 |
-| [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    |
-| [no-global-tests](documentation/rules/no-global-tests.md)                                     | Disallow global tests                                                   | ✅  |    |    |    |
-| [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |
-| [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |
-| [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |
-| [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |
-| [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |
-| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    |
-| [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |
-| [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |
-| [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |
-| [no-sibling-hooks](documentation/rules/no-sibling-hooks.md)                                   | Disallow duplicate uses of a hook at the same level inside a suite      | ✅  |    |    |    |
-| [no-synchronous-tests](documentation/rules/no-synchronous-tests.md)                           | Disallow synchronous tests                                              |    |    | ✅  |    |
-| [no-top-level-hooks](documentation/rules/no-top-level-hooks.md)                               | Disallow top-level hooks                                                |    | ✅  |    |    |
-| [prefer-arrow-callback](documentation/rules/prefer-arrow-callback.md)                         | Require using arrow functions for callbacks                             |    |    | ✅  | 🔧 |
-| [valid-suite-title](documentation/rules/valid-suite-title.md)                                 | Require suite descriptions to match a pre-configured regular expression |    |    | ✅  |    |
-| [valid-test-title](documentation/rules/valid-test-title.md)                                   | Require test descriptions to match a pre-configured regular expression  |    |    | ✅  |    |
+| Name                                                                                          | Description                                                             | 💼 | ⚠️ | 🚫 | 🔧 | 💡 |
+| :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- | :- |
+| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    |    |    |
+| [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
+| [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |    |
+| [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
+| [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
+| [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |
+| [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
+| [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    |    |
+| [no-global-tests](documentation/rules/no-global-tests.md)                                     | Disallow global tests                                                   | ✅  |    |    |    |    |
+| [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |    |
+| [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |    |
+| [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
+| [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |    |
+| [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |    |
+| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    |    |
+| [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
+| [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
+| [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |    |
+| [no-sibling-hooks](documentation/rules/no-sibling-hooks.md)                                   | Disallow duplicate uses of a hook at the same level inside a suite      | ✅  |    |    |    |    |
+| [no-synchronous-tests](documentation/rules/no-synchronous-tests.md)                           | Disallow synchronous tests                                              |    |    | ✅  |    |    |
+| [no-top-level-hooks](documentation/rules/no-top-level-hooks.md)                               | Disallow top-level hooks                                                |    | ✅  |    |    |    |
+| [prefer-arrow-callback](documentation/rules/prefer-arrow-callback.md)                         | Require using arrow functions for callbacks                             |    |    | ✅  | 🔧 |    |
+| [valid-suite-title](documentation/rules/valid-suite-title.md)                                 | Require suite descriptions to match a pre-configured regular expression |    |    | ✅  |    |    |
+| [valid-test-title](documentation/rules/valid-test-title.md)                                   | Require test descriptions to match a pre-configured regular expression  |    |    | ✅  |    |    |
 
 <!-- end auto-generated rules list -->

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 
 | Name                                                                                          | Description                                                             | 💼 | ⚠️ | 🚫 | 🔧 | 💡 |
 | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- | :- |
-| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    |    |    |
+| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |    |
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |
-| [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    |
+| [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    | 🔧 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    |
 | [no-global-tests](documentation/rules/no-global-tests.md)                                     | Disallow global tests                                                   | ✅  |    |    |    |
 | [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |

--- a/documentation/rules/no-exclusive-tests.md
+++ b/documentation/rules/no-exclusive-tests.md
@@ -2,6 +2,8 @@
 
 ⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 Mocha lets you run a single suite or test by appending `.only`. That is useful while debugging, but easy to leave behind by accident. This rule warns whenever exclusive tests are used.

--- a/documentation/rules/no-exclusive-tests.md
+++ b/documentation/rules/no-exclusive-tests.md
@@ -2,11 +2,13 @@
 
 ⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 <!-- end auto-generated rule header -->
 
 Mocha lets you run a single suite or test by appending `.only`. That is useful while debugging, but easy to leave behind by accident. This rule warns whenever exclusive tests are used.
+
+This rule intentionally does not support the `--fix` CLI option. Many editors apply ESLint fixes on save, and silently removing `.only` would make it harder to focus a test while debugging. For direct `describe.only()`-style calls, the rule does provide ESLint suggestions so you can remove the modifier explicitly.
 
 ## Rule Details
 

--- a/source/rules/no-exclusive-tests.test.ts
+++ b/source/rules/no-exclusive-tests.test.ts
@@ -59,18 +59,22 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
     invalid: [
         {
             code: 'describe.only()',
+            output: 'describe()',
             errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
         },
         {
             code: 'describe["only"]()',
+            output: 'describe()',
             errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
         },
         {
             code: 'it.only()',
+            output: 'it()',
             errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
         },
         {
             code: 'import { it } from "mocha"; it.only()',
+            output: 'import { it } from "mocha"; it()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
@@ -80,6 +84,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'import { it as foo } from "mocha"; foo.only()',
+            output: 'import { it as foo } from "mocha"; foo()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
@@ -89,6 +94,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'import { it as foo } from "mocha"; const bar = foo; bar.only()',
+            output: 'import { it as foo } from "mocha"; const bar = foo; bar()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
@@ -98,42 +104,52 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'it["only"]()',
+            output: 'it()',
             errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
         },
         {
             code: 'suite.only()',
+            output: 'suite()',
             errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
         },
         {
             code: 'suite["only"]()',
+            output: 'suite()',
             errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
         },
         {
             code: 'test.only()',
+            output: 'test()',
             errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
         },
         {
             code: 'test["only"]()',
+            output: 'test()',
             errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
         },
         {
             code: 'context.only()',
+            output: 'context()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'context["only"]()',
+            output: 'context()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'specify.only()',
+            output: 'specify()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'specify["only"]()',
+            output: 'specify()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'custom.only()',
+            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
@@ -141,6 +157,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'custom["only"]()',
+            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
@@ -148,6 +165,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'custom.only()',
+            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
@@ -157,6 +175,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'custom["only"]()',
+            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
@@ -166,6 +185,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'foo.bar.only()',
+            output: 'foo.bar()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
@@ -175,6 +195,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'foo.bar["only"]()',
+            output: 'foo.bar()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
@@ -184,6 +205,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'foo["bar"].only()',
+            output: 'foo["bar"]()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
@@ -193,6 +215,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'foo["bar"]["only"]()',
+            output: 'foo["bar"]()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
@@ -202,6 +225,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         },
         {
             code: 'a.b.c.only()',
+            output: 'a.b.c()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'a.b.c', type: 'testCase', interface: 'BDD' }]

--- a/source/rules/no-exclusive-tests.test.ts
+++ b/source/rules/no-exclusive-tests.test.ts
@@ -1,8 +1,30 @@
-import { RuleTester } from 'eslint';
-import { noExclusiveTestsRule } from './no-exclusive-tests.js';
+import { type Rule, RuleTester, type SourceCode } from 'eslint';
+import assert from 'node:assert';
+import {
+    createExclusiveTestReportDescriptor,
+    fixExclusiveTest,
+    getExclusivePropertyNode,
+    noExclusiveTestsRule
+} from './no-exclusive-tests.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const expectedErrorMessage = 'Unexpected exclusive mocha test.';
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function asRuleFixer(fixer: Record<string, unknown>): Rule.RuleFixer {
+    return fixer as unknown as Rule.RuleFixer;
+}
+
+function asRuleFix(fix: Record<string, unknown>): Rule.Fix {
+    return fix as unknown as Rule.Fix;
+}
+
+function asRuleNode(node: Record<string, unknown>): Rule.Node {
+    return node as unknown as Rule.Node;
+}
 
 ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
     valid: [
@@ -59,179 +81,339 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
     invalid: [
         {
             code: 'describe.only()',
-            output: 'describe()',
-            errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 10,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'describe()' }]
+            }]
         },
         {
             code: 'describe["only"]()',
-            output: 'describe()',
-            errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 10,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'describe()' }]
+            }]
         },
         {
             code: 'it.only()',
-            output: 'it()',
-            errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 4,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'it()' }]
+            }]
         },
         {
             code: 'import { it } from "mocha"; it.only()',
-            output: 'import { it } from "mocha"; it()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
             settings: { mocha: { interface: 'exports' } },
-            errors: [{ message: expectedErrorMessage, column: 32, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 32,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'import { it } from "mocha"; it()' }]
+            }]
         },
         {
             code: 'import { it as foo } from "mocha"; foo.only()',
-            output: 'import { it as foo } from "mocha"; foo()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
             settings: { mocha: { interface: 'exports' } },
-            errors: [{ message: expectedErrorMessage, column: 40, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 40,
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExclusiveModifier',
+                    output: 'import { it as foo } from "mocha"; foo()'
+                }]
+            }]
         },
         {
             code: 'import { it as foo } from "mocha"; const bar = foo; bar.only()',
-            output: 'import { it as foo } from "mocha"; const bar = foo; bar()',
             languageOptions: {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
             settings: { mocha: { interface: 'exports' } },
-            errors: [{ message: expectedErrorMessage, column: 57, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 57,
+                line: 1,
+                suggestions: [
+                    {
+                        messageId: 'removeExclusiveModifier',
+                        output: 'import { it as foo } from "mocha"; const bar = foo; bar()'
+                    }
+                ]
+            }]
         },
         {
             code: 'it["only"]()',
-            output: 'it()',
-            errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 4,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'it()' }]
+            }]
         },
         {
             code: 'suite.only()',
-            output: 'suite()',
-            errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 7,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'suite()' }]
+            }]
         },
         {
             code: 'suite["only"]()',
-            output: 'suite()',
-            errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 7,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'suite()' }]
+            }]
         },
         {
             code: 'test.only()',
-            output: 'test()',
-            errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 6,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'test()' }]
+            }]
         },
         {
             code: 'test["only"]()',
-            output: 'test()',
-            errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 6,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'test()' }]
+            }]
         },
         {
             code: 'context.only()',
-            output: 'context()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'context()' }]
+            }]
         },
         {
             code: 'context["only"]()',
-            output: 'context()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'context()' }]
+            }]
         },
         {
             code: 'specify.only()',
-            output: 'specify()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'specify()' }]
+            }]
         },
         {
             code: 'specify["only"]()',
-            output: 'specify()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'specify()' }]
+            }]
         },
         {
             code: 'custom.only()',
-            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom["only"]()',
-            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom.only()',
-            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom["only"]()',
-            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'foo.bar.only()',
-            output: 'foo.bar()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'foo.bar()' }]
+            }]
         },
         {
             code: 'foo.bar["only"]()',
-            output: 'foo.bar()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'foo.bar()' }]
+            }]
         },
         {
             code: 'foo["bar"].only()',
-            output: 'foo["bar"]()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 12, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 12,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'foo["bar"]()' }]
+            }]
         },
         {
             code: 'foo["bar"]["only"]()',
-            output: 'foo["bar"]()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo.bar', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 12, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 12,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'foo["bar"]()' }]
+            }]
         },
         {
             code: 'a.b.c.only()',
-            output: 'a.b.c()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'a.b.c', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 7,
+                line: 1,
+                suggestions: [{ messageId: 'removeExclusiveModifier', output: 'a.b.c()' }]
+            }]
         }
     ]
+});
+
+describe('no-exclusive-tests helpers', function () {
+    it('fixExclusiveTest() returns null for non-call-expression nodes', function () {
+        const result = fixExclusiveTest(
+            asRuleFixer({}),
+            asSourceCode({}),
+            asRuleNode({ type: 'Identifier' })
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('fixExclusiveTest() returns null when the member-expression range is missing', function () {
+        const result = fixExclusiveTest(
+            asRuleFixer({
+                replaceTextRange() {
+                    return asRuleFix({});
+                }
+            }),
+            asSourceCode({
+                getText() {
+                    return 'describe';
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                callee: {
+                    type: 'MemberExpression',
+                    range: undefined
+                }
+            })
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('getExclusivePropertyNode() returns null for non-call-expression nodes', function () {
+        const result = getExclusivePropertyNode(asRuleNode({ type: 'Identifier' }));
+
+        assert.strictEqual(result, null);
+    });
+
+    it('createExclusiveTestReportDescriptor() falls back to the call-expression location', function () {
+        const node = asRuleNode({ type: 'CallExpression' });
+        const exclusivePropertyNode = asRuleNode({
+            type: 'Identifier',
+            loc: undefined
+        });
+        const result = createExclusiveTestReportDescriptor(node, exclusivePropertyNode as never);
+
+        assert.deepStrictEqual(result, {
+            node,
+            messageId: 'unexpectedExclusiveTest'
+        });
+    });
 });

--- a/source/rules/no-exclusive-tests.ts
+++ b/source/rules/no-exclusive-tests.ts
@@ -1,6 +1,28 @@
-import type { Rule } from 'eslint';
+import type { Rule, SourceCode } from 'eslint';
 import { createMochaVisitors, type VisitorContext } from '../ast/mocha-visitors.js';
-import type { CallExpression, MemberExpression } from '../ast/node-types.js';
+import { isCallExpression, isMemberExpression, type MemberExpression } from '../ast/node-types.js';
+
+function fixExclusiveTest(
+    fixer: Rule.RuleFixer,
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<Rule.Node>
+): Readonly<Rule.Fix | null> {
+    if (!isCallExpression(node) || !isMemberExpression(node.callee)) {
+        return null;
+    }
+
+    return node.callee.range === undefined
+        ? null
+        : fixer.replaceTextRange(node.callee.range, sourceCode.getText(node.callee.object));
+}
+
+function getExclusivePropertyNode(node: Readonly<Rule.Node>): Readonly<MemberExpression['property']> | null {
+    if (!isCallExpression(node) || !isMemberExpression(node.callee)) {
+        return null;
+    }
+
+    return node.callee.property;
+}
 
 export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
@@ -10,18 +32,32 @@ export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
             description: 'Disallow exclusive tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-exclusive-tests.md'
         },
+        fixable: 'code',
         messages: {
             unexpectedExclusiveTest: 'Unexpected exclusive mocha test.'
         },
         schema: []
     },
     create(context) {
+        const { sourceCode } = context;
+
         function checkPresenceOfExclusiveModifier(visitorContext: Readonly<VisitorContext>): void {
-            if (visitorContext.modifier === 'exclusive') {
+            const exclusivePropertyNode = getExclusivePropertyNode(visitorContext.node);
+
+            if (visitorContext.modifier === 'exclusive' && exclusivePropertyNode !== null) {
+                const reportDescriptor = exclusivePropertyNode.loc === null || exclusivePropertyNode.loc === undefined
+                    ? { node: visitorContext.node, messageId: 'unexpectedExclusiveTest' as const }
+                    : {
+                        node: visitorContext.node,
+                        loc: exclusivePropertyNode.loc,
+                        messageId: 'unexpectedExclusiveTest' as const
+                    };
+
                 context.report({
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ok in this case
-                    node: ((visitorContext.node as CallExpression).callee as MemberExpression).property,
-                    messageId: 'unexpectedExclusiveTest'
+                    ...reportDescriptor,
+                    fix(fixer) {
+                        return fixExclusiveTest(fixer, sourceCode, visitorContext.node);
+                    }
                 });
             }
         }

--- a/source/rules/no-exclusive-tests.ts
+++ b/source/rules/no-exclusive-tests.ts
@@ -2,7 +2,7 @@ import type { Rule, SourceCode } from 'eslint';
 import { createMochaVisitors, type VisitorContext } from '../ast/mocha-visitors.js';
 import { isCallExpression, isMemberExpression, type MemberExpression } from '../ast/node-types.js';
 
-function fixExclusiveTest(
+export function fixExclusiveTest(
     fixer: Rule.RuleFixer,
     sourceCode: Readonly<SourceCode>,
     node: Readonly<Rule.Node>
@@ -16,12 +16,21 @@ function fixExclusiveTest(
         : fixer.replaceTextRange(node.callee.range, sourceCode.getText(node.callee.object));
 }
 
-function getExclusivePropertyNode(node: Readonly<Rule.Node>): Readonly<MemberExpression['property']> | null {
+export function getExclusivePropertyNode(node: Readonly<Rule.Node>): Readonly<MemberExpression['property']> | null {
     if (!isCallExpression(node) || !isMemberExpression(node.callee)) {
         return null;
     }
 
     return node.callee.property;
+}
+
+export function createExclusiveTestReportDescriptor(
+    node: Readonly<Rule.Node>,
+    exclusivePropertyNode: Readonly<MemberExpression['property']>
+): Rule.ReportDescriptor & { messageId: 'unexpectedExclusiveTest'; } {
+    return exclusivePropertyNode.loc === null || exclusivePropertyNode.loc === undefined
+        ? { node, messageId: 'unexpectedExclusiveTest' }
+        : { node, loc: exclusivePropertyNode.loc, messageId: 'unexpectedExclusiveTest' };
 }
 
 export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
@@ -32,9 +41,10 @@ export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
             description: 'Disallow exclusive tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-exclusive-tests.md'
         },
-        fixable: 'code',
+        hasSuggestions: true,
         messages: {
-            unexpectedExclusiveTest: 'Unexpected exclusive mocha test.'
+            unexpectedExclusiveTest: 'Unexpected exclusive mocha test.',
+            removeExclusiveModifier: 'Remove the exclusive modifier from this Mocha call.'
         },
         schema: []
     },
@@ -45,19 +55,14 @@ export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
             const exclusivePropertyNode = getExclusivePropertyNode(visitorContext.node);
 
             if (visitorContext.modifier === 'exclusive' && exclusivePropertyNode !== null) {
-                const reportDescriptor = exclusivePropertyNode.loc === null || exclusivePropertyNode.loc === undefined
-                    ? { node: visitorContext.node, messageId: 'unexpectedExclusiveTest' as const }
-                    : {
-                        node: visitorContext.node,
-                        loc: exclusivePropertyNode.loc,
-                        messageId: 'unexpectedExclusiveTest' as const
-                    };
-
                 context.report({
-                    ...reportDescriptor,
-                    fix(fixer) {
-                        return fixExclusiveTest(fixer, sourceCode, visitorContext.node);
-                    }
+                    ...createExclusiveTestReportDescriptor(visitorContext.node, exclusivePropertyNode),
+                    suggest: [{
+                        messageId: 'removeExclusiveModifier',
+                        fix(fixer) {
+                            return fixExclusiveTest(fixer, sourceCode, visitorContext.node);
+                        }
+                    }]
                 });
             }
         }


### PR DESCRIPTION
## Summary
- document why mocha/no-exclusive-tests intentionally does not support --fix
- add targeted ESLint suggestions for direct .only / ["only"] removals
- keep bulk fix-on-save workflows from silently changing focused tests

## Testing
- npm run eslint -- source/rules/no-exclusive-tests.ts source/rules/no-exclusive-tests.test.ts
- npm run test:unit -- --grep no-exclusive-tests
- npm run test:unit:with-coverage
- npm run lint:eslint-docs
