### PR TITLE
Don’t flag usage of non-configured mocha interface methods

### DIFF
--- a/source/ast/mocha-visitors.ts
+++ b/source/ast/mocha-visitors.ts
@@ -323,11 +323,19 @@ const cachedCalls = new Map<
     WeakMap<SourceCode, Readonly<WeakMap<Rule.Node, Readonly<CachedMochaCall>>>>
 >();
 
+type CreateMochaVisitorOptions = {
+    readonly includeAllInterfaces?: boolean;
+};
+
 // eslint-disable-next-line max-statements -- caching with two cache keys, requires weird dance of statements
 function findCallsCached(
-    context: Readonly<Rule.RuleContext>
+    context: Readonly<Rule.RuleContext>,
+    options: Readonly<CreateMochaVisitorOptions>
 ): Readonly<WeakMap<Rule.Node, Readonly<CachedMochaCall>>> {
-    const settingsCacheKey = JSON.stringify(context.settings);
+    const settingsCacheKey = JSON.stringify({
+        settings: context.settings,
+        includeAllInterfaces: options.includeAllInterfaces === true
+    });
     let callsPerSettings = cachedCalls.get(settingsCacheKey);
     if (callsPerSettings === undefined) {
         callsPerSettings = new WeakMap();
@@ -339,7 +347,7 @@ function findCallsCached(
     if (cachedMochaCallsByNode === undefined) {
         const additionalCustomNames = getAdditionalNames(context.settings);
         const interfaceToUse = getInterface(context.settings);
-        const names = getAllNames(additionalCustomNames);
+        const names = getAllNames(additionalCustomNames, interfaceToUse, options.includeAllInterfaces === true);
         const calls = findMochaVariableCalls(context, names, interfaceToUse);
 
         cachedMochaCallsByNode = createMochaCallCache(calls);
@@ -522,10 +530,11 @@ function createSpecificVisitors(
 
 export function createMochaVisitors(
     context: Readonly<Rule.RuleContext>,
-    visitors: Readonly<MochaVisitors>
+    visitors: Readonly<MochaVisitors>,
+    options: Readonly<CreateMochaVisitorOptions> = {}
 ): Readonly<Rule.RuleListener> {
     const splitVisitors = splitMochaVisitors(visitors);
-    const cachedMochaCallsByNode = findCallsCached(context);
+    const cachedMochaCallsByNode = findCallsCached(context, options);
 
     return {
         ...splitVisitors.genericVisitors,

--- a/source/mocha-interface-test-cases.test.ts
+++ b/source/mocha-interface-test-cases.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { withInterface } from './mocha-interface-test-cases.js';
+
+describe('mocha-interface-test-cases', function () {
+    it('adds interface settings to string test cases', function () {
+        const result = withInterface('TDD', 'test()');
+
+        assert.deepStrictEqual(result, {
+            code: 'test()',
+            settings: {
+                'mocha/interface': 'TDD',
+                mocha: {
+                    interface: 'TDD'
+                }
+            }
+        });
+    });
+
+    it('merges interface settings into object test cases', function () {
+        const result = withInterface('BDD', {
+            code: 'describe()',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'suite', interface: 'BDD' }]
+                },
+                foo: 'bar'
+            }
+        });
+
+        assert.deepStrictEqual(result, {
+            code: 'describe()',
+            settings: {
+                'mocha/interface': 'BDD',
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'suite', interface: 'BDD' }],
+                    interface: 'BDD'
+                },
+                foo: 'bar'
+            }
+        });
+    });
+});

--- a/source/mocha-interface-test-cases.ts
+++ b/source/mocha-interface-test-cases.ts
@@ -1,0 +1,40 @@
+import type { RuleTester } from 'eslint';
+import type { MochaInterface } from './mocha/descriptors.js';
+import { isRecord } from './record.js';
+
+type RuleTestCase = RuleTester.InvalidTestCase | RuleTester.ValidTestCase;
+
+function mergeMochaInterfaceIntoSettings(
+    settings: Record<string, unknown> | undefined,
+    interfaceToUse: MochaInterface
+): Record<string, unknown> {
+    const mochaSettings = isRecord(settings?.mocha)
+        ? settings.mocha
+        : {};
+
+    return {
+        ...settings,
+        'mocha/interface': interfaceToUse,
+        mocha: {
+            ...mochaSettings,
+            interface: interfaceToUse
+        }
+    };
+}
+
+export function withInterface(interfaceToUse: MochaInterface, testCase: string): RuleTester.ValidTestCase;
+export function withInterface<T extends RuleTestCase>(interfaceToUse: MochaInterface, testCase: T): T;
+export function withInterface(
+    interfaceToUse: MochaInterface,
+    testCase: RuleTestCase | string
+): RuleTestCase {
+    const normalizedTestCase = typeof testCase === 'string'
+        ? { code: testCase }
+        : testCase;
+    const testCaseWithInterface: typeof normalizedTestCase = {
+        ...normalizedTestCase,
+        settings: mergeMochaInterfaceIntoSettings(normalizedTestCase.settings, interfaceToUse)
+    };
+
+    return testCaseWithInterface;
+}

--- a/source/mocha/all-name-details.test.ts
+++ b/source/mocha/all-name-details.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert';
+import { getAllNames } from './all-name-details.js';
+
+describe('all-name-details', function () {
+    it('includes custom names for the exports interface', function () {
+        const names = getAllNames([
+            { name: 'custom', type: 'suite', interface: 'BDD' }
+        ], 'exports');
+
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'custom';
+        }));
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'custom.only';
+        }));
+    });
+
+    it('filters custom names by the configured interface', function () {
+        const names = getAllNames([
+            { name: 'custom', type: 'suite', interface: 'BDD' },
+            { name: 'customTdd', type: 'suite', interface: 'TDD' }
+        ], 'BDD');
+
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'custom';
+        }));
+        assert.ok(
+            !names.some((nameDetails) => {
+                return nameDetails.path.join('.') === 'customTdd';
+            })
+        );
+    });
+
+    it('can include all interfaces regardless of the configured interface', function () {
+        const names = getAllNames([], 'BDD', true);
+
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'before';
+        }));
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'setup';
+        }));
+    });
+
+    it('includes custom names when all interfaces are enabled', function () {
+        const names = getAllNames(
+            [
+                { name: 'custom', type: 'suite', interface: 'BDD' }
+            ],
+            'BDD',
+            true
+        );
+
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'custom';
+        }));
+        assert.ok(names.some((nameDetails) => {
+            return nameDetails.path.join('.') === 'custom.only';
+        }));
+    });
+});

--- a/source/mocha/all-name-details.ts
+++ b/source/mocha/all-name-details.ts
@@ -1,4 +1,9 @@
-import { builtinNames, type CustomMochaEntityType, type NameDetailsConfig } from './descriptors.js';
+import {
+    builtinNames,
+    type CustomMochaEntityType,
+    type MochaInterface,
+    type NameDetailsConfig
+} from './descriptors.js';
 import { buildAllNameDetailsWithVariants, type NameDetails } from './name-details.js';
 import { convertNameToPathArray } from './path.js';
 
@@ -14,13 +19,67 @@ function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readon
 
 const builtinNameDetailsList = buildAllNameDetailsWithVariants(builtinNames);
 
-export function getAllNames(additionalNames: readonly CustomNameConfig[]): readonly NameDetails[] {
+function hasMatchingInterface(
+    nameDetails: Readonly<NameDetailsConfig>,
+    interfaceToUse: MochaInterface
+): boolean {
+    return interfaceToUse === 'exports' || nameDetails.interface === interfaceToUse;
+}
+
+function filterByInterface(
+    nameDetailsList: readonly NameDetailsConfig[],
+    interfaceToUse: MochaInterface
+): readonly NameDetailsConfig[] {
+    return nameDetailsList.filter((nameDetails) => {
+        return hasMatchingInterface(nameDetails, interfaceToUse);
+    });
+}
+
+function buildNameDetailsForInterface(
+    nameDetailsList: readonly NameDetailsConfig[],
+    interfaceToUse: MochaInterface
+): readonly NameDetails[] {
+    return buildAllNameDetailsWithVariants(filterByInterface(nameDetailsList, interfaceToUse));
+}
+
+function getBuiltinNameDetailsForInterface(interfaceToUse: MochaInterface): readonly NameDetails[] {
+    return interfaceToUse === 'exports'
+        ? builtinNameDetailsList
+        : buildNameDetailsForInterface(builtinNames, interfaceToUse);
+}
+
+function buildAdditionalNameDetails(additionalNames: readonly CustomNameConfig[]): readonly NameDetails[] {
+    const additionalNameDetails = additionalNames.map(nameConfigToNameDetails);
+
+    return buildAllNameDetailsWithVariants(additionalNameDetails);
+}
+
+function buildAdditionalNameDetailsForInterface(
+    additionalNames: readonly CustomNameConfig[],
+    interfaceToUse: MochaInterface
+): readonly NameDetails[] {
+    return interfaceToUse === 'exports'
+        ? buildAdditionalNameDetails(additionalNames)
+        : buildNameDetailsForInterface(additionalNames.map(nameConfigToNameDetails), interfaceToUse);
+}
+
+export function getAllNames(
+    additionalNames: readonly CustomNameConfig[],
+    interfaceToUse: MochaInterface,
+    includeAllInterfaces = false
+): readonly NameDetails[] {
+    const builtinNameDetails = includeAllInterfaces
+        ? builtinNameDetailsList
+        : getBuiltinNameDetailsForInterface(interfaceToUse);
+
     if (additionalNames.length === 0) {
-        return builtinNameDetailsList;
+        return builtinNameDetails;
     }
 
     return [
-        ...builtinNameDetailsList,
-        ...buildAllNameDetailsWithVariants(additionalNames.map(nameConfigToNameDetails))
+        ...builtinNameDetails,
+        ...(includeAllInterfaces
+            ? buildAdditionalNameDetails(additionalNames)
+            : buildAdditionalNameDetailsForInterface(additionalNames, interfaceToUse))
     ];
 }

--- a/source/rules/consistent-interface.ts
+++ b/source/rules/consistent-interface.ts
@@ -323,6 +323,8 @@ export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
                         );
                     }
                 }
+            }, {
+                includeAllInterfaces: true
             })
         };
     }

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -1,5 +1,6 @@
 import { RuleTester, type Scope } from 'eslint';
 import assert from 'node:assert';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { findParamInScope, handleDoneCallbackRule } from './handle-done-callback.js';
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 
@@ -20,8 +21,8 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         'it("", function (done) { done(new Error("foo")); });',
         'it("", function (done) { promise.then(done).catch(done); });',
         'it.only("", function (done) { done(); });',
-        'test("", function (done) { done(); });',
-        'test.only("", function (done) { done(); });',
+        withInterface('TDD', 'test("", function (done) { done(); });'),
+        withInterface('TDD', 'test.only("", function (done) { done(); });'),
         'before(function (done) { done(); });',
         'after(function (done) { done(); });',
         'beforeEach(function (done) { done(); });',
@@ -66,14 +67,14 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
             code: 'it.only("", function (done) { });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 23, line: 1 }]
         },
-        {
+        withInterface('TDD', {
             code: 'test("", function (done) { });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 20, line: 1 }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test.only("", function (done) { });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 25, line: 1 }]
-        },
+        }),
         {
             code: 'specify("", function (done) { });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 23, line: 1 }]

--- a/source/rules/max-top-level-suites.test.ts
+++ b/source/rules/max-top-level-suites.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { maxTopLevelSuitesRule } from './max-top-level-suites.js';
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 
@@ -10,18 +11,18 @@ ruleTester.run('max-top-level-suites', maxTopLevelSuitesRule, {
         {
             code: 'context("This is a test", function () { });'
         },
-        {
+        withInterface('TDD', {
             code: 'suite("This is a test", function () { });'
-        },
+        }),
         {
             code: 'describe("This is a test", function () { describe("This is a different test", function () { }) });'
         },
         {
             code: 'context("This is a test", function () { context("This is a different test", function () { }) });'
         },
-        {
+        withInterface('TDD', {
             code: 'suite("This is a test", function () { suite("This is a different test", function () { }) });'
-        },
+        }),
         {
             options: [{ limit: 2 }],
             code: 'describe("This is a test", function () { });'
@@ -140,21 +141,15 @@ ruleTester.run('max-top-level-suites', maxTopLevelSuitesRule, {
                 { message: 'The number of top-level suites is more than 1.' }
             ]
         },
-        {
+        withInterface('TDD', {
             code: 'suite("this is a test", function () { });' +
                 'suite("this is a different test", function () { });',
             errors: [
                 { message: 'The number of top-level suites is more than 1.' }
             ]
-        },
+        }),
         {
             code: 'describe("this is a test", function () { }); context("this is a test", function () { });',
-            errors: [
-                { message: 'The number of top-level suites is more than 1.' }
-            ]
-        },
-        {
-            code: 'suite("this is a test", function () { }); context("this is a test", function () { });',
             errors: [
                 { message: 'The number of top-level suites is more than 1.' }
             ]
@@ -193,7 +188,7 @@ ruleTester.run('max-top-level-suites', maxTopLevelSuitesRule, {
                 { message: 'The number of top-level suites is more than 1.' }
             ]
         },
-        {
+        withInterface('TDD', {
             options: [{ limit: 2 }],
             code: 'suite.skip("this is a test", function () { });' +
                 'suite.only("this is a different test", function () { });' +
@@ -201,7 +196,7 @@ ruleTester.run('max-top-level-suites', maxTopLevelSuitesRule, {
             errors: [
                 { message: 'The number of top-level suites is more than 2.' }
             ]
-        },
+        }),
         {
             options: [{ limit: 2 }],
             code: 'context.skip("this is a test", function () { });' +

--- a/source/rules/no-empty-title.test.ts
+++ b/source/rules/no-empty-title.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { noEmptyTitleRule } from './no-empty-title.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -20,13 +21,13 @@ ruleTester.run('no-empty-title', noEmptyTitleRule, {
         'it.only("some text")',
         'it("some text", function() { })',
 
-        'suite("some text")',
-        'suite.only("some text")',
-        'suite("some text", function() { })',
+        withInterface('TDD', 'suite("some text")'),
+        withInterface('TDD', 'suite.only("some text")'),
+        withInterface('TDD', 'suite("some text", function() { })'),
 
-        'test("some text")',
-        'test.only("some text")',
-        'test("some text", function() { })',
+        withInterface('TDD', 'test("some text")'),
+        withInterface('TDD', 'test.only("some text")'),
+        withInterface('TDD', 'test("some text", function() { })'),
 
         'var dynamicTitle = "foo"; it(dynamicTitle, function() {});',
         'it(dynamicTitle, function() {});',
@@ -94,22 +95,22 @@ ruleTester.run('no-empty-title', noEmptyTitleRule, {
     ],
 
     invalid: [
-        {
+        withInterface('TDD', {
             code: 'test()',
             errors: [{ message: defaultErrorMessage, ...firstLine }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test(function() { })',
             errors: [{ message: defaultErrorMessage, ...firstLine }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test("", function() { })',
             errors: [{ message: defaultErrorMessage, ...firstLine }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test("      ", function() { })',
             errors: [{ message: defaultErrorMessage, ...firstLine }]
-        },
+        }),
 
         {
             options: [{ message: 'Custom Error' }],

--- a/source/rules/no-exclusive-tests.test.ts
+++ b/source/rules/no-exclusive-tests.test.ts
@@ -1,5 +1,6 @@
 import { type Rule, RuleTester, type SourceCode } from 'eslint';
 import assert from 'node:assert';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import {
     createExclusiveTestReportDescriptor,
     fixExclusiveTest,
@@ -32,15 +33,15 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
         'it()',
         'describe.skip()',
         'it.skip()',
-        'suite()',
-        'test()',
-        'suite.skip()',
-        'test.skip()',
+        withInterface('TDD', 'suite()'),
+        withInterface('TDD', 'test()'),
+        withInterface('TDD', 'suite.skip()'),
+        withInterface('TDD', 'test.skip()'),
         'context()',
         'context.skip()',
         'var appliedOnly = describe.only; appliedOnly.apply(describe)',
         'var calledOnly = it.only; calledOnly.call(it)',
-        'var dynamicOnly = "onl"; dynamicOnly += "y"; suite[dynamicOnly]()',
+        withInterface('TDD', 'var dynamicOnly = "onl"; dynamicOnly += "y"; suite[dynamicOnly]()'),
         'function foo() { var it; it.only(); }',
         'specify()',
         'specify.skip()',
@@ -165,7 +166,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'it()' }]
             }]
         },
-        {
+        withInterface('TDD', {
             code: 'suite.only()',
             errors: [{
                 message: expectedErrorMessage,
@@ -173,8 +174,8 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'suite()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'suite["only"]()',
             errors: [{
                 message: expectedErrorMessage,
@@ -182,8 +183,8 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'suite()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test.only()',
             errors: [{
                 message: expectedErrorMessage,
@@ -191,8 +192,8 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'test()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test["only"]()',
             errors: [{
                 message: expectedErrorMessage,
@@ -200,7 +201,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removeExclusiveModifier', output: 'test()' }]
             }]
-        },
+        }),
         {
             code: 'context.only()',
             errors: [{

--- a/source/rules/no-global-tests.test.ts
+++ b/source/rules/no-global-tests.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { noGlobalTestsRule } from './no-global-tests.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -7,7 +8,7 @@ const expectedErrorMessage = 'Unexpected global mocha test.';
 ruleTester.run('no-global-tests', noGlobalTestsRule, {
     valid: [
         'describe();',
-        'suite();',
+        withInterface('TDD', 'suite();'),
         'context();',
         'describe("", function () { it(); });',
         'describe("", function () { it.only(); });',
@@ -17,10 +18,10 @@ ruleTester.run('no-global-tests', noGlobalTestsRule, {
         'describe("", function () { test.skip(); });',
         'describe.only("", function () { it(); });',
         'describe.skip("", function () { it(); });',
-        'suite("", function () { it(); });',
-        'suite("", function () { test(); });',
-        'suite.only("", function () { it(); });',
-        'suite.skip("", function () { it(); });',
+        withInterface('TDD', 'suite("", function () { it(); });'),
+        withInterface('TDD', 'suite("", function () { test(); });'),
+        withInterface('TDD', 'suite.only("", function () { it(); });'),
+        withInterface('TDD', 'suite.skip("", function () { it(); });'),
         'context("", function () { it(); });',
         'context("", function () { test(); });',
         'context.only("", function () { it(); });',
@@ -59,26 +60,26 @@ ruleTester.run('no-global-tests', noGlobalTestsRule, {
             code: 'it["skip"]();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
-        {
+        withInterface('TDD', {
             code: 'test();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test.only();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test["only"]();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test.skip();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test["skip"]();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
+        }),
         {
             code: 'specify();',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]

--- a/source/rules/no-nested-tests.test.ts
+++ b/source/rules/no-nested-tests.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { noNestedTestsRule } from './no-nested-tests.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -44,14 +45,14 @@ ruleTester.run('no-nested-tests', noNestedTestsRule, {
                 column: 27
             }]
         },
-        {
-            code: 'test("", function () { it() });',
+        withInterface('TDD', {
+            code: 'test("", function () { test() });',
             errors: [{
                 message: 'Unexpected test nested within another test.',
                 line: 1,
                 column: 24
             }]
-        },
+        }),
         {
             code: 'specify("", function () { it() });',
             errors: [{
@@ -76,14 +77,14 @@ ruleTester.run('no-nested-tests', noNestedTestsRule, {
                 column: 22
             }]
         },
-        {
-            code: 'it("", function () { suite() });',
+        withInterface('TDD', {
+            code: 'test("", function () { suite() });',
             errors: [{
                 message: 'Unexpected suite nested within a test.',
                 line: 1,
-                column: 22
+                column: 24
             }]
-        },
+        }),
         {
             code: 'it("", function () { describe.skip() });',
             errors: [{

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -1,5 +1,6 @@
 import { type Rule, RuleTester, type SourceCode } from 'eslint';
 import assert from 'node:assert';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import {
     checkPendingSuite,
     checkPendingTestCase,
@@ -35,8 +36,8 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
     valid: [
         'it()',
         'it("should be false", function() { assert(something, false); })',
-        'test()',
-        'test("should be false", function() { assert(something, false); })',
+        withInterface('TDD', 'test()'),
+        withInterface('TDD', 'test("should be false", function() { assert(something, false); })'),
         'specify()',
         'specify("should be false", function() { assert(something, false); })',
         'something.it()',
@@ -44,14 +45,14 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         'describe()',
         'describe.only()',
         'it.only()',
-        'suite()',
-        'suite.only()',
-        'test.only()',
+        withInterface('TDD', 'suite()'),
+        withInterface('TDD', 'suite.only()'),
+        withInterface('TDD', 'test.only()'),
         'context()',
         'context.only()',
         'var appliedOnly = describe.skip; appliedOnly.apply(describe)',
         'var calledOnly = it.skip; calledOnly.call(it)',
-        'var dynamicOnly = "ski"; dynamicOnly += String.fromCharCode(112); suite[dynamicOnly]()',
+        withInterface('TDD', 'var dynamicOnly = "ski"; dynamicOnly += String.fromCharCode(112); suite[dynamicOnly]()'),
         {
             code: 'xcustom()',
             settings: {
@@ -67,10 +68,10 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
             code: 'it("is pending")',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
-        {
+        withInterface('TDD', {
             code: 'test("is pending")',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
-        },
+        }),
         {
             code: 'specify("is pending")',
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
@@ -129,7 +130,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 suggestions: [{ messageId: 'removePendingModifier', output: 'it()' }]
             }]
         },
-        {
+        withInterface('TDD', {
             code: 'suite.skip()',
             errors: [{
                 message: expectedErrorMessage,
@@ -137,8 +138,8 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removePendingModifier', output: 'suite()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'suite["skip"]()',
             errors: [{
                 message: expectedErrorMessage,
@@ -146,8 +147,8 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removePendingModifier', output: 'suite()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test.skip()',
             errors: [{
                 message: expectedErrorMessage,
@@ -155,8 +156,8 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removePendingModifier', output: 'test()' }]
             }]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'test["skip"]()',
             errors: [{
                 message: expectedErrorMessage,
@@ -164,7 +165,7 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 line: 1,
                 suggestions: [{ messageId: 'removePendingModifier', output: 'test()' }]
             }]
-        },
+        }),
         {
             code: 'context.skip()',
             errors: [{
@@ -288,10 +289,10 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
             }]
         },
-        {
+        withInterface('TDD', {
             code: 'var dynamicOnly = "skip"; suite[dynamicOnly]()',
             errors: [{ message: expectedErrorMessage, column: 33, line: 1 }]
-        }
+        })
     ]
 });
 

--- a/source/rules/no-setup-in-describe.test.ts
+++ b/source/rules/no-setup-in-describe.test.ts
@@ -1,5 +1,6 @@
 import { type Rule, RuleTester } from 'eslint';
 import assert from 'node:assert';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { noSetupInDescribeRule } from './no-setup-in-describe.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -46,10 +47,10 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
         'describe("", () => { after(function() {}).timeout(10_000); });',
         'describe("", () => { beforeEach(function() {}).timeout(10_000); });',
         'describe("", () => { afterEach(function() {}).timeout(10_000); });',
-        'suite("", function () { teardown(function() { b(); }); test(); })',
-        'suite("", function () { suiteTeardown(function() { b(); }); test(); })',
-        'suite("", function () { setup(function() { b(); }); test(); })',
-        'suite("", function () { suiteSetup(function() { b(); }); test(); })',
+        withInterface('TDD', 'suite("", function () { teardown(function() { b(); }); test(); })'),
+        withInterface('TDD', 'suite("", function () { suiteTeardown(function() { b(); }); test(); })'),
+        withInterface('TDD', 'suite("", function () { setup(function() { b(); }); test(); })'),
+        withInterface('TDD', 'suite("", function () { suiteSetup(function() { b(); }); test(); })'),
         {
             code: 'describe("", function () { before(() => { b(); }); it(); })',
             languageOptions: { ecmaVersion: 6 }
@@ -126,7 +127,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
     ],
 
     invalid: [
-        {
+        withInterface('TDD', {
             code: 'suite("", function () { this.timeout(42); a(); });',
             errors: [
                 {
@@ -135,8 +136,8 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
                     column: 43
                 }
             ]
-        },
-        {
+        }),
+        withInterface('TDD', {
             code: 'suite("", function () { a(); });',
             errors: [
                 {
@@ -145,7 +146,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
                     column: 25
                 }
             ]
-        },
+        }),
         {
             code: 'describe("", function () { a(); });',
             errors: [

--- a/source/rules/no-sibling-hooks.test.ts
+++ b/source/rules/no-sibling-hooks.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { noSiblingHooksRule } from './no-sibling-hooks.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -180,7 +181,8 @@ ruleTester.run('no-sibling-hooks', noSiblingHooksRule, {
                     ]
                 }
             }
-        }
+        },
+        withInterface('BDD', 'describe(function() { setup(function() {}); setup(function() {}); });')
     ],
 
     invalid: [
@@ -200,6 +202,10 @@ ruleTester.run('no-sibling-hooks', noSiblingHooksRule, {
             code: 'describe(function() { afterEach(function() {}); afterEach(function() {}); });',
             errors: [{ message: 'Unexpected use of duplicate Mocha `afterEach()` hook', column: 49, line: 1 }]
         },
+        withInterface('TDD', {
+            code: 'describe(function() { setup(function() {}); setup(function() {}); });',
+            errors: [{ message: 'Unexpected use of duplicate Mocha `setup()` hook', column: 45, line: 1 }]
+        }),
         {
             code: [
                 'describe(function() {',

--- a/source/rules/prefer-arrow-callback.test.ts
+++ b/source/rules/prefer-arrow-callback.test.ts
@@ -9,6 +9,7 @@
 // ------------------------------------------------------------------------------
 
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { preferArrowCallbackRule } from './prefer-arrow-callback.js';
 
 const ruleTester = new RuleTester({
@@ -49,16 +50,16 @@ ruleTester.run('prefer-arrow-callback', preferArrowCallbackRule, {
         'xcontext("name", function bar() {});',
         'context.only("name", function bar() {});',
         'context.skip("name", function bar() {});',
-        'suite("name", function bar() {});',
-        'suite.only("name", function bar() {});',
-        'suite.skip("name", function bar() {});',
+        withInterface('TDD', 'suite("name", function bar() {});'),
+        withInterface('TDD', 'suite.only("name", function bar() {});'),
+        withInterface('TDD', 'suite.skip("name", function bar() {});'),
         'it("name", function bar() {});',
         'it.only("name", function bar() {});',
         'it.skip("name", function bar() {});',
         'xit("name", function bar() {});',
-        'test("name", function bar() {});',
-        'test.only("name", function bar() {});',
-        'test.skip("name", function bar() {});',
+        withInterface('TDD', 'test("name", function bar() {});'),
+        withInterface('TDD', 'test.only("name", function bar() {});'),
+        withInterface('TDD', 'test.skip("name", function bar() {});'),
         'specify("name", function bar() {});',
         'specify.only("name", function bar() {});',
         'specify.skip("name", function bar() {});',

--- a/source/rules/valid-suite-title.test.ts
+++ b/source/rules/valid-suite-title.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { validSuiteTitleRule } from './valid-suite-title.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -13,10 +14,10 @@ ruleTester.run('valid-suite-title', validSuiteTitleRule, {
             options: [{ pattern: '^[A-Z]' }],
             code: 'context("This is a test", function () { });'
         },
-        {
+        withInterface('TDD', {
             options: [{ pattern: '^[A-Z]' }],
             code: 'suite("This is a test", function () { });'
-        },
+        }),
         {
             options: [{ pattern: '^[A-Z]' }],
             settings: {
@@ -67,13 +68,13 @@ ruleTester.run('valid-suite-title', validSuiteTitleRule, {
                 { message: 'Invalid "context()" description found.' }
             ]
         },
-        {
+        withInterface('TDD', {
             options: [{ pattern: '^[A-Z]' }],
             code: 'suite("this is a test", function () { });',
             errors: [
                 { message: 'Invalid "suite()" description found.' }
             ]
-        },
+        }),
         {
             options: [{ pattern: '^[A-Z]' }],
             settings: {

--- a/source/rules/valid-test-title.test.ts
+++ b/source/rules/valid-test-title.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
 import { validTestTitleRule } from './valid-test-title.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
@@ -9,15 +10,15 @@ ruleTester.run('valid-test-title', validTestTitleRule, {
         'it("should do something");',
         'specify("should respond to GET", function() { });',
         'specify("should do something");',
-        'test("should respond to GET", function() { });',
-        'test("should do something");',
+        withInterface('TDD', 'test("should respond to GET", function() { });'),
+        withInterface('TDD', 'test("should do something");'),
         'it();',
         'specify();',
-        'test();',
-        {
+        withInterface('TDD', 'test();'),
+        withInterface('TDD', {
             options: [{ pattern: 'test' }],
             code: 'test("this is a test", function () { });'
-        },
+        }),
         {
             options: [{ pattern: '^should' }],
             code: 'someFunction("should do something", function () { });',
@@ -64,12 +65,12 @@ ruleTester.run('valid-test-title', validTestTitleRule, {
                 { message: 'Invalid "specify()" description found.' }
             ]
         },
-        {
+        withInterface('TDD', {
             code: 'test("does something", function() { });',
             errors: [
                 { message: 'Invalid "test()" description found.' }
             ]
-        },
+        }),
         {
             options: [{ pattern: 'required' }],
             code: 'it("this is a test", function () { });',
@@ -84,13 +85,13 @@ ruleTester.run('valid-test-title', validTestTitleRule, {
                 { message: 'Invalid "specify()" description found.' }
             ]
         },
-        {
+        withInterface('TDD', {
             options: [{ pattern: 'required' }],
             code: 'test("this is a test", function () { });',
             errors: [
                 { message: 'Invalid "test()" description found.' }
             ]
-        },
+        }),
         {
             options: [{ pattern: 'required' }],
             code: 'customFunction("this is a test", function () { });',


### PR DESCRIPTION
Respect `settings.mocha.interface` when matching built-in Mocha names so TDD hooks like `setup()` are not reported under the BDD interface.

Fixes #296.