### PR TITLE
Add an autofix for consistent-interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 
 | Name                                                                                          | Description                                                             | 💼 | ⚠️ | 🚫 | 🔧 |
 | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- |
-| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    |    |
+| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |

--- a/documentation/rules/consistent-interface.md
+++ b/documentation/rules/consistent-interface.md
@@ -2,6 +2,8 @@
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 Mocha has several interfaces such as `BDD`, `TDD`, `Exports`, `QUnit` etc. Usually Mocha injects the variables and functions of the selected interface into the global scope. When using the `Exports` interface, named imports from `mocha` are used instead. This rule enforces a consistent `BDD` or `TDD` interface for imported Mocha interface methods, and it also reports imported Mocha interface methods when `settings.mocha.interface` is configured for globals.
@@ -25,6 +27,8 @@ where:
 With `settings.mocha.interface: "exports"`, this rule enforces that imported Mocha interface methods all belong to the configured `BDD` or `TDD` interface.
 
 With `settings.mocha.interface: "BDD"` or `settings.mocha.interface: "TDD"`, this rule reports named imports of Mocha interface methods from `mocha`, because those imports indicate `exports`-style usage and can prevent other rules from recognizing Mocha calls.
+
+The autofix is intentionally limited to direct named imports such as `import { describe } from 'mocha'`. Aliased imports and mixed default imports are still reported, but they are left for manual cleanup.
 
 ## When Not To Use It
 

--- a/source/rules/consistent-interface.test.ts
+++ b/source/rules/consistent-interface.test.ts
@@ -1,7 +1,27 @@
-import { RuleTester } from 'eslint';
-import { consistentInterfaceRule } from './consistent-interface.js';
+import { type Rule, RuleTester, type Scope, type SourceCode } from 'eslint';
+import assert from 'node:assert';
+import {
+    consistentInterfaceRule,
+    createUnexpectedImportDescriptor,
+    fixImportSpecifier,
+    getImportedName,
+    getImportSpecifierRemovalRange,
+    getMochaImportBinding,
+    getMochaModuleScope,
+    removeFullImportDeclaration,
+    reportUnexpectedImportBinding,
+    reportUnexpectedImportBindingsInModule
+} from './consistent-interface.js';
 
 const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2020, sourceType: 'module' } });
+
+function asRuleContext(ruleContext: Record<string, unknown>): Rule.RuleContext {
+    return ruleContext as unknown as Rule.RuleContext;
+}
+
+function asScopeVariable(variable: Record<string, unknown>): Scope.Variable {
+    return variable as unknown as Scope.Variable;
+}
 
 ruleTester.run('consistent-interface', consistentInterfaceRule, {
     valid: [
@@ -41,7 +61,7 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             settings: { mocha: { interface: 'exports' } }
         },
         {
-            code: "import {run} from 'mocha'; run();",
+            code: 'import {run} from "mocha"; run();',
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'BDD' } }
         }
@@ -90,45 +110,360 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             code: `import {describe, it} from 'mocha'; describe('foo', () => {
                 it('bar', () => {});
             });`,
+            output: `describe('foo', () => {
+                it('bar', () => {});
+            });`,
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { line: 1, column: 37, message: 'Unexpected use of exports interface instead of global BDD' },
-                { line: 2, column: 17, message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of exports interface instead of global BDD' },
+                { message: 'Unexpected use of exports interface instead of global BDD' }
             ]
         },
         {
             code: `import {suite, test} from 'mocha'; suite('foo', () => {
                 test('bar', () => {});
             });`,
+            output: `suite('foo', () => {
+                test('bar', () => {});
+            });`,
             options: [{ interface: 'TDD' }],
             settings: { mocha: { interface: 'TDD' } },
             errors: [
-                { line: 1, column: 36, message: 'Unexpected use of exports interface instead of global TDD' },
-                { line: 2, column: 17, message: 'Unexpected use of exports interface instead of global TDD' }
+                { message: 'Unexpected use of exports interface instead of global TDD' },
+                { message: 'Unexpected use of exports interface instead of global TDD' }
             ]
         },
         {
             code: `import {describe as foo, it as bar} from 'mocha'; foo('foo', () => {
                 bar('bar', () => {});
             });`,
+            output: null,
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'TDD' } },
             errors: [
-                { line: 1, column: 51, message: 'Unexpected use of exports interface instead of global TDD' },
-                { line: 2, column: 17, message: 'Unexpected use of exports interface instead of global TDD' }
+                { message: 'Unexpected use of exports interface instead of global TDD' },
+                { message: 'Unexpected use of exports interface instead of global TDD' }
             ]
         },
         {
             code: `import {describe, it} from 'mocha'; describe('foo', () => {
                 it('bar', () => {});
             });`,
+            output: `describe('foo', () => {
+                it('bar', () => {});
+            });`,
             options: [{ interface: 'TDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { line: 1, column: 37, message: 'Unexpected use of exports interface instead of global BDD' },
-                { line: 2, column: 17, message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of exports interface instead of global BDD' },
+                { message: 'Unexpected use of exports interface instead of global BDD' }
+            ]
+        },
+        {
+            code: `import {describe, run} from 'mocha'; describe('foo', () => {
+                run();
+            });`,
+            output: `import {run} from 'mocha'; describe('foo', () => {
+                run();
+            });`,
+            options: [{ interface: 'BDD' }],
+            settings: { mocha: { interface: 'BDD' } },
+            errors: [
+                { message: 'Unexpected use of exports interface instead of global BDD' }
+            ]
+        },
+        {
+            code: 'import mocha, {describe} from "mocha"; describe("foo", () => {});',
+            output: null,
+            options: [{ interface: 'BDD' }],
+            settings: { mocha: { interface: 'BDD' } },
+            errors: [
+                { message: 'Unexpected use of exports interface instead of global BDD' }
             ]
         }
     ]
+});
+
+describe('consistent-interface helpers', function () {
+    it('getMochaImportBinding() returns null when no matching specifier exists', function () {
+        const result = getMochaImportBinding(asScopeVariable({
+            name: 'missing',
+            defs: [{
+                type: 'ImportBinding',
+                node: { type: 'ImportSpecifier' },
+                parent: {
+                    source: { value: 'mocha' },
+                    specifiers: [{ type: 'ImportSpecifier', local: { name: 'describe' } }]
+                }
+            }]
+        }));
+
+        assert.strictEqual(result, null);
+    });
+
+    it('getImportedName() returns string literal import names', function () {
+        const result = getImportedName({
+            type: 'ImportSpecifier',
+            imported: { type: 'Literal', value: 'describe' },
+            local: { type: 'Identifier', name: 'describe' }
+        });
+
+        assert.strictEqual(result, 'describe');
+    });
+
+    it('getImportedName() returns null for non-string literal import names', function () {
+        const result = getImportedName({
+            type: 'ImportSpecifier',
+            imported: { type: 'Literal', value: 1 },
+            local: { type: 'Identifier', name: 'describe' }
+        });
+
+        assert.strictEqual(result, null);
+    });
+
+    it('removeFullImportDeclaration() returns null without a range', function () {
+        const result = removeFullImportDeclaration(
+            {
+                removeRange() {
+                    return null;
+                }
+            } as unknown as Rule.RuleFixer,
+            {
+                getTokenAfter() {
+                    return null;
+                }
+            } as unknown as SourceCode,
+            {
+                type: 'ImportDeclaration',
+                source: { type: 'Literal', value: 'mocha' },
+                specifiers: []
+            }
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('removeFullImportDeclaration() removes the declaration range when there is no following token', function () {
+        let removedRange: readonly [number, number] | null = null;
+
+        removeFullImportDeclaration(
+            {
+                removeRange(range: readonly [number, number]) {
+                    removedRange = range;
+                    return null;
+                }
+            } as unknown as Rule.RuleFixer,
+            {
+                getTokenAfter() {
+                    return null;
+                }
+            } as unknown as SourceCode,
+            {
+                type: 'ImportDeclaration',
+                range: [0, 30],
+                source: { type: 'Literal', value: 'mocha' },
+                specifiers: []
+            }
+        );
+
+        assert.deepStrictEqual(removedRange, [0, 30]);
+    });
+
+    it('getImportSpecifierRemovalRange() returns null when the specifier is not present', function () {
+        const result = getImportSpecifierRemovalRange(
+            {
+                type: 'ImportSpecifier',
+                imported: { type: 'Identifier', name: 'it' },
+                local: { type: 'Identifier', name: 'it' },
+                range: [15, 17]
+            },
+            []
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('getImportSpecifierRemovalRange() returns null when the next specifier has no range', function () {
+        const specifier: Parameters<typeof getImportSpecifierRemovalRange>[0] = {
+            type: 'ImportSpecifier',
+            imported: { type: 'Identifier', name: 'describe' },
+            local: { type: 'Identifier', name: 'describe' },
+            range: [8, 16]
+        };
+
+        const result = getImportSpecifierRemovalRange(
+            specifier,
+            [
+                specifier,
+                {
+                    type: 'ImportSpecifier',
+                    imported: { type: 'Identifier', name: 'run' },
+                    local: { type: 'Identifier', name: 'run' }
+                }
+            ]
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('getImportSpecifierRemovalRange() removes a later specifier from the previous range', function () {
+        const specifier: Parameters<typeof getImportSpecifierRemovalRange>[0] = {
+            type: 'ImportSpecifier',
+            imported: { type: 'Identifier', name: 'it' },
+            local: { type: 'Identifier', name: 'it' },
+            range: [15, 17]
+        };
+
+        const result = getImportSpecifierRemovalRange(
+            specifier,
+            [
+                {
+                    type: 'ImportSpecifier',
+                    imported: { type: 'Identifier', name: 'describe' },
+                    local: { type: 'Identifier', name: 'describe' },
+                    range: [8, 16]
+                },
+                specifier
+            ]
+        );
+
+        assert.deepStrictEqual(result, [16, 17]);
+    });
+
+    it('getImportSpecifierRemovalRange() returns null when the previous specifier has no range', function () {
+        const specifier: Parameters<typeof getImportSpecifierRemovalRange>[0] = {
+            type: 'ImportSpecifier',
+            imported: { type: 'Identifier', name: 'it' },
+            local: { type: 'Identifier', name: 'it' },
+            range: [15, 17]
+        };
+
+        const result = getImportSpecifierRemovalRange(
+            specifier,
+            [
+                {
+                    type: 'ImportSpecifier',
+                    imported: { type: 'Identifier', name: 'describe' },
+                    local: { type: 'Identifier', name: 'describe' }
+                },
+                specifier
+            ]
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('createUnexpectedImportDescriptor() returns null when no location is available', function () {
+        const result = createUnexpectedImportDescriptor(
+            {
+                importDeclaration: {
+                    type: 'ImportDeclaration',
+                    source: { type: 'Literal', value: 'mocha' },
+                    specifiers: []
+                },
+                specifier: {
+                    type: 'ImportSpecifier',
+                    imported: { type: 'Identifier', name: 'describe' },
+                    local: { type: 'Identifier', name: 'describe' }
+                }
+            },
+            'BDD'
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('getMochaModuleScope() returns null without a global scope', function () {
+        const result = getMochaModuleScope({ scopeManager: { globalScope: null } } as unknown as SourceCode);
+
+        assert.strictEqual(result, null);
+    });
+
+    it('fixImportSpecifier() returns null when partial removal has no usable range', function () {
+        const specifier: Parameters<typeof fixImportSpecifier>[2] = {
+            type: 'ImportSpecifier',
+            imported: { type: 'Identifier', name: 'describe' },
+            local: { type: 'Identifier', name: 'describe' },
+            range: [8, 16]
+        };
+        const result = fixImportSpecifier(
+            {
+                removeRange() {
+                    return null;
+                }
+            } as unknown as Rule.RuleFixer,
+            {
+                getTokenAfter() {
+                    return null;
+                }
+            } as unknown as SourceCode,
+            specifier,
+            {
+                type: 'ImportDeclaration',
+                range: [0, 30],
+                source: { type: 'Literal', value: 'mocha' },
+                specifiers: [
+                    specifier,
+                    {
+                        type: 'ImportSpecifier',
+                        imported: { type: 'Identifier', name: 'run' },
+                        local: { type: 'Identifier', name: 'run' }
+                    }
+                ]
+            }
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('reportUnexpectedImportBinding() skips reports when the binding has no location', function () {
+        const reports: string[] = [];
+
+        reportUnexpectedImportBinding(
+            asRuleContext({
+                sourceCode: {},
+                report() {
+                    reports.push('reported');
+                }
+            }),
+            {
+                importDeclaration: {
+                    type: 'ImportDeclaration',
+                    source: { type: 'Literal', value: 'mocha' },
+                    specifiers: []
+                },
+                specifier: {
+                    type: 'ImportSpecifier',
+                    imported: { type: 'Identifier', name: 'describe' },
+                    local: { type: 'Identifier', name: 'describe' }
+                }
+            },
+            'BDD'
+        );
+
+        assert.deepStrictEqual(reports, []);
+    });
+
+    it('reportUnexpectedImportBindingsInModule() ignores non-module scopes', function () {
+        const reports: string[] = [];
+
+        reportUnexpectedImportBindingsInModule(
+            asRuleContext({
+                sourceCode: {
+                    scopeManager: {
+                        globalScope: {
+                            childScopes: []
+                        }
+                    }
+                },
+                report() {
+                    reports.push('reported');
+                }
+            }),
+            'BDD'
+        );
+
+        assert.deepStrictEqual(reports, []);
+    });
 });

--- a/source/rules/consistent-interface.test.ts
+++ b/source/rules/consistent-interface.test.ts
@@ -23,6 +23,10 @@ function asScopeVariable(variable: Record<string, unknown>): Scope.Variable {
     return variable as unknown as Scope.Variable;
 }
 
+function asImportDeclaration(node: Record<string, unknown>): Parameters<typeof removeFullImportDeclaration>[2] {
+    return node as unknown as Parameters<typeof removeFullImportDeclaration>[2];
+}
+
 ruleTester.run('consistent-interface', consistentInterfaceRule, {
     valid: [
         {
@@ -234,11 +238,12 @@ describe('consistent-interface helpers', function () {
                     return null;
                 }
             } as unknown as SourceCode,
-            {
+            asImportDeclaration({
                 type: 'ImportDeclaration',
+                attributes: [],
                 source: { type: 'Literal', value: 'mocha' },
                 specifiers: []
-            }
+            })
         );
 
         assert.strictEqual(result, null);
@@ -259,12 +264,13 @@ describe('consistent-interface helpers', function () {
                     return null;
                 }
             } as unknown as SourceCode,
-            {
+            asImportDeclaration({
                 type: 'ImportDeclaration',
+                attributes: [],
                 range: [0, 30],
                 source: { type: 'Literal', value: 'mocha' },
                 specifiers: []
-            }
+            })
         );
 
         assert.deepStrictEqual(removedRange, [0, 30]);
@@ -357,11 +363,12 @@ describe('consistent-interface helpers', function () {
     it('createUnexpectedImportDescriptor() returns null when no location is available', function () {
         const result = createUnexpectedImportDescriptor(
             {
-                importDeclaration: {
+                importDeclaration: asImportDeclaration({
                     type: 'ImportDeclaration',
+                    attributes: [],
                     source: { type: 'Literal', value: 'mocha' },
                     specifiers: []
-                },
+                }),
                 specifier: {
                     type: 'ImportSpecifier',
                     imported: { type: 'Identifier', name: 'describe' },
@@ -399,8 +406,9 @@ describe('consistent-interface helpers', function () {
                 }
             } as unknown as SourceCode,
             specifier,
-            {
+            asImportDeclaration({
                 type: 'ImportDeclaration',
+                attributes: [],
                 range: [0, 30],
                 source: { type: 'Literal', value: 'mocha' },
                 specifiers: [
@@ -411,7 +419,7 @@ describe('consistent-interface helpers', function () {
                         local: { type: 'Identifier', name: 'run' }
                     }
                 ]
-            }
+            })
         );
 
         assert.strictEqual(result, null);
@@ -428,11 +436,12 @@ describe('consistent-interface helpers', function () {
                 }
             }),
             {
-                importDeclaration: {
+                importDeclaration: asImportDeclaration({
                     type: 'ImportDeclaration',
+                    attributes: [],
                     source: { type: 'Literal', value: 'mocha' },
                     specifiers: []
-                },
+                }),
                 specifier: {
                     type: 'ImportSpecifier',
                     imported: { type: 'Identifier', name: 'describe' },

--- a/source/rules/consistent-interface.ts
+++ b/source/rules/consistent-interface.ts
@@ -1,7 +1,7 @@
-import type { Rule } from 'eslint';
-import { findMochaVariableCalls } from '../ast/find-mocha-variable-calls.js';
+import type { AST, Rule, Scope, SourceCode } from 'eslint';
+import type * as ESTree from 'estree';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { getAllNames } from '../mocha/all-name-details.js';
+import { builtinNames } from '../mocha/descriptors.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 import { getInterface } from '../settings.js';
 
@@ -17,10 +17,38 @@ const optionSchema = {
     additionalProperties: false
 } as const satisfies RuleSchema;
 
+type InterfaceName = (typeof interfaces)[number];
 type Option = InferSchemaOption<typeof optionSchema>;
-type ResolvedOption = Option & { interface: (typeof interfaces)[number]; };
+type ResolvedOption = Option & { interface: InterfaceName; };
+type ImportSpecifierNode = ESTree.ImportSpecifier;
+type ImportDeclarationNode = ESTree.ImportDeclaration;
+type MochaImportBinding = {
+    importDeclaration: Readonly<ImportDeclarationNode>;
+    specifier: Readonly<ImportSpecifierNode>;
+};
+type MochaImportDefinition = Extract<Scope.Definition, { type: 'ImportBinding'; }> & {
+    node: ESTree.ImportSpecifier;
+    parent: ESTree.ImportDeclaration;
+};
+type UnexpectedImportDescriptor = {
+    readonly loc: AST.SourceLocation;
+    readonly messageId: 'unexpectedInterface';
+    readonly data: {
+        readonly actualInterface: string;
+        readonly expectedInterface: string;
+    };
+};
+
 const defaultOption: ResolvedOption = { interface: 'BDD' };
-const builtinMochaNames = getAllNames([]);
+const interfaceMethodNames = new Set<string>();
+
+for (const nameDetails of builtinNames) {
+    const [name] = nameDetails.path;
+
+    if (name !== undefined) {
+        interfaceMethodNames.add(name);
+    }
+}
 
 function reportUnexpectedInterface(
     context: Readonly<Rule.RuleContext>,
@@ -38,19 +66,223 @@ function reportUnexpectedInterface(
     });
 }
 
-function reportUnexpectedExportsInterface(
-    context: Readonly<Rule.RuleContext>,
-    node: Readonly<Rule.Node>,
-    expectedInterface: string
-): void {
-    context.report({
-        node,
-        messageId: 'unexpectedInterface',
-        data: {
-            actualInterface: 'exports',
-            expectedInterface: `global ${expectedInterface}`
-        }
+export function getMochaModuleScope(sourceCode: Readonly<SourceCode>): Readonly<Scope.Scope> | null {
+    const { globalScope } = sourceCode.scopeManager;
+    const [maybeModuleScope] = globalScope?.childScopes ?? [];
+
+    return maybeModuleScope?.type === 'module' ? maybeModuleScope : null;
+}
+
+function isMochaImportDefinition(importDef: Readonly<Scope.Definition>): importDef is Readonly<MochaImportDefinition> {
+    return importDef.type === 'ImportBinding' &&
+        importDef.parent.source.value === 'mocha' &&
+        importDef.node.type === 'ImportSpecifier';
+}
+
+export function getMochaImportBinding(variable: Readonly<Scope.Variable>): Readonly<MochaImportBinding> | null {
+    const importDef = variable.defs[0];
+
+    if (importDef === undefined || !isMochaImportDefinition(importDef)) {
+        return null;
+    }
+
+    const specifier = importDef.parent.specifiers.find((currentSpecifier): currentSpecifier is ImportSpecifierNode => {
+        return currentSpecifier.type === 'ImportSpecifier' &&
+            currentSpecifier.local.name === variable.name;
     });
+
+    if (specifier === undefined) {
+        return null;
+    }
+
+    return {
+        importDeclaration: importDef.parent,
+        specifier
+    };
+}
+
+export function getImportedName(specifier: Readonly<ImportSpecifierNode>): string | null {
+    if (specifier.imported.type === 'Identifier') {
+        return specifier.imported.name;
+    }
+
+    return typeof specifier.imported.value === 'string'
+        ? specifier.imported.value
+        : null;
+}
+
+function isInterfaceMethodImport(
+    specifier: Readonly<ImportSpecifierNode>
+): boolean {
+    const importedName = getImportedName(specifier);
+
+    return importedName !== null && interfaceMethodNames.has(importedName);
+}
+
+function isCanonicalNamedImportSpecifier(specifier: Readonly<ImportSpecifierNode>): boolean {
+    return specifier.imported.type === 'Identifier' &&
+        specifier.local.name === specifier.imported.name;
+}
+
+function isFixableImportSpecifier(specifier: Readonly<ImportSpecifierNode>): boolean {
+    return isCanonicalNamedImportSpecifier(specifier) && isInterfaceMethodImport(specifier);
+}
+
+function isAutoFixableImportSpecifier(
+    specifier: Readonly<ImportSpecifierNode>,
+    importDeclaration: Readonly<ImportDeclarationNode>
+): boolean {
+    return isCanonicalNamedImportSpecifier(specifier) &&
+        importDeclaration.specifiers.every((currentSpecifier) => {
+            return currentSpecifier.type === 'ImportSpecifier';
+        });
+}
+
+function getNamedImportSpecifiers(
+    importDeclaration: Readonly<ImportDeclarationNode>
+): readonly ImportSpecifierNode[] {
+    return importDeclaration.specifiers.filter((currentSpecifier): currentSpecifier is ImportSpecifierNode => {
+        return currentSpecifier.type === 'ImportSpecifier';
+    });
+}
+
+export function removeFullImportDeclaration(
+    fixer: Rule.RuleFixer,
+    sourceCode: Readonly<SourceCode>,
+    importDeclaration: Readonly<ImportDeclarationNode>
+): Readonly<Rule.Fix | null> {
+    if (importDeclaration.range === undefined) {
+        return null;
+    }
+
+    const nextToken = sourceCode.getTokenAfter(importDeclaration);
+
+    return nextToken === null
+        ? fixer.removeRange(importDeclaration.range)
+        : fixer.removeRange([importDeclaration.range[0], nextToken.range[0]]);
+}
+
+function shouldRemoveFullImportDeclaration(importDeclaration: Readonly<ImportDeclarationNode>): boolean {
+    return importDeclaration.specifiers.length > 0 &&
+        importDeclaration.specifiers.every((currentSpecifier): currentSpecifier is ImportSpecifierNode => {
+            return currentSpecifier.type === 'ImportSpecifier' && isFixableImportSpecifier(currentSpecifier);
+        });
+}
+
+function getRangeBeforeNextSpecifier(
+    specifier: Readonly<ImportSpecifierNode>,
+    nextSpecifier: Readonly<ImportSpecifierNode | undefined>
+): AST.Range | null {
+    return nextSpecifier?.range === undefined || specifier.range === undefined
+        ? null
+        : [specifier.range[0], nextSpecifier.range[0]];
+}
+
+function getRangeAfterPreviousSpecifier(
+    previousSpecifier: Readonly<ImportSpecifierNode | undefined>,
+    specifier: Readonly<ImportSpecifierNode>
+): AST.Range | null {
+    return previousSpecifier?.range === undefined || specifier.range === undefined
+        ? null
+        : [previousSpecifier.range[1], specifier.range[1]];
+}
+
+export function getImportSpecifierRemovalRange(
+    specifier: Readonly<ImportSpecifierNode>,
+    specifiers: readonly ImportSpecifierNode[]
+): AST.Range | null {
+    const index = specifiers.indexOf(specifier);
+    if (index === -1) {
+        return null;
+    }
+
+    if (index === 0) {
+        return getRangeBeforeNextSpecifier(specifier, specifiers[1]);
+    }
+
+    return getRangeAfterPreviousSpecifier(specifiers[index - 1], specifier);
+}
+
+export function fixImportSpecifier(
+    fixer: Rule.RuleFixer,
+    sourceCode: Readonly<SourceCode>,
+    specifier: Readonly<ImportSpecifierNode>,
+    importDeclaration: Readonly<ImportDeclarationNode>
+): Readonly<Rule.Fix | null> {
+    if (shouldRemoveFullImportDeclaration(importDeclaration)) {
+        return removeFullImportDeclaration(fixer, sourceCode, importDeclaration);
+    }
+
+    const specifiers = getNamedImportSpecifiers(importDeclaration);
+    const removalRange = getImportSpecifierRemovalRange(specifier, specifiers);
+
+    return removalRange === null ? null : fixer.removeRange(removalRange);
+}
+
+export function createUnexpectedImportDescriptor(
+    binding: Readonly<MochaImportBinding>,
+    configuredMochaInterface: InterfaceName
+): UnexpectedImportDescriptor | null {
+    const { importDeclaration, specifier } = binding;
+    const loc = specifier.local.loc ?? specifier.loc ?? importDeclaration.loc;
+
+    return loc === null || loc === undefined
+        ? null
+        : {
+            loc,
+            messageId: 'unexpectedInterface',
+            data: {
+                actualInterface: 'exports',
+                expectedInterface: `global ${configuredMochaInterface}`
+            }
+        };
+}
+
+export function reportUnexpectedImportBinding(
+    context: Readonly<Rule.RuleContext>,
+    binding: Readonly<MochaImportBinding>,
+    configuredMochaInterface: InterfaceName
+): void {
+    if (!isInterfaceMethodImport(binding.specifier)) {
+        return;
+    }
+
+    const descriptor = createUnexpectedImportDescriptor(binding, configuredMochaInterface);
+    if (descriptor === null) {
+        return;
+    }
+
+    const { importDeclaration, specifier } = binding;
+
+    if (isAutoFixableImportSpecifier(specifier, importDeclaration)) {
+        context.report({
+            ...descriptor,
+            fix(fixer) {
+                return fixImportSpecifier(fixer, context.sourceCode, specifier, importDeclaration);
+            }
+        });
+        return;
+    }
+
+    context.report(descriptor);
+}
+
+export function reportUnexpectedImportBindingsInModule(
+    context: Readonly<Rule.RuleContext>,
+    configuredMochaInterface: InterfaceName
+): void {
+    const moduleScope = getMochaModuleScope(context.sourceCode);
+    if (moduleScope === null) {
+        return;
+    }
+
+    for (const variable of moduleScope.variables) {
+        const binding = getMochaImportBinding(variable);
+
+        if (binding !== null && variable.references.length > 0) {
+            reportUnexpectedImportBinding(context, binding, configuredMochaInterface);
+        }
+    }
 }
 
 export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
@@ -61,6 +293,7 @@ export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/consistent-interface.md'
         },
         defaultOptions: [defaultOption],
+        fixable: 'code',
         messages: {
             unexpectedInterface: 'Unexpected use of {{actualInterface}} interface instead of {{expectedInterface}}'
         },
@@ -76,15 +309,7 @@ export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
                     return;
                 }
 
-                const importedMochaInterfaceCalls = findMochaVariableCalls(context, builtinMochaNames, 'exports');
-
-                for (const importedMochaInterfaceCall of importedMochaInterfaceCalls) {
-                    reportUnexpectedExportsInterface(
-                        context,
-                        importedMochaInterfaceCall.node,
-                        configuredMochaInterface
-                    );
-                }
+                reportUnexpectedImportBindingsInModule(context, configuredMochaInterface);
             },
             ...createMochaVisitors(context, {
                 anyTestEntity(visitorContext) {


### PR DESCRIPTION
## Summary
- add an autofix for direct named mocha interface imports when globals are configured
- keep alias and mixed default import cases diagnostic-only
- add coverage for the new import-handling helpers and regenerate docs

## Testing
- npm run eslint -- source/rules/consistent-interface.ts source/rules/consistent-interface.test.ts
- npm run test:unit -- --grep consistent-interface
- npm run test:unit:with-coverage
- npm run update:eslint-docs
- npm run lint:eslint-docs