### PR TITLE
Prevent duplicate CI runs for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [opened, reopened, synchronize]
 
 jobs:
     build:


### PR DESCRIPTION
This changes CI to run push only on main and use pull_request for pull request updates, which avoids running the same workflow twice for the same pull request commit. It also adds workflow concurrency so outdated pull requests runs are cancelled when new commits are pushed.