### PR TITLE
Rename no-global-tests to no-top-level-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |
-| [no-global-tests](documentation/rules/no-global-tests.md)                                     | Disallow global tests                                                   | ✅  |    |    |    |    |
 | [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |    |
 | [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |    |
 | [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
@@ -146,6 +145,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |    |
 | [no-sibling-hooks](documentation/rules/no-sibling-hooks.md)                                   | Disallow duplicate uses of a hook at the same level inside a suite      | ✅  |    |    |    |    |
 | [no-synchronous-tests](documentation/rules/no-synchronous-tests.md)                           | Disallow synchronous tests                                              |    |    | ✅  |    |    |
+| [no-top-level-tests](documentation/rules/no-top-level-tests.md)                               | Disallow top-level tests                                                | ✅  |    |    |    |    |
 | [prefer-arrow-callback](documentation/rules/prefer-arrow-callback.md)                         | Require using arrow functions for callbacks                             |    |    | ✅  | 🔧 |    |
 | [valid-suite-title](documentation/rules/valid-suite-title.md)                                 | Require suite descriptions to match a pre-configured regular expression |    |    | ✅  |    |    |
 | [valid-test-title](documentation/rules/valid-test-title.md)                                   | Require test descriptions to match a pre-configured regular expression  |    |    | ✅  |    |    |

--- a/documentation/rules/no-top-level-tests.md
+++ b/documentation/rules/no-top-level-tests.md
@@ -1,10 +1,10 @@
-# Disallow global tests (`mocha/no-global-tests`)
+# Disallow top-level tests (`mocha/no-top-level-tests`)
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 
-Mocha gives you the possibility to structure your tests inside of suites using `describe`, `suite` or `context`.
+Mocha lets you structure tests inside suites using `describe`, `suite` or `context`.
 
 Example:
 
@@ -14,7 +14,7 @@ describe('something', function () {
 });
 ```
 
-This rule aims to prevent writing tests outside of test-suites:
+This rule prevents writing tests outside of suites:
 
 ```js
 it('should work', function () {});
@@ -22,7 +22,7 @@ it('should work', function () {});
 
 ## Rule Details
 
-This rule checks each mocha test function to not be located directly in the global scope.
+This rule reports Mocha test functions declared outside any suite.
 
 The following patterns are considered problems:
 

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -10,7 +10,6 @@ import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
 import { noExportsRule } from './rules/no-exports.js';
-import { noGlobalTestsRule } from './rules/no-global-tests.js';
 import { noHooksForSingleCaseRule } from './rules/no-hooks-for-single-case.js';
 import { noHooksRule } from './rules/no-hooks.js';
 import { noIdenticalTitleRule } from './rules/no-identical-title.js';
@@ -23,6 +22,7 @@ import { noRootHooksRule } from './rules/no-root-hooks.js';
 import { noSetupInDescribeRule } from './rules/no-setup-in-describe.js';
 import { noSiblingHooksRule } from './rules/no-sibling-hooks.js';
 import { noSynchronousTestsRule } from './rules/no-synchronous-tests.js';
+import { noTopLevelTestsRule } from './rules/no-top-level-tests.js';
 import { preferArrowCallbackRule } from './rules/prefer-arrow-callback.js';
 import { validSuiteTitleRule } from './rules/valid-suite-title.js';
 import { validTestTitleRule } from './rules/valid-test-title.js';
@@ -36,7 +36,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-exports': 'error',
-    'mocha/no-global-tests': 'error',
+    'mocha/no-top-level-tests': 'error',
     'mocha/no-hooks': 'error',
     'mocha/no-hooks-for-single-case': 'error',
     'mocha/no-identical-title': 'error',
@@ -64,7 +64,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
-    'mocha/no-global-tests': 'error',
+    'mocha/no-top-level-tests': 'error',
     'mocha/no-hooks': 'off',
     'mocha/no-hooks-for-single-case': 'off',
     'mocha/no-identical-title': 'error',
@@ -92,7 +92,7 @@ const rules = {
     'no-async-suite': noAsyncSuiteRule,
     'no-exclusive-tests': noExclusiveTestsRule,
     'no-exports': noExportsRule,
-    'no-global-tests': noGlobalTestsRule,
+    'no-top-level-tests': noTopLevelTestsRule,
     'no-hooks': noHooksRule,
     'no-hooks-for-single-case': noHooksForSingleCaseRule,
     'no-identical-title': noIdenticalTitleRule,

--- a/source/rules/no-top-level-tests.test.ts
+++ b/source/rules/no-top-level-tests.test.ts
@@ -1,11 +1,11 @@
 import { RuleTester } from 'eslint';
 import { withInterface } from '../mocha-interface-test-cases.js';
-import { noGlobalTestsRule } from './no-global-tests.js';
+import { noTopLevelTestsRule } from './no-top-level-tests.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
-const expectedErrorMessage = 'Unexpected global mocha test.';
+const expectedErrorMessage = 'Unexpected top-level mocha test.';
 
-ruleTester.run('no-global-tests', noGlobalTestsRule, {
+ruleTester.run('no-top-level-tests', noTopLevelTestsRule, {
     valid: [
         'describe();',
         withInterface('TDD', 'suite();'),

--- a/source/rules/no-top-level-tests.ts
+++ b/source/rules/no-top-level-tests.ts
@@ -1,20 +1,20 @@
 import type { Rule, Scope } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 
-function isGlobalScope(scope: Readonly<Scope.Scope>): boolean {
+function isTopLevelScope(scope: Readonly<Scope.Scope>): boolean {
     return scope.type === 'global' || scope.type === 'module';
 }
 
-export const noGlobalTestsRule: Readonly<Rule.RuleModule> = {
+export const noTopLevelTestsRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
         languages: ['js/js'],
         docs: {
-            description: 'Disallow global tests',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-global-tests.md'
+            description: 'Disallow top-level tests',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-top-level-tests.md'
         },
         messages: {
-            unexpectedGlobalTest: 'Unexpected global mocha test.'
+            unexpectedTopLevelTest: 'Unexpected top-level mocha test.'
         },
         schema: []
     },
@@ -23,8 +23,8 @@ export const noGlobalTestsRule: Readonly<Rule.RuleModule> = {
             testCase(visitorContext) {
                 const scope = context.sourceCode.getScope(visitorContext.node);
 
-                if (isGlobalScope(scope)) {
-                    context.report({ node: visitorContext.node, messageId: 'unexpectedGlobalTest' });
+                if (isTopLevelScope(scope)) {
+                    context.report({ node: visitorContext.node, messageId: 'unexpectedTopLevelTest' });
                 }
             }
         });


### PR DESCRIPTION
This rule reports Mocha test cases declared outside any suite.

The old `no-global-tests` name was easy to confuse with Mocha globals, global fixtures, or the global interface. `no-top-level-tests` matches the plugin terminology used for suites declared at the top level.

Users should replace `mocha/no-global-tests` with `mocha/no-top-level-tests` in their ESLint config.
