### PR TITLE
Fix no-sibling-hooks nested function false positives

### DIFF
--- a/documentation/rules/no-sibling-hooks.md
+++ b/documentation/rules/no-sibling-hooks.md
@@ -10,6 +10,7 @@ It is possible to declare a hook multiple times inside the same test suite, but 
 ## Rule Details
 
 This rule looks for every call to `before`, `after`, `beforeEach` and `afterEach` and reports them if they are called at least twice inside of a test suite at the same level.
+Hooks declared inside nested functions are not treated as siblings of hooks in the surrounding suite.
 
 The following patterns are considered warnings:
 
@@ -55,6 +56,12 @@ describe('foo', function () {
             // ...
         });
     });
+
+    function addSharedTests() {
+        before(function () { // Is allowed because it's inside a nested function
+            // ...
+        });
+    }
 });
 ```
 

--- a/source/rules/no-sibling-hooks.test.ts
+++ b/source/rules/no-sibling-hooks.test.ts
@@ -37,6 +37,51 @@ ruleTester.run('no-sibling-hooks', noSiblingHooksRule, {
         },
         [
             'describe(function() {',
+            '    before(function() {});',
+            '    function runSomeTests() {',
+            '        before(function() {});',
+            '        it(function() {});',
+            '    }',
+            '    function runSomeOtherTests() {',
+            '        before(function() {});',
+            '        it(function() {});',
+            '    }',
+            '    context(function() {',
+            '        before(function() {});',
+            '        context(function() {',
+            '            runSomeTests();',
+            '        });',
+            '        context(function() {',
+            '            runSomeOtherTests();',
+            '        });',
+            '    });',
+            '    context(function() {',
+            '        before(function() {});',
+            '        context(function() {',
+            '            runSomeTests();',
+            '        });',
+            '        context(function() {',
+            '            runSomeOtherTests();',
+            '        });',
+            '    });',
+            '});'
+        ]
+            .join('\n'),
+        [
+            'describe(function() {',
+            '    before(function() {});',
+            '    const runSomeTests = () => {',
+            '        before(function() {});',
+            '        it(function() {});',
+            '    };',
+            '    context(function() {',
+            '        runSomeTests();',
+            '    });',
+            '});'
+        ]
+            .join('\n'),
+        [
+            'describe(function() {',
             '    describe.only(function() {',
             '        before(function() {});',
             '    });',
@@ -247,6 +292,19 @@ ruleTester.run('no-sibling-hooks', noSiblingHooksRule, {
                 'mocha/additionalCustomNames': [{ name: 'foo', type: 'suite', interface: 'BDD' }]
             },
             errors: [{ message: 'Unexpected use of duplicate Mocha `before()` hook', column: 5, line: 6 }]
+        },
+        {
+            code: [
+                'function createSuite() {',
+                '    describe(function() {',
+                '        before(function() {});',
+                '        before(function() {});',
+                '    });',
+                '}',
+                'createSuite();'
+            ]
+                .join('\n'),
+            errors: [{ message: 'Unexpected use of duplicate Mocha `before()` hook', column: 9, line: 4 }]
         },
         {
             code: [

--- a/source/rules/no-sibling-hooks.ts
+++ b/source/rules/no-sibling-hooks.ts
@@ -4,14 +4,26 @@ import { createMochaVisitors } from '../ast/mocha-visitors.js';
 
 type Layer = {
     suiteNode: Except<Rule.Node, 'parent'>;
+    isProgram: boolean;
+    functionDepth: number;
     alreadyUsedHooks: Set<string>;
 };
 
-function createNewLayer(node: Except<Rule.Node, 'parent'>): Readonly<Layer> {
+function createNewLayer(
+    node: Except<Rule.Node, 'parent'>,
+    isProgram: boolean,
+    functionDepth: number
+): Readonly<Layer> {
     return {
         suiteNode: node,
+        isProgram,
+        functionDepth,
         alreadyUsedHooks: new Set()
     };
+}
+
+function isInLayerBody(layer: Readonly<Layer> | undefined, functionDepth: number): boolean {
+    return layer !== undefined && (layer.isProgram || layer.functionDepth === functionDepth);
 }
 
 export const noSiblingHooksRule: Readonly<Rule.RuleModule> = {
@@ -29,23 +41,45 @@ export const noSiblingHooksRule: Readonly<Rule.RuleModule> = {
     },
     create(context) {
         const layers: Layer[] = [];
+        const suiteCallbackNodes = new Set<Rule.Node>();
+        let functionDepth = 0;
+
+        function enterFunction(node: Rule.Node): void {
+            if (!suiteCallbackNodes.has(node)) {
+                functionDepth += 1;
+            }
+        }
+
+        function exitFunction(node: Rule.Node): void {
+            if (!suiteCallbackNodes.has(node)) {
+                functionDepth -= 1;
+            }
+        }
 
         return createMochaVisitors(context, {
             Program(node) {
-                layers.push(createNewLayer(node));
+                layers.push(createNewLayer(node, true, functionDepth));
             },
 
             suite(visitorContext) {
-                layers.push(createNewLayer(visitorContext.node));
+                layers.push(createNewLayer(visitorContext.node, false, functionDepth));
             },
 
             'suite:exit'() {
                 layers.pop();
             },
 
+            suiteCallback(visitorContext) {
+                suiteCallbackNodes.add(visitorContext.node);
+            },
+
             hook(visitorContext) {
                 const { name, node } = visitorContext;
                 const currentLayer = layers.at(-1);
+
+                if (!isInLayerBody(currentLayer, functionDepth)) {
+                    return;
+                }
 
                 if (currentLayer?.alreadyUsedHooks.has(name) === true) {
                     context.report({
@@ -56,7 +90,14 @@ export const noSiblingHooksRule: Readonly<Rule.RuleModule> = {
                 } else {
                     currentLayer?.alreadyUsedHooks.add(name);
                 }
-            }
+            },
+
+            FunctionDeclaration: enterFunction,
+            'FunctionDeclaration:exit': exitFunction,
+            FunctionExpression: enterFunction,
+            'FunctionExpression:exit': exitFunction,
+            ArrowFunctionExpression: enterFunction,
+            'ArrowFunctionExpression:exit': exitFunction
         });
     }
 };


### PR DESCRIPTION
Fixes #113.

Nested ordinary functions inside a suite no longer contribute hooks to the surrounding suite level. Direct duplicate hooks in suite callbacks still report.