### PR TITLE
Support custom hook names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default [
 
 These settings are shared by multiple rules.
 
-- `additionalCustomNames`: Adds custom suite or test function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha) or [`mocha-each`](https://github.com/ryym/mocha-each).
+- `additionalCustomNames`: Adds custom suite, test, or hook function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha) or project-specific helpers that wrap setup and teardown.
 
 ```json
 {
@@ -63,6 +63,11 @@ These settings are shared by multiple rules.
                 "name": "testModule",
                 "type": "testCase",
                 "interface": "TDD"
+            },
+            {
+                "name": "prepareTestContexts",
+                "type": "hook",
+                "interface": "BDD"
             }
         ]
     }
@@ -95,6 +100,7 @@ forEach([1, 2, 3]).describe("example", function (n) {});
 forEach([1, 2, 3]).describeModule.modifier("example", function (n) {});
 ```
 
+- `type`: Selects `suite`, `testCase`, or `hook`.
 - `interface`: Selects `BDD`, `TDD`, or `exports`. The default is `BDD`. With `exports`, rule resolution uses named `import` statements instead of globals. `mocha/consistent-interface` also reports named imports of Mocha interface methods when this setting is `BDD` or `TDD`, which helps catch accidental `exports`-style usage and interface misconfiguration earlier.
 
 ## Rules

--- a/source/mocha/all-name-details.ts
+++ b/source/mocha/all-name-details.ts
@@ -1,8 +1,11 @@
-import { builtinNames, type NameDetailsConfig } from './descriptors.js';
+import { builtinNames, type CustomMochaEntityType, type NameDetailsConfig } from './descriptors.js';
 import { buildAllNameDetailsWithVariants, type NameDetails } from './name-details.js';
 import { convertNameToPathArray } from './path.js';
 
-export type CustomNameConfig = Pick<NameDetailsConfig, 'interface' | 'type'> & { name: string; };
+export type CustomNameConfig = Pick<NameDetailsConfig, 'interface'> & {
+    name: string;
+    type: CustomMochaEntityType;
+};
 
 function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readonly<NameDetailsConfig> {
     const { name, ...rest } = nameConfig;

--- a/source/mocha/descriptors.ts
+++ b/source/mocha/descriptors.ts
@@ -15,6 +15,12 @@ export const configCallNames = ['timeout', 'slow', 'retries'] as const;
 export type MochaConfigCall = (typeof configCallNames)[number];
 
 export type MochaEntityType = 'config' | 'hook' | 'suite' | 'testCase';
+const customNameTypes = ['hook', 'suite', 'testCase'] as const;
+export type CustomMochaEntityType = (typeof customNameTypes)[number];
+
+export function isCustomMochaEntityType(value: unknown): value is CustomMochaEntityType {
+    return (customNameTypes as readonly unknown[]).includes(value);
+}
 
 export type MochaModifier = 'exclusive' | 'pending';
 

--- a/source/rules/no-hooks.test.ts
+++ b/source/rules/no-hooks.test.ts
@@ -60,6 +60,15 @@ ruleTester.run('no-hooks', noHooksRule, {
         {
             code: 'describe(function() { suiteTeardown(function() {}); });',
             options: [{ allow: ['suiteTeardown()'] }]
+        },
+        {
+            code: 'describe(function() { prepareTestContexts(function() {}); });',
+            options: [{ allow: ['prepareTestContexts()'] }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'prepareTestContexts', type: 'hook', interface: 'BDD' }]
+                }
+            }
         }
     ],
 
@@ -88,6 +97,15 @@ ruleTester.run('no-hooks', noHooksRule, {
             code: 'describe(function() { after(function() {}); });',
             options: [{ allow: ['before'] }],
             errors: [{ message: 'Unexpected use of Mocha `after()` hook', column: 23, line: 1 }]
+        },
+        {
+            code: 'describe(function() { prepareTestContexts(function() {}); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'prepareTestContexts', type: 'hook', interface: 'BDD' }]
+                }
+            },
+            errors: [{ message: 'Unexpected use of Mocha `prepareTestContexts()` hook', column: 23, line: 1 }]
         }
     ]
 });

--- a/source/rules/no-top-level-hooks.test.ts
+++ b/source/rules/no-top-level-hooks.test.ts
@@ -59,6 +59,14 @@ ruleTester.run('no-top-level-hooks', noTopLevelHooksRule, {
             }
         },
         {
+            code: 'describe(function() { prepareTestContexts(function() {}); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'prepareTestContexts', type: 'hook', interface: 'BDD' }]
+                }
+            }
+        },
+        {
             code: 'describe(function() { before(function() {}); });',
             languageOptions: {
                 ecmaVersion: 2019,
@@ -136,6 +144,19 @@ ruleTester.run('no-top-level-hooks', noTopLevelHooksRule, {
             errors: [{
                 message: 'Unexpected use of Mocha `before()` hook outside of a test suite',
                 column: 32,
+                line: 1
+            }]
+        },
+        {
+            code: 'prepareTestContexts(function() {});',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'prepareTestContexts', type: 'hook', interface: 'BDD' }]
+                }
+            },
+            errors: [{
+                message: 'Unexpected use of Mocha `prepareTestContexts()` hook outside of a test suite',
+                column: 1,
                 line: 1
             }]
         },

--- a/source/settings.test.ts
+++ b/source/settings.test.ts
@@ -19,11 +19,11 @@ describe('settings', function () {
         it('returns the configured additional names from nested settings', function () {
             const result = getAdditionalNames({
                 mocha: {
-                    additionalCustomNames: [{ interface: 'TDD', name: 'bar', type: 'testCase' }]
+                    additionalCustomNames: [{ interface: 'BDD', name: 'prepareTestContexts', type: 'hook' }]
                 }
             });
 
-            assert.deepStrictEqual(result, [{ interface: 'TDD', name: 'bar', type: 'testCase' }]);
+            assert.deepStrictEqual(result, [{ interface: 'BDD', name: 'prepareTestContexts', type: 'hook' }]);
         });
 
         it('throws when additionalCustomNames is not an array', function () {
@@ -88,6 +88,20 @@ describe('settings', function () {
                 function (error: unknown) {
                     return error instanceof TypeError &&
                         error.message === 'additionalCustomNames type missing or invalid';
+                }
+            );
+        });
+
+        it('throws when an additionalCustomNames item has an unknown type', function () {
+            assert.throws(
+                function () {
+                    getAdditionalNames({
+                        'mocha/additionalCustomNames': [{ interface: 'BDD', name: 'bar', type: 'config' }]
+                    });
+                },
+                function (error: unknown) {
+                    return error instanceof Error &&
+                        error.message === 'additionalCustomNames type config is invalid';
                 }
             );
         });

--- a/source/settings.ts
+++ b/source/settings.ts
@@ -1,5 +1,5 @@
 import type { CustomNameConfig } from './mocha/all-name-details.js';
-import { isMochaInterface, type MochaInterface } from './mocha/descriptors.js';
+import { isCustomMochaEntityType, isMochaInterface, type MochaInterface } from './mocha/descriptors.js';
 import { isRecord } from './record.js';
 
 function settingFor(settings: Record<string, unknown>, propertyName: string, fallback: unknown): unknown {
@@ -36,6 +36,9 @@ function validateAdditionalNames(value: unknown): asserts value is readonly Cust
         }
         if (typeof item.type !== 'string') {
             throw new TypeError('additionalCustomNames type missing or invalid');
+        }
+        if (!isCustomMochaEntityType(item.type)) {
+            throw new Error(`additionalCustomNames type ${item.type} is invalid`);
         }
     }
 }


### PR DESCRIPTION
Closes #405

- allow `hook` in `mocha/additionalCustomNames`
- add validation, tests, and README coverage