### PR TITLE
Handle TypeScript this parameters in done callback rule

### DIFF
--- a/documentation/rules/handle-done-callback.md
+++ b/documentation/rules/handle-done-callback.md
@@ -64,6 +64,14 @@ before(function (done) {
 });
 ```
 
+When linting TypeScript, a typed `this` parameter is not treated as a `done` callback:
+
+```ts
+before(function (this: Mocha.Context) {
+    this.timeout(6000);
+});
+```
+
 ## Options
 
 This rule supports one option:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@enormora/eslint-config-typescript": "0.0.37",
                 "@packtory/cli": "0.0.5",
                 "@types/mocha": "10.0.10",
+                "@typescript-eslint/parser": "8.59.3",
                 "c8": "11.0.0",
                 "change-case": "5.4.4",
                 "coveralls": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@enormora/eslint-config-typescript": "0.0.37",
         "@packtory/cli": "0.0.5",
         "@types/mocha": "10.0.10",
+        "@typescript-eslint/parser": "8.59.3",
         "c8": "11.0.0",
         "change-case": "5.4.4",
         "coveralls": "3.1.1",

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -1,8 +1,10 @@
+import * as typescriptParser from '@typescript-eslint/parser';
 import { RuleTester, type Scope } from 'eslint';
 import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import { findParamInScope, handleDoneCallbackRule } from './handle-done-callback.js';
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const typescriptLanguageOptions = { parser: typescriptParser };
 
 ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
     valid: [
@@ -35,6 +37,10 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         {
             code: 'it.skip("", function (done) { });',
             options: [{ ignorePending: true }]
+        },
+        {
+            code: 'before(async function setupApplication(this: Mocha.Context) { this.timeout(6000); });',
+            languageOptions: typescriptLanguageOptions
         }
     ],
 
@@ -115,6 +121,11 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         {
             code: 'it("", function (done) { var foo = done; });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (this: Mocha.Context, done) { });',
+            languageOptions: typescriptLanguageOptions,
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 39, line: 1 }]
         }
     ]
 });

--- a/source/rules/handle-done-callback.ts
+++ b/source/rules/handle-done-callback.ts
@@ -1,6 +1,6 @@
 import type { Rule, Scope } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { getParentNode } from '../ast/node-types.js';
+import { getParentNode, isIdentifier } from '../ast/node-types.js';
 import type { FunctionExpression } from '../ast/node-types.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
@@ -25,6 +25,22 @@ export function findParamInScope(
     const variable = scope.set.get(paramName);
 
     return variable?.defs[0]?.type === 'Parameter' ? variable : undefined;
+}
+
+function isTypeScriptThisParameter(param: FunctionExpression['params'][number]): boolean {
+    return isIdentifier(param) && param.name === 'this';
+}
+
+function getDoneCallback(
+    functionExpression: Readonly<FunctionExpression>
+): FunctionExpression['params'][number] | undefined {
+    const [firstParam, secondParam] = functionExpression.params;
+
+    if (firstParam === undefined) {
+        return undefined;
+    }
+
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
 }
 
 export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
@@ -56,7 +72,7 @@ export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
 
         function checkAsyncMochaFunction(functionExpression: Readonly<FunctionExpression>): void {
             const scope = context.sourceCode.getScope(functionExpression);
-            const callback = functionExpression.params[0];
+            const callback = getDoneCallback(functionExpression);
 
             if (callback === undefined || callback.type !== 'Identifier') {
                 return;


### PR DESCRIPTION
Fixes #270.

Treats TypeScript typed this parameters as context parameters instead of Mocha done callbacks.