### PR TITLE
Declare rules as JS-only

### DIFF
--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -54,6 +54,12 @@ describe('eslint-plugin-mocha', function () {
         }
     });
 
+    it('should declare all rules as js-only', function () {
+        for (const rule of Object.values(plugin.rules)) {
+            assert.deepStrictEqual(rule.meta?.languages, ['js/js']);
+        }
+    });
+
     describe('documentation', function () {
         it('should have each rule documented', async function () {
             const ruleFiles = await determineAllRuleFiles();

--- a/source/rules/consistent-interface.ts
+++ b/source/rules/consistent-interface.ts
@@ -288,6 +288,7 @@ export function reportUnexpectedImportBindingsInModule(
 export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Enforces consistent use of mocha interfaces',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/consistent-interface.md'

--- a/source/rules/consistent-spacing-between-blocks.ts
+++ b/source/rules/consistent-spacing-between-blocks.ts
@@ -105,6 +105,7 @@ function getSpacingCheck(
 export const consistentSpacingBetweenBlocksRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         fixable: 'whitespace',
         schema: [],
         messages: {

--- a/source/rules/handle-done-callback.ts
+++ b/source/rules/handle-done-callback.ts
@@ -30,6 +30,7 @@ export function findParamInScope(
 export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Enforces handling of callbacks for async tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/handle-done-callback.md'

--- a/source/rules/max-top-level-suites.ts
+++ b/source/rules/max-top-level-suites.ts
@@ -24,6 +24,7 @@ function isTopLevelScope(scope: Readonly<Scope.Scope>): boolean {
 export const maxTopLevelSuitesRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Enforce the number of top-level suites in a single file',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/max-top-level-suites.md'

--- a/source/rules/no-async-suite.ts
+++ b/source/rules/no-async-suite.ts
@@ -93,6 +93,7 @@ export function fixAsyncFunction(
 export const noAsyncSuiteRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow async functions passed to a suite',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-suite.md'

--- a/source/rules/no-empty-title.ts
+++ b/source/rules/no-empty-title.ts
@@ -59,6 +59,7 @@ function isValidDescriptionArgumentNode(node: Except<Rule.Node, 'parent'> | unde
 export const noEmptyTitleRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow empty test descriptions',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-empty-title.md'

--- a/source/rules/no-exclusive-tests.ts
+++ b/source/rules/no-exclusive-tests.ts
@@ -5,6 +5,7 @@ import type { CallExpression, MemberExpression } from '../ast/node-types.js';
 export const noExclusiveTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow exclusive tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-exclusive-tests.md'

--- a/source/rules/no-exports.ts
+++ b/source/rules/no-exports.ts
@@ -11,6 +11,7 @@ export const noExportsRule: Readonly<Rule.RuleModule> = {
             unexpectedExport: 'Unexpected export from a test file'
         },
         type: 'suggestion',
+        languages: ['js/js'],
         schema: []
     },
     create(context) {

--- a/source/rules/no-global-tests.ts
+++ b/source/rules/no-global-tests.ts
@@ -8,6 +8,7 @@ function isGlobalScope(scope: Readonly<Scope.Scope>): boolean {
 export const noGlobalTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow global tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-global-tests.md'

--- a/source/rules/no-hooks-for-single-case.ts
+++ b/source/rules/no-hooks-for-single-case.ts
@@ -49,6 +49,7 @@ function ensureEndsWithParens(value: unknown): string {
 export const noHooksForSingleCaseRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow hooks for a single test or test suite',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-hooks-for-single-case.md'

--- a/source/rules/no-hooks.ts
+++ b/source/rules/no-hooks.ts
@@ -33,6 +33,7 @@ function ensureEndsWithParens(value: unknown): string {
 export const noHooksRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow hooks',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-hooks.md'

--- a/source/rules/no-identical-title.ts
+++ b/source/rules/no-identical-title.ts
@@ -29,6 +29,7 @@ export function extractTitleArgument(node: Readonly<Rule.Node>): string | null {
 export const noIdenticalTitleRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow identical titles',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-identical-title.md'

--- a/source/rules/no-mocha-arrows.ts
+++ b/source/rules/no-mocha-arrows.ts
@@ -71,6 +71,7 @@ function fixArrowFunction(
 export const noMochaArrowsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow arrow functions as arguments to mocha functions',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-mocha-arrows.md'

--- a/source/rules/no-nested-tests.ts
+++ b/source/rules/no-nested-tests.ts
@@ -4,6 +4,7 @@ import { createMochaVisitors } from '../ast/mocha-visitors.js';
 export const noNestedTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow tests to be nested within other tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-nested-tests.md'

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -55,6 +55,7 @@ export function checkPendingSuite(
 export const noPendingTestsRule: Rule.RuleModule = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow pending tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-pending-tests.md'

--- a/source/rules/no-return-and-callback.ts
+++ b/source/rules/no-return-and-callback.ts
@@ -63,6 +63,7 @@ export function checkNodeForReturnAndCallback(context: Readonly<Rule.RuleContext
 export const noReturnAndCallbackRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow returning in a test or hook function that uses a callback',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-return-and-callback.md'

--- a/source/rules/no-return-from-async.ts
+++ b/source/rules/no-return-from-async.ts
@@ -54,6 +54,7 @@ export function checkNodeForReturnFromAsync(context: Readonly<Rule.RuleContext>,
 export const noReturnFromAsyncRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow returning from an async test or hook',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-return-from-async.md'

--- a/source/rules/no-setup-in-describe.ts
+++ b/source/rules/no-setup-in-describe.ts
@@ -33,6 +33,7 @@ function reportMemberExpression(
 export const noSetupInDescribeRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow setup in describe blocks',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-setup-in-describe.md'

--- a/source/rules/no-sibling-hooks.ts
+++ b/source/rules/no-sibling-hooks.ts
@@ -17,6 +17,7 @@ function createNewLayer(node: Except<Rule.Node, 'parent'>): Readonly<Layer> {
 export const noSiblingHooksRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow duplicate uses of a hook at the same level inside a suite',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-sibling-hooks.md'

--- a/source/rules/no-synchronous-tests.ts
+++ b/source/rules/no-synchronous-tests.ts
@@ -71,6 +71,7 @@ const asyncChecksByMethod = {
 export const noSynchronousTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow synchronous tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-synchronous-tests.md'

--- a/source/rules/no-top-level-hooks.ts
+++ b/source/rules/no-top-level-hooks.ts
@@ -4,6 +4,7 @@ import { createMochaVisitors } from '../ast/mocha-visitors.js';
 export const noTopLevelHooksRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
+        languages: ['js/js'],
         docs: {
             description: 'Disallow top-level hooks',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-top-level-hooks.md'

--- a/source/rules/prefer-arrow-callback.additional.test.ts
+++ b/source/rules/prefer-arrow-callback.additional.test.ts
@@ -62,6 +62,7 @@ describe('prefer-arrow-callback rule wrapper', function () {
 
             assert.deepStrictEqual(preferArrowCallbackRule.meta, {
                 type: 'suggestion',
+                languages: ['js/js'],
                 docs: {
                     description: 'Require using arrow functions for callbacks',
                     recommended: false,

--- a/source/rules/prefer-arrow-callback.ts
+++ b/source/rules/prefer-arrow-callback.ts
@@ -47,6 +47,7 @@ function createCoreContext(
 export const preferArrowCallbackRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: coreRule.meta?.type ?? 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: coreRule.meta?.docs?.description ?? 'Require using arrow functions for callbacks',
             recommended: false,

--- a/source/rules/valid-suite-title.ts
+++ b/source/rules/valid-suite-title.ts
@@ -36,6 +36,7 @@ function objectOptions(options: Readonly<ResolvedOption>): Readonly<NormalizedOp
 export const validSuiteTitleRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Require suite descriptions to match a pre-configured regular expression',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/valid-suite-title.md'

--- a/source/rules/valid-test-title.ts
+++ b/source/rules/valid-test-title.ts
@@ -36,6 +36,7 @@ function objectOptions(options: Readonly<ResolvedOption>): Readonly<NormalizedOp
 export const validTestTitleRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
+        languages: ['js/js'],
         docs: {
             description: 'Require test descriptions to match a pre-configured regular expression',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/valid-test-title.md'


### PR DESCRIPTION
## Summary
- declare every rule as JS-only with `meta.languages: ["js/js"]`
- add a plugin-level test that asserts all rules expose that language metadata
- make the JS-only behavior explicit instead of letting misconfigured non-JS usage fail later during rule execution

Fixes #390.

## Verification
- npm run eslint
- npm run test:unit
