### PR TITLE
Add suggestions for no-pending-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
 | [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |    |
 | [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |    |
-| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    | 🔧 |    |
+| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    | 💡 |
 | [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
 | [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
 | [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |    |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
 | [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |    |
 | [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |    |
-| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    |    |
+| [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    | 🔧 |    |
 | [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
 | [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
 | [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |    |

--- a/documentation/rules/no-pending-tests.md
+++ b/documentation/rules/no-pending-tests.md
@@ -2,6 +2,8 @@
 
 ⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 Mocha supports pending tests. These are tests with no implementation, such as `it('unimplemented test');`, or tests that are explicitly skipped. This rule lets you warn or error on those cases.

--- a/documentation/rules/no-pending-tests.md
+++ b/documentation/rules/no-pending-tests.md
@@ -2,11 +2,13 @@
 
 ⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 <!-- end auto-generated rule header -->
 
 Mocha supports pending tests. These are tests with no implementation, such as `it('unimplemented test');`, or tests that are explicitly skipped. This rule lets you warn or error on those cases.
+
+This rule intentionally does not support the `--fix` CLI option. Many editors apply ESLint fixes on save, and silently enabling skipped tests again would be a bad default while debugging. For direct `.skip` and `xdescribe()`-style calls, the rule does provide ESLint suggestions so you can remove the pending modifier explicitly.
 
 ## Rule Details
 

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -47,78 +47,97 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
     invalid: [
         {
             code: 'it("is pending")',
+            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'test("is pending")',
+            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'specify("is pending")',
+            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'describe.skip()',
+            output: 'describe()',
             errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
         },
         {
             code: 'describe["skip"]()',
+            output: 'describe()',
             errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
         },
         {
             code: 'xdescribe()',
+            output: 'describe()',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'it.skip()',
+            output: 'it()',
             errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
         },
         {
             code: 'it["skip"]()',
+            output: 'it()',
             errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
         },
         {
             code: 'xit()',
+            output: 'it()',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'suite.skip()',
+            output: 'suite()',
             errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
         },
         {
             code: 'suite["skip"]()',
+            output: 'suite()',
             errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
         },
         {
             code: 'test.skip()',
+            output: 'test()',
             errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
         },
         {
             code: 'test["skip"]()',
+            output: 'test()',
             errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
         },
         {
             code: 'context.skip()',
+            output: 'context()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'context["skip"]()',
+            output: 'context()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'xcontext()',
+            output: 'context()',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'specify.skip()',
+            output: 'specify()',
             errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
         },
         {
             code: 'xspecify()',
+            output: 'specify()',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'custom.skip()',
+            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
@@ -126,6 +145,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'custom["skip"]()',
+            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
@@ -133,6 +153,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'xcustom()',
+            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
@@ -140,6 +161,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'custom.skip()',
+            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
@@ -149,6 +171,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'custom["skip"]()',
+            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
@@ -158,6 +181,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'xcustom()',
+            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
@@ -167,6 +191,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         },
         {
             code: 'var dynamicOnly = "skip"; suite[dynamicOnly]()',
+            output: null,
             errors: [{ message: expectedErrorMessage, column: 33, line: 1 }]
         }
     ]

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -1,6 +1,12 @@
-import { type Rule, RuleTester } from 'eslint';
+import { type Rule, RuleTester, type SourceCode } from 'eslint';
 import assert from 'node:assert';
-import { checkPendingSuite, checkPendingTestCase, noPendingTestsRule } from './no-pending-tests.js';
+import {
+    checkPendingSuite,
+    checkPendingTestCase,
+    fixPendingMemberExpression,
+    isPendingMemberExpression,
+    noPendingTestsRule
+} from './no-pending-tests.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const expectedErrorMessage = 'Unexpected pending mocha test.';
@@ -11,6 +17,18 @@ function asRuleContext(ruleContext: Record<string, unknown>): Rule.RuleContext {
 
 function asRuleNode(node: Record<string, unknown>): Rule.Node {
     return node as unknown as Rule.Node;
+}
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function asRuleFixer(fixer: Record<string, unknown>): Rule.RuleFixer {
+    return fixer as unknown as Rule.RuleFixer;
+}
+
+function asRuleFix(fix: Record<string, unknown>): Rule.Fix {
+    return fix as unknown as Rule.Fix;
 }
 
 ruleTester.run('no-pending-tests', noPendingTestsRule, {
@@ -47,151 +65,231 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
     invalid: [
         {
             code: 'it("is pending")',
-            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'test("is pending")',
-            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'specify("is pending")',
-            output: null,
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
             code: 'describe.skip()',
-            output: 'describe()',
-            errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 10,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'describe()' }]
+            }]
         },
         {
             code: 'describe["skip"]()',
-            output: 'describe()',
-            errors: [{ message: expectedErrorMessage, column: 10, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 10,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'describe()' }]
+            }]
         },
         {
             code: 'xdescribe()',
-            output: 'describe()',
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'describe()' }]
+            }]
         },
         {
             code: 'it.skip()',
-            output: 'it()',
-            errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 4,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'it()' }]
+            }]
         },
         {
             code: 'it["skip"]()',
-            output: 'it()',
-            errors: [{ message: expectedErrorMessage, column: 4, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 4,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'it()' }]
+            }]
         },
         {
             code: 'xit()',
-            output: 'it()',
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'it()' }]
+            }]
         },
         {
             code: 'suite.skip()',
-            output: 'suite()',
-            errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 7,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'suite()' }]
+            }]
         },
         {
             code: 'suite["skip"]()',
-            output: 'suite()',
-            errors: [{ message: expectedErrorMessage, column: 7, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 7,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'suite()' }]
+            }]
         },
         {
             code: 'test.skip()',
-            output: 'test()',
-            errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 6,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'test()' }]
+            }]
         },
         {
             code: 'test["skip"]()',
-            output: 'test()',
-            errors: [{ message: expectedErrorMessage, column: 6, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 6,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'test()' }]
+            }]
         },
         {
             code: 'context.skip()',
-            output: 'context()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'context()' }]
+            }]
         },
         {
             code: 'context["skip"]()',
-            output: 'context()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'context()' }]
+            }]
         },
         {
             code: 'xcontext()',
-            output: 'context()',
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'context()' }]
+            }]
         },
         {
             code: 'specify.skip()',
-            output: 'specify()',
-            errors: [{ message: expectedErrorMessage, column: 9, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 9,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'specify()' }]
+            }]
         },
         {
             code: 'xspecify()',
-            output: 'specify()',
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'specify()' }]
+            }]
         },
         {
             code: 'custom.skip()',
-            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom["skip"]()',
-            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'xcustom()',
-            output: 'custom()',
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             },
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom.skip()',
-            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'custom["skip"]()',
-            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 8, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 8,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'xcustom()',
-            output: 'custom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+            errors: [{
+                message: expectedErrorMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
         },
         {
             code: 'var dynamicOnly = "skip"; suite[dynamicOnly]()',
-            output: null,
             errors: [{ message: expectedErrorMessage, column: 33, line: 1 }]
         }
     ]
@@ -232,5 +330,35 @@ describe('no-pending-tests helpers', function () {
         );
 
         assert.deepStrictEqual(reports, []);
+    });
+
+    it('isPendingMemberExpression() returns false for non-member-expression callees', function () {
+        const result = isPendingMemberExpression({ type: 'Identifier', name: 'xdescribe' } as never);
+
+        assert.strictEqual(result, false);
+    });
+
+    it('fixPendingMemberExpression() returns null when the member-expression range is missing', function () {
+        const result = fixPendingMemberExpression(
+            asRuleFixer({
+                replaceTextRange() {
+                    return asRuleFix({});
+                }
+            }),
+            asSourceCode({
+                getText() {
+                    return 'describe';
+                }
+            }),
+            {
+                type: 'MemberExpression',
+                computed: false,
+                object: { type: 'Identifier', name: 'describe' },
+                property: { type: 'Identifier', name: 'skip' },
+                range: undefined
+            } as never
+        );
+
+        assert.strictEqual(result, null);
     });
 });

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -38,7 +38,7 @@ function isLiteralSkipProperty(property: Readonly<MemberExpression['property']>)
     return isLiteral(property) && property.value === 'skip';
 }
 
-function isPendingMemberExpression(
+export function isPendingMemberExpression(
     callee: Readonly<CallExpression['callee']>
 ): callee is Extract<CallExpression['callee'], { type: 'MemberExpression'; }> {
     if (!isMemberExpression(callee)) {
@@ -51,7 +51,7 @@ function isPendingMemberExpression(
         (callee.computed && isLiteralSkipProperty(property));
 }
 
-function fixPendingMemberExpression(
+export function fixPendingMemberExpression(
     fixer: Rule.RuleFixer,
     sourceCode: Readonly<SourceCode>,
     callee: Readonly<CallExpression['callee']>
@@ -73,15 +73,26 @@ function fixPendingTest(
     return fixPendingIdentifier(fixer, node.callee) ?? fixPendingMemberExpression(fixer, sourceCode, node.callee);
 }
 
+function canSuggestPendingTest(node: Readonly<CallExpression>): boolean {
+    return (isIdentifier(node.callee) && node.callee.name.startsWith('x')) || isPendingMemberExpression(node.callee);
+}
+
 export function reportSkipped(context: Readonly<Rule.RuleContext>, node: CallExpression): void {
     const nodeToReport = node.callee.type === 'MemberExpression' ? node.callee.property : node.callee;
 
     context.report({
         node: nodeToReport,
         messageId: 'unexpectedPendingTest',
-        fix(fixer) {
-            return fixPendingTest(fixer, context.sourceCode, node);
-        }
+        ...(canSuggestPendingTest(node)
+            ? {
+                suggest: [{
+                    messageId: 'removePendingModifier' as const,
+                    fix(fixer: Rule.RuleFixer) {
+                        return fixPendingTest(fixer, context.sourceCode, node);
+                    }
+                }]
+            }
+            : {})
     });
 }
 
@@ -124,9 +135,10 @@ export const noPendingTestsRule: Rule.RuleModule = {
             description: 'Disallow pending tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-pending-tests.md'
         },
-        fixable: 'code',
+        hasSuggestions: true,
         messages: {
-            unexpectedPendingTest: 'Unexpected pending mocha test.'
+            unexpectedPendingTest: 'Unexpected pending mocha test.',
+            removePendingModifier: 'Remove the pending modifier from this Mocha call.'
         },
         schema: []
     },

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -1,6 +1,13 @@
-import type { Rule } from 'eslint';
+import type { Rule, SourceCode } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import {
+    type CallExpression,
+    isCallExpression,
+    isIdentifier,
+    isLiteral,
+    isMemberExpression,
+    type MemberExpression
+} from '../ast/node-types.js';
 
 type PendingVisitorContext = {
     readonly node: Rule.Node;
@@ -12,12 +19,69 @@ export function isCallbackMissing(node: CallExpression): boolean {
     return firstArgument !== undefined && firstArgument.type === 'Literal' && node.arguments.length === 1;
 }
 
+function fixPendingIdentifier(
+    fixer: Rule.RuleFixer,
+    callee: Readonly<CallExpression['callee']>
+): Readonly<Rule.Fix | null> {
+    if (!isIdentifier(callee) || !callee.name.startsWith('x')) {
+        return null;
+    }
+
+    return fixer.replaceText(callee, callee.name.slice(1));
+}
+
+function isNamedSkipProperty(property: Readonly<MemberExpression['property']>): boolean {
+    return isIdentifier(property) && property.name === 'skip';
+}
+
+function isLiteralSkipProperty(property: Readonly<MemberExpression['property']>): boolean {
+    return isLiteral(property) && property.value === 'skip';
+}
+
+function isPendingMemberExpression(
+    callee: Readonly<CallExpression['callee']>
+): callee is Extract<CallExpression['callee'], { type: 'MemberExpression'; }> {
+    if (!isMemberExpression(callee)) {
+        return false;
+    }
+
+    const { property } = callee;
+
+    return (!callee.computed && isNamedSkipProperty(property)) ||
+        (callee.computed && isLiteralSkipProperty(property));
+}
+
+function fixPendingMemberExpression(
+    fixer: Rule.RuleFixer,
+    sourceCode: Readonly<SourceCode>,
+    callee: Readonly<CallExpression['callee']>
+): Readonly<Rule.Fix | null> {
+    if (!isPendingMemberExpression(callee) || callee.range === undefined) {
+        return null;
+    }
+
+    const { object, range } = callee;
+
+    return fixer.replaceTextRange(range, sourceCode.getText(object));
+}
+
+function fixPendingTest(
+    fixer: Rule.RuleFixer,
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<CallExpression>
+): Readonly<Rule.Fix | null> {
+    return fixPendingIdentifier(fixer, node.callee) ?? fixPendingMemberExpression(fixer, sourceCode, node.callee);
+}
+
 export function reportSkipped(context: Readonly<Rule.RuleContext>, node: CallExpression): void {
     const nodeToReport = node.callee.type === 'MemberExpression' ? node.callee.property : node.callee;
 
     context.report({
         node: nodeToReport,
-        messageId: 'unexpectedPendingTest'
+        messageId: 'unexpectedPendingTest',
+        fix(fixer) {
+            return fixPendingTest(fixer, context.sourceCode, node);
+        }
     });
 }
 
@@ -60,6 +124,7 @@ export const noPendingTestsRule: Rule.RuleModule = {
             description: 'Disallow pending tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-pending-tests.md'
         },
+        fixable: 'code',
         messages: {
             unexpectedPendingTest: 'Unexpected pending mocha test.'
         },


### PR DESCRIPTION
## Summary
- document why mocha/no-pending-tests intentionally does not support --fix
- add targeted ESLint suggestions for direct .skip / ["skip"] / xdescribe-style removals
- keep callback-missing and dynamic computed cases diagnostic-only

## Testing
- npm run eslint -- source/rules/no-pending-tests.ts source/rules/no-pending-tests.test.ts
- npm run test:unit -- --grep no-pending-tests
- npm run test:unit:with-coverage
- npm run lint:eslint-docs
