### PR TITLE
Rename named-import interface setting from exports to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default [
 
 These settings are shared by multiple rules.
 
-- `additionalCustomNames`: Adds custom suite, test, or hook function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha), [`mocha-each`](https://github.com/ryym/mocha-each), or project-specific helpers that wrap setup and teardown. Use `interface: "exports"` for wrappers that expose named imports from a helper module instead of importing directly from `mocha`.
+- `additionalCustomNames`: Adds custom suite, test, or hook function names. This is useful for Mocha wrappers such as [`ember-mocha`](https://github.com/switchfly/ember-mocha), [`mocha-each`](https://github.com/ryym/mocha-each), or project-specific helpers that wrap setup and teardown. Use `interface: "require"` for wrappers that expose named imports from a helper module instead of importing directly from `mocha`.
 
 ```json
 {
@@ -101,7 +101,7 @@ forEach([1, 2, 3]).describeModule.modifier("example", function (n) {});
 ```
 
 - `type`: Selects `suite`, `testCase`, or `hook`.
-- `interface`: Selects `BDD`, `TDD`, or `exports`. The default is `BDD`. With `exports`, rule resolution uses named `import` statements instead of globals. `mocha/consistent-interface` also reports named imports of Mocha interface methods when this setting is `BDD` or `TDD`, which helps catch accidental `exports`-style usage and interface misconfiguration earlier.
+- `interface`: Selects `BDD`, `TDD`, or `require`. The default is `BDD`. With `require`, rule resolution uses named `import` statements instead of globals. `mocha/consistent-interface` also reports named imports of Mocha interface methods when this setting is `BDD` or `TDD`, which helps catch accidental `require`-style usage and interface misconfiguration earlier.
 
 ## Rules
 

--- a/documentation/rules/consistent-interface.md
+++ b/documentation/rules/consistent-interface.md
@@ -6,7 +6,7 @@
 
 <!-- end auto-generated rule header -->
 
-Mocha has several interfaces such as `BDD`, `TDD`, `Exports`, `QUnit` etc. Usually Mocha injects the variables and functions of the selected interface into the global scope. When using the `Exports` interface, named imports from `mocha` are used instead. This rule enforces a consistent `BDD` or `TDD` interface for imported Mocha interface methods, and it also reports imported Mocha interface methods when `settings.mocha.interface` is configured for globals.
+Mocha has several interfaces such as `BDD`, `TDD`, `Require`, `Exports`, `QUnit` etc. Usually Mocha injects the variables and functions of the selected interface into the global scope. When using the `Require` interface, named imports from `mocha` are used instead. This rule enforces a consistent `BDD` or `TDD` interface for imported Mocha interface methods, and it also reports imported Mocha interface methods when `settings.mocha.interface` is configured for globals.
 
 ## Options
 
@@ -24,9 +24,9 @@ where:
 
 ## Rule Details
 
-With `settings.mocha.interface: "exports"`, this rule enforces that imported Mocha interface methods all belong to the configured `BDD` or `TDD` interface.
+With `settings.mocha.interface: "require"`, this rule enforces that imported Mocha interface methods all belong to the configured `BDD` or `TDD` interface.
 
-With `settings.mocha.interface: "BDD"` or `settings.mocha.interface: "TDD"`, this rule reports named imports of Mocha interface methods from `mocha`, because those imports indicate `exports`-style usage and can prevent other rules from recognizing Mocha calls.
+With `settings.mocha.interface: "BDD"` or `settings.mocha.interface: "TDD"`, this rule reports named imports of Mocha interface methods from `mocha`, because those imports indicate `require`-style usage and can prevent other rules from recognizing Mocha calls.
 
 The autofix is intentionally limited to direct named imports such as `import { describe } from 'mocha'`. Aliased imports and mixed default imports are still reported, but they are left for manual cleanup.
 

--- a/source/ast/find-mocha-variable-calls.ts
+++ b/source/ast/find-mocha-variable-calls.ts
@@ -113,17 +113,17 @@ function isResultWithConstantPath(result: Readonly<ResolvedReference>): boolean 
 }
 
 type SplitCustomNames = {
-    readonly exports: readonly NameDetails[];
+    readonly require: readonly NameDetails[];
     readonly globals: readonly NameDetails[];
 };
 
 function splitCustomNamesByInterface(customNames: readonly NameDetails[]): Readonly<SplitCustomNames> {
     return {
-        exports: customNames.filter((nameDetails) => {
-            return nameDetails.interface === 'exports';
+        require: customNames.filter((nameDetails) => {
+            return nameDetails.interface === 'require';
         }),
         globals: customNames.filter((nameDetails) => {
-            return nameDetails.interface !== 'exports';
+            return nameDetails.interface !== 'require';
         })
     };
 }
@@ -136,20 +136,20 @@ export function findMochaVariableCalls(
 ): readonly ResolvedReferenceWithNameDetails[] {
     const { sourceCode } = context;
     const builtinNames = getAllNames([], interfaceToUse, includeAllInterfaces);
-    const builtinReferences = interfaceToUse === 'exports'
+    const builtinReferences = interfaceToUse === 'require'
         ? findImportReferencesByName(context, builtinNames, 'mocha')
         : findGlobalReferencesByName(context, builtinNames);
     const customNamesByInterface = splitCustomNamesByInterface(customNames);
-    const customExportReferences = findImportReferencesByName(
+    const customRequireReferences = findImportReferencesByName(
         context,
-        customNamesByInterface.exports,
+        customNamesByInterface.require,
         null
     );
     const customGlobalReferences = findGlobalReferencesByName(context, customNamesByInterface.globals);
 
     const resolvedReferences = resolveAliasedReferences(sourceCode, [
         ...builtinReferences,
-        ...customExportReferences,
+        ...customRequireReferences,
         ...customGlobalReferences
     ]);
 

--- a/source/mocha/all-name-details.test.ts
+++ b/source/mocha/all-name-details.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert';
 import { getAllNames } from './all-name-details.js';
 
 describe('all-name-details', function () {
-    it('includes custom names for the exports interface', function () {
+    it('includes custom names for the require interface', function () {
         const names = getAllNames([
             { name: 'custom', type: 'suite', interface: 'BDD' }
-        ], 'exports');
+        ], 'require');
 
         assert.ok(names.some((nameDetails) => {
             return nameDetails.path.join('.') === 'custom';

--- a/source/mocha/all-name-details.ts
+++ b/source/mocha/all-name-details.ts
@@ -23,14 +23,14 @@ function hasMatchingInterface(
     nameDetails: Readonly<NameDetailsConfig>,
     interfaceToUse: MochaInterface
 ): boolean {
-    return interfaceToUse === 'exports' || nameDetails.interface === interfaceToUse;
+    return interfaceToUse === 'require' || nameDetails.interface === interfaceToUse;
 }
 
 function hasMatchingCustomInterface(
     nameDetails: Readonly<NameDetailsConfig>,
     interfaceToUse: MochaInterface
 ): boolean {
-    return nameDetails.interface === 'exports' || hasMatchingInterface(nameDetails, interfaceToUse);
+    return nameDetails.interface === 'require' || hasMatchingInterface(nameDetails, interfaceToUse);
 }
 
 function filterByInterface(
@@ -59,7 +59,7 @@ function buildNameDetailsForInterface(
 }
 
 function getBuiltinNameDetailsForInterface(interfaceToUse: MochaInterface): readonly NameDetails[] {
-    return interfaceToUse === 'exports'
+    return interfaceToUse === 'require'
         ? builtinNameDetailsList
         : buildNameDetailsForInterface(builtinNames, interfaceToUse);
 }

--- a/source/mocha/descriptors.ts
+++ b/source/mocha/descriptors.ts
@@ -1,7 +1,7 @@
 const mochaInterfaces = [
     'BDD',
     'TDD',
-    'exports'
+    'require'
 ] as const;
 
 export type MochaInterface = (typeof mochaInterfaces)[number];

--- a/source/rules/consistent-interface.test.ts
+++ b/source/rules/consistent-interface.test.ts
@@ -48,21 +48,21 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
                 test('bar', () => {});
             });`,
             options: [{ interface: 'TDD' }],
-            settings: { mocha: { interface: 'exports' } }
+            settings: { mocha: { interface: 'require' } }
         },
         {
             code: `import {describe, it} from 'mocha'; describe('foo', () => {
                 it('bar', () => {});
             });`,
             options: [{ interface: 'BDD' }],
-            settings: { mocha: { interface: 'exports' } }
+            settings: { mocha: { interface: 'require' } }
         },
         {
             code: `import {describe as foo, it as bar} from 'mocha'; foo('foo', () => {
                 bar('bar', () => {});
             });`,
             options: [{ interface: 'BDD' }],
-            settings: { mocha: { interface: 'exports' } }
+            settings: { mocha: { interface: 'require' } }
         },
         {
             code: 'import {run} from "mocha"; run();',
@@ -93,7 +93,7 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
                 test('bar', () => {});
             });`,
             options: [{ interface: 'BDD' }],
-            settings: { mocha: { interface: 'exports' } },
+            settings: { mocha: { interface: 'require' } },
             errors: [
                 { line: 1, column: 36, message: 'Unexpected use of TDD interface instead of BDD' },
                 { line: 2, column: 17, message: 'Unexpected use of TDD interface instead of BDD' }
@@ -104,7 +104,7 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
                 it('bar', () => {});
             });`,
             options: [{ interface: 'TDD' }],
-            settings: { mocha: { interface: 'exports' } },
+            settings: { mocha: { interface: 'require' } },
             errors: [
                 { line: 1, column: 37, message: 'Unexpected use of BDD interface instead of TDD' },
                 { line: 2, column: 17, message: 'Unexpected use of BDD interface instead of TDD' }
@@ -120,8 +120,8 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global BDD' },
-                { message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of require interface instead of global BDD' },
+                { message: 'Unexpected use of require interface instead of global BDD' }
             ]
         },
         {
@@ -134,8 +134,8 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'TDD' }],
             settings: { mocha: { interface: 'TDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global TDD' },
-                { message: 'Unexpected use of exports interface instead of global TDD' }
+                { message: 'Unexpected use of require interface instead of global TDD' },
+                { message: 'Unexpected use of require interface instead of global TDD' }
             ]
         },
         {
@@ -146,8 +146,8 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'TDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global TDD' },
-                { message: 'Unexpected use of exports interface instead of global TDD' }
+                { message: 'Unexpected use of require interface instead of global TDD' },
+                { message: 'Unexpected use of require interface instead of global TDD' }
             ]
         },
         {
@@ -160,8 +160,8 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'TDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global BDD' },
-                { message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of require interface instead of global BDD' },
+                { message: 'Unexpected use of require interface instead of global BDD' }
             ]
         },
         {
@@ -174,7 +174,7 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of require interface instead of global BDD' }
             ]
         },
         {
@@ -183,7 +183,7 @@ ruleTester.run('consistent-interface', consistentInterfaceRule, {
             options: [{ interface: 'BDD' }],
             settings: { mocha: { interface: 'BDD' } },
             errors: [
-                { message: 'Unexpected use of exports interface instead of global BDD' }
+                { message: 'Unexpected use of require interface instead of global BDD' }
             ]
         }
     ]

--- a/source/rules/consistent-interface.ts
+++ b/source/rules/consistent-interface.ts
@@ -232,7 +232,7 @@ export function createUnexpectedImportDescriptor(
             loc,
             messageId: 'unexpectedInterface',
             data: {
-                actualInterface: 'exports',
+                actualInterface: 'require',
                 expectedInterface: `global ${configuredMochaInterface}`
             }
         };
@@ -306,7 +306,7 @@ export const consistentInterfaceRule: Readonly<Rule.RuleModule> = {
 
         return {
             Program() {
-                if (configuredMochaInterface === 'exports') {
+                if (configuredMochaInterface === 'require') {
                     return;
                 }
 

--- a/source/rules/no-exclusive-tests.test.ts
+++ b/source/rules/no-exclusive-tests.test.ts
@@ -83,7 +83,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
-            settings: { mocha: { interface: 'exports' } }
+            settings: { mocha: { interface: 'require' } }
         }
     ],
 
@@ -121,7 +121,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
-            settings: { mocha: { interface: 'exports' } },
+            settings: { mocha: { interface: 'require' } },
             errors: [{
                 message: expectedErrorMessage,
                 column: 32,
@@ -135,7 +135,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
-            settings: { mocha: { interface: 'exports' } },
+            settings: { mocha: { interface: 'require' } },
             errors: [{
                 message: expectedErrorMessage,
                 column: 40,
@@ -152,7 +152,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 ecmaVersion: 2018,
                 sourceType: 'module'
             },
-            settings: { mocha: { interface: 'exports' } },
+            settings: { mocha: { interface: 'require' } },
             errors: [{
                 message: expectedErrorMessage,
                 column: 57,
@@ -375,7 +375,7 @@ ruleTester.run('no-exclusive-tests', noExclusiveTestsRule, {
                 sourceType: 'module'
             },
             settings: {
-                'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'exports' }]
+                'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'require' }]
             },
             errors: [{
                 message: expectedErrorMessage,

--- a/source/settings.test.ts
+++ b/source/settings.test.ts
@@ -114,8 +114,8 @@ describe('settings', function () {
         });
 
         it('returns the given valid interface', function () {
-            const result = getInterface({ 'mocha/interface': 'exports' });
-            assert.strictEqual(result, 'exports');
+            const result = getInterface({ 'mocha/interface': 'require' });
+            assert.strictEqual(result, 'require');
         });
 
         it('returns the given valid nested interface', function () {


### PR DESCRIPTION
Shame on me: somehow I confused the interface naming and mixed up `exports` with `require`.

The Mocha `exports` interface is the `module.exports` based UI. The named-import UI, where tests import `describe`, `it`, and hooks from `mocha`, is the `require` interface.

This renames the plugin setting value from `exports` to `require` so the configuration matches Mocha terminology. Users who configured `settings.mocha.interface: "exports"` or `additionalCustomNames[].interface`: `"exports"` for named imports need to change those values to `"require"`.
