### PR TITLE
Document targeted Mocha version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 ESLint rules for [Mocha](https://mochajs.org/).
 
+This plugin targets Mocha's current JavaScript interfaces documented for Mocha 11. It does not execute Mocha or require Mocha at runtime.
+
 ## Install
 
 This plugin requires ESLint `10.2.0` or later.


### PR DESCRIPTION
Clarifies the Mocha version the plugin targets.

The README now states that the plugin targets Mocha 11 documented JavaScript interfaces and does not execute or require Mocha at runtime.
