### PR TITLE
Support custom exports wrapper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default [
 
 These settings are shared by multiple rules.
 
-- `additionalCustomNames`: Adds custom suite, test, or hook function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha) or project-specific helpers that wrap setup and teardown.
+- `additionalCustomNames`: Adds custom suite, test, or hook function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha), [`mocha-each`](https://github.com/ryym/mocha-each), or project-specific helpers that wrap setup and teardown. Use `interface: "exports"` for wrappers that expose named imports from a helper module instead of importing directly from `mocha`.
 
 ```json
 {

--- a/source/ast/find-import-references.test.ts
+++ b/source/ast/find-import-references.test.ts
@@ -8,7 +8,7 @@ import type { ResolvedReference } from './resolved-reference.js';
 function findReferenceNames(
     code: string,
     names: readonly Partial<NameDetails>[],
-    importSource: string,
+    importSource: string | null,
     sourceType: 'module' | 'script' = 'module'
 ): readonly Except<ResolvedReference, 'node'>[] {
     const linter = new Linter();
@@ -193,6 +193,17 @@ describe('findImportReferencesByName()', function () {
         const foundResolvedReferences = findReferenceNames('import { foo as baz } from "bar"; baz;', [
             { path: ['foo'] }
         ], 'bar');
+
+        assert.deepStrictEqual(foundResolvedReferences, [{
+            path: ['baz'],
+            resolvedPath: ['foo']
+        }]);
+    });
+
+    it('returns matching references from any module when the import source is null', function () {
+        const foundResolvedReferences = findReferenceNames('import { foo as baz } from "bar"; baz;', [
+            { path: ['foo'] }
+        ], null);
 
         assert.deepStrictEqual(foundResolvedReferences, [{
             path: ['baz'],

--- a/source/ast/find-import-references.ts
+++ b/source/ast/find-import-references.ts
@@ -1,34 +1,62 @@
 import type { Rule, Scope, SourceCode } from 'eslint';
 import type { Except } from 'type-fest';
-import { filterWithArgs, flatMapWithArgs, mapWithArgs } from '../list.js';
+import { flatMapWithArgs, mapWithArgs } from '../list.js';
 import type { NameDetails } from '../mocha/name-details.js';
 import { getUniqueBaseNames } from '../mocha/path.js';
+import { isRecord } from '../record.js';
 import { type DynamicPath, isConstantPath } from './member-expression.js';
 import { getParentNode } from './node-types.js';
 import { findParentNodeAndPathForIdentifier, type ResolvedReference } from './resolved-reference.js';
 
-function isLiteralWithValue(node: Except<Rule.Node, 'parent'>, expectedValue: string): boolean {
-    return node.type === 'Literal' && node.value === expectedValue;
+function isLiteralWithValue(node: Except<Rule.Node, 'parent'>, expectedValue: string | null): boolean {
+    return node.type === 'Literal' && (expectedValue === null || node.value === expectedValue);
+}
+
+type ImportSpecifierNode = {
+    readonly type: 'ImportSpecifier';
+    readonly imported: {
+        readonly name: string;
+    };
+};
+
+type ImportBindingDefinition = Readonly<Scope.Definition> & {
+    readonly type: 'ImportBinding';
+    readonly node: Readonly<ImportSpecifierNode>;
+};
+
+type NamedImportBindingVariable = Readonly<Scope.Variable> & {
+    readonly defs: readonly [ImportBindingDefinition, ...(readonly Scope.Definition[])];
+};
+
+function isImportSpecifierNode(node: unknown): node is Readonly<ImportSpecifierNode> {
+    return isRecord(node) &&
+        node.type === 'ImportSpecifier' &&
+        isRecord(node.imported) &&
+        typeof node.imported.name === 'string';
 }
 
 function isExclusiveNamedImportBindingWithMatchingSource(
     variable: Readonly<Scope.Variable>,
-    expectedSource: string
-): boolean {
+    expectedSource: string | null
+): variable is NamedImportBindingVariable {
     const importDef = variable.defs[0];
+    const importNode: unknown = importDef?.node;
 
     return (
         importDef !== undefined &&
         importDef.type === 'ImportBinding' &&
+        isImportSpecifierNode(importNode) &&
         isLiteralWithValue(importDef.parent.source, expectedSource)
     );
 }
 
 function getAllNamedImportBindingVariables(
     moduleScope: Readonly<Scope.Scope>,
-    expectedSource: string
-): readonly Scope.Variable[] {
-    return filterWithArgs(moduleScope.variables, isExclusiveNamedImportBindingWithMatchingSource, expectedSource);
+    expectedSource: string | null
+): readonly NamedImportBindingVariable[] {
+    return moduleScope.variables.filter((variable): variable is NamedImportBindingVariable => {
+        return isExclusiveNamedImportBindingWithMatchingSource(variable, expectedSource);
+    });
 }
 
 function isNonAssignmentReference(reference: Readonly<Scope.Reference>): boolean {
@@ -71,18 +99,13 @@ function resolveImportPathWithOriginalName(
 }
 
 function resolveReferencesForNamedImport(
-    variable: Readonly<Scope.Variable>,
+    variable: Readonly<NamedImportBindingVariable>,
     sourceCode: Readonly<SourceCode>,
     identifierNames: readonly string[]
 ): readonly ResolvedReference[] {
-    const importDef = variable.defs[0];
-    if (importDef !== undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- filtered to import bindings above
-        const originalName = (importDef.node as { imported: { name: string; }; }).imported.name;
-
-        if (identifierNames.includes(originalName)) {
-            return mapWithArgs(variable.references, resolveImportPathWithOriginalName, sourceCode, originalName);
-        }
+    const originalName = variable.defs[0].node.imported.name;
+    if (identifierNames.includes(originalName)) {
+        return mapWithArgs(variable.references, resolveImportPathWithOriginalName, sourceCode, originalName);
     }
 
     return [];
@@ -92,7 +115,7 @@ function processNamedImports(
     sourceCode: Readonly<SourceCode>,
     moduleScope: Readonly<Scope.Scope>,
     identifierNames: readonly string[],
-    importSource: string
+    importSource: string | null
 ): readonly ResolvedReference[] {
     const namedImportVariables = getAllNamedImportBindingVariables(moduleScope, importSource);
     const constantNamedImports = namedImportVariables.filter(isBindingConstant);
@@ -103,7 +126,7 @@ function processNamedImports(
 export function findImportReferencesByName(
     context: Readonly<Rule.RuleContext>,
     nameDetailsList: readonly NameDetails[],
-    importSource: string
+    importSource: string | null
 ): readonly ResolvedReference[] {
     const { sourceCode } = context;
     const { globalScope } = sourceCode.scopeManager;

--- a/source/ast/find-mocha-variable-calls.test.ts
+++ b/source/ast/find-mocha-variable-calls.test.ts
@@ -15,7 +15,7 @@ function findCalls(
         create(ruleContext) {
             return {
                 'Program:exit'() {
-                    calls = findMochaVariableCalls(ruleContext, names as (readonly NameDetails[]), 'BDD');
+                    calls = findMochaVariableCalls(ruleContext, names as (readonly NameDetails[]), 'BDD', false);
                 }
             };
         }

--- a/source/ast/find-mocha-variable-calls.ts
+++ b/source/ast/find-mocha-variable-calls.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/max-dependencies -- needs to be refactored */
 import type { Rule } from 'eslint';
 import { reduceWithArgs } from '../list.js';
+import { getAllNames } from '../mocha/all-name-details.js';
 import type { MochaInterface } from '../mocha/descriptors.js';
 import { type NameDetails, reformatLastPathSegmentWithCallExpressions } from '../mocha/name-details.js';
 import { isSamePath } from '../mocha/path.js';
@@ -111,17 +112,46 @@ function isResultWithConstantPath(result: Readonly<ResolvedReference>): boolean 
     return isConstantPath(result.path);
 }
 
+type SplitCustomNames = {
+    readonly exports: readonly NameDetails[];
+    readonly globals: readonly NameDetails[];
+};
+
+function splitCustomNamesByInterface(customNames: readonly NameDetails[]): Readonly<SplitCustomNames> {
+    return {
+        exports: customNames.filter((nameDetails) => {
+            return nameDetails.interface === 'exports';
+        }),
+        globals: customNames.filter((nameDetails) => {
+            return nameDetails.interface !== 'exports';
+        })
+    };
+}
+
 export function findMochaVariableCalls(
     context: Readonly<Rule.RuleContext>,
-    names: readonly NameDetails[],
-    interfaceToUse: MochaInterface
+    customNames: readonly NameDetails[],
+    interfaceToUse: MochaInterface,
+    includeAllInterfaces: boolean
 ): readonly ResolvedReferenceWithNameDetails[] {
     const { sourceCode } = context;
-    const references = interfaceToUse === 'exports'
-        ? findImportReferencesByName(context, names, 'mocha')
-        : findGlobalReferencesByName(context, names);
+    const builtinNames = getAllNames([], interfaceToUse, includeAllInterfaces);
+    const builtinReferences = interfaceToUse === 'exports'
+        ? findImportReferencesByName(context, builtinNames, 'mocha')
+        : findGlobalReferencesByName(context, builtinNames);
+    const customNamesByInterface = splitCustomNamesByInterface(customNames);
+    const customExportReferences = findImportReferencesByName(
+        context,
+        customNamesByInterface.exports,
+        null
+    );
+    const customGlobalReferences = findGlobalReferencesByName(context, customNamesByInterface.globals);
 
-    const resolvedReferences = resolveAliasedReferences(sourceCode, references);
+    const resolvedReferences = resolveAliasedReferences(sourceCode, [
+        ...builtinReferences,
+        ...customExportReferences,
+        ...customGlobalReferences
+    ]);
 
     const constantResolvedReferences = reduceWithArgs(resolvedReferences, shouldProcessReference, []);
 
@@ -131,6 +161,6 @@ export function findMochaVariableCalls(
         filteredReferences,
         shouldAddReferenceToResults,
         [],
-        names
+        [...builtinNames, ...customNames]
     );
 }

--- a/source/ast/mocha-visitors.ts
+++ b/source/ast/mocha-visitors.ts
@@ -1,5 +1,5 @@
 import type { Rule, SourceCode } from 'eslint';
-import { getAllNames } from '../mocha/all-name-details.js';
+import { getAllCustomNameDetails, getCustomNameDetailsForInterface } from '../mocha/all-name-details.js';
 import type { MochaEntityType, MochaInterface, MochaModifier } from '../mocha/descriptors.js';
 import { getAdditionalNames, getInterface } from '../settings.js';
 import { findMochaVariableCalls, type ResolvedReferenceWithNameDetails } from './find-mocha-variable-calls.js';
@@ -347,8 +347,16 @@ function findCallsCached(
     if (cachedMochaCallsByNode === undefined) {
         const additionalCustomNames = getAdditionalNames(context.settings);
         const interfaceToUse = getInterface(context.settings);
-        const names = getAllNames(additionalCustomNames, interfaceToUse, options.includeAllInterfaces === true);
-        const calls = findMochaVariableCalls(context, names, interfaceToUse);
+        const includeAllInterfaces = options.includeAllInterfaces === true;
+        const customNames = includeAllInterfaces
+            ? getAllCustomNameDetails(additionalCustomNames)
+            : getCustomNameDetailsForInterface(additionalCustomNames, interfaceToUse);
+        const calls = findMochaVariableCalls(
+            context,
+            customNames,
+            interfaceToUse,
+            includeAllInterfaces
+        );
 
         cachedMochaCallsByNode = createMochaCallCache(calls);
         callsPerSettings.set(callCacheKey, cachedMochaCallsByNode);

--- a/source/mocha/all-name-details.ts
+++ b/source/mocha/all-name-details.ts
@@ -12,12 +12,12 @@ export type CustomNameConfig = Pick<NameDetailsConfig, 'interface'> & {
     type: CustomMochaEntityType;
 };
 
-function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readonly<NameDetailsConfig> {
+export function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readonly<NameDetailsConfig> {
     const { name, ...rest } = nameConfig;
     return { path: convertNameToPathArray(name), modifier: null, config: null, ...rest };
 }
 
-const builtinNameDetailsList = buildAllNameDetailsWithVariants(builtinNames);
+export const builtinNameDetailsList = buildAllNameDetailsWithVariants(builtinNames);
 
 function hasMatchingInterface(
     nameDetails: Readonly<NameDetailsConfig>,
@@ -26,12 +26,28 @@ function hasMatchingInterface(
     return interfaceToUse === 'exports' || nameDetails.interface === interfaceToUse;
 }
 
+function hasMatchingCustomInterface(
+    nameDetails: Readonly<NameDetailsConfig>,
+    interfaceToUse: MochaInterface
+): boolean {
+    return nameDetails.interface === 'exports' || hasMatchingInterface(nameDetails, interfaceToUse);
+}
+
 function filterByInterface(
     nameDetailsList: readonly NameDetailsConfig[],
     interfaceToUse: MochaInterface
 ): readonly NameDetailsConfig[] {
     return nameDetailsList.filter((nameDetails) => {
         return hasMatchingInterface(nameDetails, interfaceToUse);
+    });
+}
+
+function filterCustomNamesByInterface(
+    nameDetailsList: readonly NameDetailsConfig[],
+    interfaceToUse: MochaInterface
+): readonly NameDetailsConfig[] {
+    return nameDetailsList.filter((nameDetails) => {
+        return hasMatchingCustomInterface(nameDetails, interfaceToUse);
     });
 }
 
@@ -58,10 +74,14 @@ function buildAdditionalNameDetailsForInterface(
     additionalNames: readonly CustomNameConfig[],
     interfaceToUse: MochaInterface
 ): readonly NameDetails[] {
-    return interfaceToUse === 'exports'
-        ? buildAdditionalNameDetails(additionalNames)
-        : buildNameDetailsForInterface(additionalNames.map(nameConfigToNameDetails), interfaceToUse);
+    const additionalNameDetails = additionalNames.map(nameConfigToNameDetails);
+
+    return buildAllNameDetailsWithVariants(filterCustomNamesByInterface(additionalNameDetails, interfaceToUse));
 }
+
+export const getAllCustomNameDetails = buildAdditionalNameDetails;
+
+export const getCustomNameDetailsForInterface = buildAdditionalNameDetailsForInterface;
 
 export function getAllNames(
     additionalNames: readonly CustomNameConfig[],
@@ -79,7 +99,7 @@ export function getAllNames(
     return [
         ...builtinNameDetails,
         ...(includeAllInterfaces
-            ? buildAdditionalNameDetails(additionalNames)
-            : buildAdditionalNameDetailsForInterface(additionalNames, interfaceToUse))
+            ? getAllCustomNameDetails(additionalNames)
+            : getCustomNameDetailsForInterface(additionalNames, interfaceToUse))
     ];
 }

--- a/source/rules/no-exclusive-tests.test.ts
+++ b/source/rules/no-exclusive-tests.test.ts
@@ -76,6 +76,14 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 sourceType: 'module'
             },
             settings: { mocha: { interface: 'BDD' } }
+        },
+        {
+            code: 'import { it } from "../helpers.js"; it.only()',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            settings: { mocha: { interface: 'exports' } }
         }
     ],
 
@@ -358,6 +366,25 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 column: 7,
                 line: 1,
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'a.b.c()' }]
+            }]
+        },
+        {
+            code: 'import { custom } from "../helpers.js"; custom.only()',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            settings: {
+                'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'exports' }]
+            },
+            errors: [{
+                message: expectedErrorMessage,
+                column: 48,
+                line: 1,
+                suggestions: [{
+                    messageId: 'removeExclusiveModifier',
+                    output: 'import { custom } from "../helpers.js"; custom()'
+                }]
             }]
         }
     ]


### PR DESCRIPTION
Fixes #398.

Allows `mocha/additionalCustomNames` entries with `interface: "exports"` to resolve named imports from helper modules, adds regression coverage, and documents the setting briefly.