### PR TITLE
Add suggestions for no-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
-| [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    |    |
+| [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |
 | [no-global-tests](documentation/rules/no-global-tests.md)                                     | Disallow global tests                                                   | ✅  |    |    |    |    |
 | [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |    |
 | [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |    |

--- a/documentation/rules/no-exports.md
+++ b/documentation/rules/no-exports.md
@@ -2,7 +2,11 @@
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
 <!-- end auto-generated rule header -->
+
+💡 This rule provides suggestions when it can preserve a local declaration or remove a plain local export list without guessing a replacement structure.
 
 Test files should stay focused on tests. If a test file also exports values, it often means helper or library code should move to a separate file.
 

--- a/source/rules/no-exports.test.ts
+++ b/source/rules/no-exports.test.ts
@@ -1,6 +1,36 @@
-import { RuleTester } from 'eslint';
-import { noExportsRule } from './no-exports.js';
+import { type Rule, RuleTester } from 'eslint';
+import assert from 'node:assert';
+import {
+    createExportSuggestions,
+    fixRemoveExportKeyword,
+    fixRemoveExportStatement,
+    noExportsRule
+} from './no-exports.js';
+
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const expectedErrorMessage = 'Unexpected export from a test file';
+
+function asRuleFixer(ruleFixer: Record<string, unknown>): Rule.RuleFixer {
+    return ruleFixer as unknown as Rule.RuleFixer;
+}
+
+function asFixKeywordNode(
+    node: Record<string, unknown>
+): Parameters<typeof fixRemoveExportKeyword>[1] {
+    return node as unknown as Parameters<typeof fixRemoveExportKeyword>[1];
+}
+
+function asFixStatementNode(
+    node: Record<string, unknown>
+): Parameters<typeof fixRemoveExportStatement>[1] {
+    return node as unknown as Parameters<typeof fixRemoveExportStatement>[1];
+}
+
+function asSuggestionNode(
+    node: Record<string, unknown>
+): Parameters<typeof createExportSuggestions>[0] {
+    return node as unknown as Parameters<typeof createExportSuggestions>[0];
+}
 
 ruleTester.run('no-exports', noExportsRule, {
     valid: [
@@ -33,7 +63,7 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'describe(function() {}); export default "foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 26,
                 line: 1
             }]
@@ -42,34 +72,46 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'describe(function() {}); export const bar = "foo";',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 26,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportKeyword',
+                    output: 'describe(function() {}); const bar = "foo";'
+                }]
             }]
         },
         {
             code: 'describe(function() {}); let foo; export { foo }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 35,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'describe(function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'describe(function() {}); let foo; export { foo as bar }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 35,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'describe(function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'describe(function() {}); export * from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 26,
                 line: 1
             }]
@@ -78,16 +120,29 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'describe(function() {}); export { bar } from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 26,
                 line: 1
+            }]
+        },
+        {
+            code: 'describe(function() {}); export default function foo() {}',
+            languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
+            errors: [{
+                message: expectedErrorMessage,
+                column: 26,
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportKeyword',
+                    output: 'describe(function() {}); function foo() {}'
+                }]
             }]
         },
         {
             code: 'it("", function() {}); export default "foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 24,
                 line: 1
             }]
@@ -96,34 +151,46 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'it("", function() {}); export const bar = "foo";',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 24,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportKeyword',
+                    output: 'it("", function() {}); const bar = "foo";'
+                }]
             }]
         },
         {
             code: 'it("", function() {}); let foo; export { foo }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 33,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'it("", function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'it("", function() {}); let foo; export { foo as bar }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 33,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'it("", function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'it("", function() {}); export * from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 24,
                 line: 1
             }]
@@ -132,7 +199,7 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'it("", function() {}); export { bar } from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 24,
                 line: 1
             }]
@@ -141,7 +208,7 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'beforeEach(function() {}); export default "foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 28,
                 line: 1
             }]
@@ -150,34 +217,46 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'beforeEach(function() {}); export const bar = "foo";',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 28,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportKeyword',
+                    output: 'beforeEach(function() {}); const bar = "foo";'
+                }]
             }]
         },
         {
             code: 'beforeEach(function() {}); let foo; export { foo }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 37,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'beforeEach(function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'beforeEach(function() {}); let foo; export { foo as bar }',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 37,
-                line: 1
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExportStatement',
+                    output: 'beforeEach(function() {}); let foo; '
+                }]
             }]
         },
         {
             code: 'beforeEach(function() {}); export * from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 28,
                 line: 1
             }]
@@ -186,10 +265,91 @@ ruleTester.run('no-exports', noExportsRule, {
             code: 'beforeEach(function() {}); export { bar } from "./foo"',
             languageOptions: { ecmaVersion: 2019, sourceType: 'module' },
             errors: [{
-                message: 'Unexpected export from a test file',
+                message: expectedErrorMessage,
                 column: 28,
                 line: 1
             }]
         }
     ]
+});
+
+describe('no-exports helpers', function () {
+    it('fixRemoveExportKeyword() returns null without a declaration', function () {
+        const result = fixRemoveExportKeyword(
+            asRuleFixer({
+                removeRange() {
+                    return null;
+                }
+            }),
+            asFixKeywordNode({ type: 'ExportDefaultDeclaration' })
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('fixRemoveExportKeyword() returns null without ranges', function () {
+        const result = fixRemoveExportKeyword(
+            asRuleFixer({
+                removeRange() {
+                    return null;
+                }
+            }),
+            asFixKeywordNode({
+                type: 'ExportNamedDeclaration',
+                declaration: {
+                    type: 'VariableDeclaration',
+                    declarations: [],
+                    kind: 'const'
+                },
+                specifiers: [],
+                source: null
+            })
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('fixRemoveExportStatement() returns null without a range', function () {
+        const result = fixRemoveExportStatement(
+            asRuleFixer({
+                removeRange() {
+                    return null;
+                }
+            }),
+            asFixStatementNode({
+                type: 'ExportNamedDeclaration',
+                declaration: null,
+                specifiers: [],
+                source: null
+            })
+        );
+
+        assert.strictEqual(result, null);
+    });
+
+    it('createExportSuggestions() ignores default export expressions', function () {
+        const result = createExportSuggestions(asSuggestionNode({
+            type: 'ExportDefaultDeclaration',
+            declaration: {
+                type: 'Literal',
+                value: 'foo'
+            }
+        }));
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('createExportSuggestions() ignores re-export declarations', function () {
+        const result = createExportSuggestions(asSuggestionNode({
+            type: 'ExportNamedDeclaration',
+            declaration: null,
+            specifiers: [],
+            source: {
+                type: 'Literal',
+                value: './foo'
+            }
+        }));
+
+        assert.deepStrictEqual(result, []);
+    });
 });

--- a/source/rules/no-exports.ts
+++ b/source/rules/no-exports.ts
@@ -1,29 +1,127 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 
+type ExportNamedDeclarationNode = Parameters<NonNullable<Rule.RuleListener['ExportNamedDeclaration']>>[0];
+type ExportDefaultDeclarationNode = Parameters<NonNullable<Rule.RuleListener['ExportDefaultDeclaration']>>[0];
+type ExportAllDeclarationNode = Parameters<NonNullable<Rule.RuleListener['ExportAllDeclaration']>>[0];
+type ExportNode = ExportAllDeclarationNode | ExportDefaultDeclarationNode | ExportNamedDeclarationNode;
+type NamedExportWithDeclaration = ExportNamedDeclarationNode & {
+    declaration: Exclude<ExportNamedDeclarationNode['declaration'], null>;
+};
+type DefaultExportWithNamedDeclaration = ExportDefaultDeclarationNode & {
+    declaration: {
+        id: Record<string, unknown>;
+        range?: Readonly<Rule.Node['range']>;
+        type: 'ClassDeclaration' | 'FunctionDeclaration';
+    };
+};
+type ExportSuggestion = NonNullable<Rule.ReportDescriptor['suggest']>[number];
+
+function isNamedExportWithDeclaration(node: Readonly<ExportNode>): node is Readonly<NamedExportWithDeclaration> {
+    return node.type === 'ExportNamedDeclaration' && node.declaration !== null;
+}
+
+function isNamedDefaultExportDeclaration(
+    node: Readonly<ExportNode>
+): node is Readonly<DefaultExportWithNamedDeclaration> {
+    return node.type === 'ExportDefaultDeclaration' &&
+        (node.declaration.type === 'ClassDeclaration' || node.declaration.type === 'FunctionDeclaration') &&
+        node.declaration.id !== null;
+}
+
+function isLocalNamedExportList(node: Readonly<ExportNode>): node is Readonly<ExportNamedDeclarationNode> {
+    return node.type === 'ExportNamedDeclaration' &&
+        node.declaration === null &&
+        node.source === null;
+}
+
+export function fixRemoveExportKeyword(
+    fixer: Rule.RuleFixer,
+    node: Readonly<DefaultExportWithNamedDeclaration | NamedExportWithDeclaration>
+): Readonly<Rule.Fix | null> {
+    const { declaration } = node;
+
+    if (declaration === undefined) {
+        return null;
+    }
+
+    return node.range === undefined || declaration.range === undefined
+        ? null
+        : fixer.removeRange([node.range[0], declaration.range[0]]);
+}
+
+export function fixRemoveExportStatement(
+    fixer: Rule.RuleFixer,
+    node: Readonly<ExportNamedDeclarationNode>
+): Readonly<Rule.Fix | null> {
+    return node.range === undefined
+        ? null
+        : fixer.removeRange(node.range);
+}
+
+export function createExportSuggestions(node: Readonly<ExportNode>): ExportSuggestion[] {
+    if (isNamedExportWithDeclaration(node) || isNamedDefaultExportDeclaration(node)) {
+        return [{
+            messageId: 'removeExportKeyword',
+            fix(fixer) {
+                return fixRemoveExportKeyword(fixer, node);
+            }
+        }];
+    }
+
+    if (isLocalNamedExportList(node)) {
+        return [{
+            messageId: 'removeExportStatement',
+            fix(fixer) {
+                return fixRemoveExportStatement(fixer, node);
+            }
+        }];
+    }
+
+    return [];
+}
+
 export const noExportsRule: Readonly<Rule.RuleModule> = {
     meta: {
         docs: {
             description: 'Disallow exports from test files',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-exports.md'
         },
+        hasSuggestions: true,
         messages: {
-            unexpectedExport: 'Unexpected export from a test file'
+            unexpectedExport: 'Unexpected export from a test file',
+            removeExportKeyword: 'Remove the export keyword',
+            removeExportStatement: 'Remove this export statement'
         },
         type: 'suggestion',
         languages: ['js/js'],
         schema: []
     },
     create(context) {
-        const exportNodes: Rule.Node[] = [];
+        const exportNodes: ExportNode[] = [];
         let hasTestCase = false;
 
         return createMochaVisitors(context, {
             'Program:exit'() {
-                if (hasTestCase && exportNodes.length > 0) {
-                    for (const node of exportNodes) {
-                        context.report({ node, messageId: 'unexpectedExport' });
-                    }
+                if (!hasTestCase || exportNodes.length === 0) {
+                    return;
+                }
+
+                for (const node of exportNodes) {
+                    const suggestions = createExportSuggestions(node);
+
+                    context.report(
+                        suggestions.length === 0
+                            ? {
+                                node,
+                                messageId: 'unexpectedExport'
+                            }
+                            : {
+                                node,
+                                messageId: 'unexpectedExport',
+                                suggest: suggestions
+                            }
+                    );
                 }
             },
 
@@ -33,9 +131,15 @@ export const noExportsRule: Readonly<Rule.RuleModule> = {
                 }
             },
 
-            'ExportNamedDeclaration, ExportDefaultDeclaration, ExportAllDeclaration'(
-                node
-            ) {
+            ExportNamedDeclaration(node) {
+                exportNodes.push(node);
+            },
+
+            ExportDefaultDeclaration(node) {
+                exportNodes.push(node);
+            },
+
+            ExportAllDeclaration(node) {
                 exportNodes.push(node);
             }
         });


### PR DESCRIPTION
## Summary
- add suggestion-only support for removable local export forms in test files
- keep export default expressions and re-exports diagnostic-only
- regenerate the rule docs and README for suggestion metadata

## Testing
- npm run eslint -- source/rules/no-exports.ts source/rules/no-exports.test.ts
- npm run test:unit -- --grep no-exports
- npm run test:unit:with-coverage
- npm run update:eslint-docs
- npm run lint:eslint-docs
- npm run lint:docs -- documentation/rules/no-exports.md README.md