### PR TITLE
Document supported Mocha interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ forEach([1, 2, 3]).describeModule.modifier("example", function (n) {});
 - `type`: Selects `suite`, `testCase`, or `hook`.
 - `interface`: Selects `BDD`, `TDD`, or `require`. The default is `BDD`. With `require`, rule resolution uses named `import` statements instead of globals. `mocha/consistent-interface` also reports named imports of Mocha interface methods when this setting is `BDD` or `TDD`, which helps catch accidental `require`-style usage and interface misconfiguration earlier.
 
+The plugin supports Mocha's `BDD`, `TDD`, and `Require` interfaces. It does not support Mocha's `Exports` or `QUnit` interfaces, or third-party UIs with different syntax. Many rules depend on suite, test, and hook calls being represented as nested call expressions, which those interfaces do not provide consistently.
+
+For wrapper APIs that still expose suite, test, or hook call functions, use `additionalCustomNames`.
+
 ## Rules
 
 For maintainers: the rules table below is generated, and the headers in `documentation/rules/*.md` are partly generated. Refresh them with `npx just update-eslint-docs`.

--- a/documentation/rules/consistent-interface.md
+++ b/documentation/rules/consistent-interface.md
@@ -6,7 +6,11 @@
 
 <!-- end auto-generated rule header -->
 
-Mocha has several interfaces such as `BDD`, `TDD`, `Require`, `Exports`, `QUnit` etc. Usually Mocha injects the variables and functions of the selected interface into the global scope. When using the `Require` interface, named imports from `mocha` are used instead. This rule enforces a consistent `BDD` or `TDD` interface for imported Mocha interface methods, and it also reports imported Mocha interface methods when `settings.mocha.interface` is configured for globals.
+Mocha has several interfaces such as `BDD`, `TDD`, `Require`, `Exports`, and `QUnit`. This plugin supports Mocha's `BDD`, `TDD`, and `Require` interfaces.
+
+It does not support Mocha's `Exports` or `QUnit` interfaces, or third-party UIs with different syntax. Many rules depend on suite, test, and hook calls being represented as nested call expressions, which those interfaces do not provide consistently.
+
+Usually Mocha injects the variables and functions of the selected interface into the global scope. When using the `Require` interface, named imports from `mocha` are used instead. This rule enforces a consistent `BDD` or `TDD` interface for imported Mocha interface methods, and it also reports imported Mocha interface methods when `settings.mocha.interface` is configured for globals.
 
 ## Options
 


### PR DESCRIPTION
Clarifies which Mocha interfaces the plugin supports.

The README and consistent-interface docs now state that BDD, TDD, and Require are supported, while Exports, QUnit, and third-party UIs with different syntax are not.

Wrapper APIs that still expose suite, test, or hook call functions are pointed to additionalCustomNames.
