### PR TITLE
Add consistent-structure rule for suite ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- | :- |
 | [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |    |
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
+| [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    |    |    | ✅  |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |

--- a/documentation/rules/consistent-structure.md
+++ b/documentation/rules/consistent-structure.md
@@ -1,0 +1,71 @@
+# Require consistent structure for Mocha test entities (`mocha/consistent-structure`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+This rule enforces a consistent arrangement of direct Mocha children within a suite body. For this rule, "structure" means the order and combination of direct hooks, test cases, and child suites. It does not check whitespace or formatting.
+
+## Rule Details
+
+This rule can enforce:
+
+- a specific order for hooks, test cases, and child suites
+- that direct test cases and direct child suites are not mixed in the same suite
+
+The following patterns are considered warnings:
+
+```js
+describe('root', function () {
+    it('works', function () {});
+    beforeEach(function () {});
+});
+
+describe('root', function () {
+    describe('nested', function () {});
+    it('works', function () {});
+});
+
+describe('root', function () {
+    it('a', function () {});
+    describe('nested', function () {});
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('root', function () {
+    beforeEach(function () {});
+    it('works', function () {});
+    it('works again', function () {});
+});
+
+describe('root', function () {
+    beforeEach(function () {});
+    describe('nested', function () {});
+    describe('other nested', function () {});
+});
+```
+
+## Options
+
+This rule supports the following options:
+
+- `order`: Controls the required order of direct Mocha children. Use `"hooks-tests-suites"` to require hooks before test cases and test cases before child suites. Defaults to `"off"`.
+- `disallowMixedTestsAndSuites`: Reports suites that contain both direct test cases and direct child suites. Hooks do not count towards this mix. Defaults to `false`.
+
+```json
+{
+    "rules": {
+        "mocha/consistent-structure": ["error", {
+            "order": "hooks-tests-suites",
+            "disallowMixedTestsAndSuites": true
+        }]
+    }
+}
+```
+
+## When Not To Use It
+
+If your project intentionally mixes direct tests and direct child suites, or if you do not care about a consistent sibling order inside suites.

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -3,6 +3,7 @@ import globals from 'globals';
 import { readClosestPackageMetadata } from './package-metadata.js';
 import { consistentInterfaceRule } from './rules/consistent-interface.js';
 import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-between-blocks.js';
+import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
@@ -29,6 +30,7 @@ import { validTestTitleRule } from './rules/valid-test-title.js';
 const pluginMeta = await readClosestPackageMetadata(import.meta.url);
 
 const allRules: Linter.RulesRecord = {
+    'mocha/consistent-structure': 'error',
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': 'error',
     'mocha/no-async-suite': 'error',
@@ -56,6 +58,7 @@ const allRules: Linter.RulesRecord = {
 };
 
 const recommendedRules: Linter.RulesRecord = {
+    'mocha/consistent-structure': 'off',
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
     'mocha/no-async-suite': 'error',
@@ -83,6 +86,7 @@ const recommendedRules: Linter.RulesRecord = {
 };
 
 const rules = {
+    'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
     'no-async-suite': noAsyncSuiteRule,

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -30,7 +30,7 @@ import { validTestTitleRule } from './rules/valid-test-title.js';
 const pluginMeta = await readClosestPackageMetadata(import.meta.url);
 
 const allRules: Linter.RulesRecord = {
-    'mocha/consistent-structure': 'error',
+    'mocha/consistent-structure': ['error', { order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }],
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': 'error',
     'mocha/no-async-suite': 'error',

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -1,8 +1,49 @@
-import { RuleTester } from 'eslint';
+import { Linter, type Rule, RuleTester, type SourceCode } from 'eslint';
+import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
-import { consistentStructureRule } from './consistent-structure.js';
+import {
+    consistentStructureRule,
+    getDirectStructureContext,
+    getStructureEntityKind,
+    getTopLevelMochaExpression,
+    isNestedStatementBoundary
+} from './consistent-structure.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+
+function readExpression(code: string): { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; } {
+    const linter = new Linter();
+    let result: { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; } | null = null;
+
+    const testRule: Rule.RuleModule = {
+        create(ruleContext) {
+            return {
+                Program() {
+                    const [firstStatement] = ruleContext.sourceCode.ast.body;
+
+                    assert.notStrictEqual(firstStatement, undefined);
+                    assert.strictEqual(firstStatement?.type, 'ExpressionStatement');
+
+                    result = {
+                        sourceCode: ruleContext.sourceCode,
+                        expression: firstStatement.expression as unknown as Readonly<Rule.Node>
+                    };
+                }
+            };
+        }
+    };
+
+    const messages = linter.verify(code, {
+        plugins: { 'test-plugin': { rules: { 'test-rule': testRule } } },
+        languageOptions: { ecmaVersion: 2020, sourceType: 'script' },
+        rules: { 'test-plugin/test-rule': 'error' }
+    });
+
+    assert.deepStrictEqual(messages, []);
+    assert.notStrictEqual(result, null);
+
+    return result as unknown as { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; };
+}
 
 ruleTester.run('consistent-structure', consistentStructureRule, {
     valid: [
@@ -123,4 +164,52 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             }]
         }
     ]
+});
+
+describe('consistent-structure helpers', function () {
+    it('getTopLevelMochaExpression() walks up member expressions', function () {
+        const { expression } = readExpression('foo.bar.baz();');
+
+        assert.strictEqual(expression.type, 'CallExpression');
+        assert.strictEqual(expression.callee.type, 'MemberExpression');
+        assert.strictEqual(expression.callee.object.type, 'MemberExpression');
+
+        const result = getTopLevelMochaExpression(expression.callee.object.object as unknown as Rule.Node);
+
+        assert.strictEqual(result.type, 'MemberExpression');
+        assert.strictEqual(result, expression.callee);
+    });
+
+    it('getStructureEntityKind() throws for unsupported mocha entities', function () {
+        assert.throws(
+            function () {
+                getStructureEntityKind({
+                    interface: 'BDD',
+                    modifier: null,
+                    name: 'timeout',
+                    node: {} as Rule.Node,
+                    type: 'config'
+                });
+            },
+            /Unexpected mocha entity type: config/u
+        );
+    });
+
+    it('getDirectStructureContext() returns null when no structure layer exists', function () {
+        const result = getDirectStructureContext([], {
+            interface: 'BDD',
+            modifier: null,
+            name: 'describe',
+            node: {} as Rule.Node,
+            type: 'suite'
+        });
+
+        assert.strictEqual(result, null);
+    });
+
+    it('isNestedStatementBoundary() handles declarations, functions, and unrelated nodes', function () {
+        assert.strictEqual(isNestedStatementBoundary({ type: 'ImportDeclaration' } as Rule.Node), true);
+        assert.strictEqual(isNestedStatementBoundary({ type: 'FunctionExpression' } as Rule.Node), true);
+        assert.strictEqual(isNestedStatementBoundary({ type: 'Identifier' } as Rule.Node), false);
+    });
 });

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -1,0 +1,126 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { consistentStructureRule } from './consistent-structure.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+
+ruleTester.run('consistent-structure', consistentStructureRule, {
+    valid: [
+        'describe(function() { before(function() {}); it(function() {}); describe(function() {}); });',
+        'describe(function() { before(function() {}); beforeEach(function() {}); it(function() {}); });',
+        'describe(function() { after(function() {}); });',
+        'describe(function() { describe(function() {}); describe(function() {}); });',
+        'describe(function() { it(function() {}); it(function() {}); });',
+        {
+            code: 'describe(function() { it(function() {}); describe(function() {}); });',
+            options: [{ order: 'hooks-tests-suites' }]
+        },
+        {
+            code: 'describe(function() { describe(function() {}); it(function() {}); });',
+            options: [{ disallowMixedTestsAndSuites: false }]
+        },
+        {
+            code: 'describe(function() { describe(function() {}); it(function() {}); });',
+            options: [{ order: 'off', disallowMixedTestsAndSuites: false }]
+        },
+        withInterface('TDD', {
+            code: 'suite(function() { setup(function() {}); suite(function() {}); suite(function() {}); });',
+            options: [{ order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }]
+        }),
+        {
+            code: [
+                'foo(function() {',
+                '    before(function() {});',
+                '    foo(function() {});',
+                '});'
+            ]
+                .join('\n'),
+            options: [{ order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
+                }
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'describe(function() { it(function() {}); before(function() {}); });',
+            options: [{ order: 'hooks-tests-suites' }],
+            errors: [{ message: 'Unexpected hook after a test case.', column: 42, line: 1 }]
+        },
+        {
+            code: 'describe(function() { describe(function() {}); before(function() {}); });',
+            options: [{ order: 'hooks-tests-suites' }],
+            errors: [{ message: 'Unexpected hook after a child suite.', column: 48, line: 1 }]
+        },
+        {
+            code: 'describe(function() { describe(function() {}); it(function() {}); });',
+            options: [{ order: 'hooks-tests-suites' }],
+            errors: [{ message: 'Unexpected test case after a child suite.', column: 48, line: 1 }]
+        },
+        {
+            code: 'describe(function() { it(function() {}); describe(function() {}); });',
+            options: [{ disallowMixedTestsAndSuites: true }],
+            errors: [{
+                message: 'Unexpected mix of test cases and child suites at the same level.',
+                column: 42,
+                line: 1
+            }]
+        },
+        {
+            code: 'describe(function() { describe(function() {}); it(function() {}); });',
+            options: [{ disallowMixedTestsAndSuites: true }],
+            errors: [{
+                message: 'Unexpected mix of test cases and child suites at the same level.',
+                column: 48,
+                line: 1
+            }]
+        },
+        {
+            code: [
+                'describe(function() {',
+                '    describe(function() {});',
+                '    it(function() {});',
+                '    it(function() {});',
+                '});'
+            ]
+                .join('\n'),
+            options: [{ order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }],
+            errors: [
+                { message: 'Unexpected test case after a child suite.', column: 5, line: 3 },
+                { message: 'Unexpected mix of test cases and child suites at the same level.', column: 5, line: 3 },
+                { message: 'Unexpected test case after a child suite.', column: 5, line: 4 }
+            ]
+        },
+        withInterface('TDD', {
+            code: 'suite(function() { suite(function() {}); test(function() {}); });',
+            options: [{ order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }],
+            errors: [
+                { message: 'Unexpected test case after a child suite.', column: 42, line: 1 },
+                { message: 'Unexpected mix of test cases and child suites at the same level.', column: 42, line: 1 }
+            ]
+        }),
+        {
+            code: [
+                'foo(function() {',
+                '    it(function() {});',
+                '    foo(function() {});',
+                '});'
+            ]
+                .join('\n'),
+            options: [{ disallowMixedTestsAndSuites: true }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
+                }
+            },
+            errors: [{
+                message: 'Unexpected mix of test cases and child suites at the same level.',
+                column: 5,
+                line: 3
+            }]
+        }
+    ]
+});

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -181,13 +181,15 @@ describe('consistent-structure helpers', function () {
     });
 
     it('getStructureEntityKind() throws for unsupported mocha entities', function () {
+        const { expression: node } = readExpression('foo;');
+
         assert.throws(
             function () {
                 getStructureEntityKind({
                     interface: 'BDD',
                     modifier: null,
                     name: 'timeout',
-                    node: {} as Rule.Node,
+                    node,
                     type: 'config'
                 });
             },
@@ -196,11 +198,12 @@ describe('consistent-structure helpers', function () {
     });
 
     it('getDirectStructureContext() returns null when no structure layer exists', function () {
+        const { expression: node } = readExpression('foo;');
         const result = getDirectStructureContext([], {
             interface: 'BDD',
             modifier: null,
             name: 'describe',
-            node: {} as Rule.Node,
+            node,
             type: 'suite'
         });
 

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -45,6 +45,57 @@ function readExpression(code: string): { sourceCode: Readonly<SourceCode>; expre
     return result as unknown as { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; };
 }
 
+function readSuiteBodyNodes(
+    code: string
+): { nestedMochaCall: Readonly<Rule.Node>; suiteBody: Readonly<Rule.Node>; } {
+    const linter = new Linter();
+    let result: { nestedMochaCall: Readonly<Rule.Node>; suiteBody: Readonly<Rule.Node>; } | null = null;
+
+    const testRule: Rule.RuleModule = {
+        create(ruleContext) {
+            return {
+                Program() {
+                    const [firstStatement] = ruleContext.sourceCode.ast.body;
+
+                    assert.notStrictEqual(firstStatement, undefined);
+                    assert.strictEqual(firstStatement?.type, 'ExpressionStatement');
+                    assert.strictEqual(firstStatement.expression.type, 'CallExpression');
+
+                    const suiteCallback = firstStatement.expression.arguments[0];
+
+                    assert.notStrictEqual(suiteCallback, undefined);
+                    assert.strictEqual(suiteCallback?.type, 'FunctionExpression');
+
+                    const [nestedStatement] = suiteCallback.body.body;
+
+                    assert.notStrictEqual(nestedStatement, undefined);
+                    assert.strictEqual(nestedStatement?.type, 'IfStatement');
+                    assert.strictEqual(nestedStatement.consequent.type, 'BlockStatement');
+                    assert.strictEqual(nestedStatement.consequent.body[0]?.type, 'ExpressionStatement');
+
+                    result = {
+                        nestedMochaCall: nestedStatement.consequent.body[0].expression as unknown as Readonly<
+                            Rule.Node
+                        >,
+                        suiteBody: suiteCallback.body as unknown as Readonly<Rule.Node>
+                    };
+                }
+            };
+        }
+    };
+
+    const messages = linter.verify(code, {
+        plugins: { 'test-plugin': { rules: { 'test-rule': testRule } } },
+        languageOptions: { ecmaVersion: 2020, sourceType: 'script' },
+        rules: { 'test-plugin/test-rule': 'error' }
+    });
+
+    assert.deepStrictEqual(messages, []);
+    assert.notStrictEqual(result, null);
+
+    return result as unknown as { nestedMochaCall: Readonly<Rule.Node>; suiteBody: Readonly<Rule.Node>; };
+}
+
 ruleTester.run('consistent-structure', consistentStructureRule, {
     valid: [
         'describe(function() { before(function() {}); it(function() {}); describe(function() {}); });',
@@ -214,5 +265,27 @@ describe('consistent-structure helpers', function () {
         assert.strictEqual(isNestedStatementBoundary({ type: 'ImportDeclaration' } as Rule.Node), true);
         assert.strictEqual(isNestedStatementBoundary({ type: 'FunctionExpression' } as Rule.Node), true);
         assert.strictEqual(isNestedStatementBoundary({ type: 'Identifier' } as Rule.Node), false);
+    });
+
+    it('getDirectStructureContext() returns null for nested statements inside a suite body', function () {
+        const { nestedMochaCall, suiteBody } = readSuiteBodyNodes('describe(function () { if (foo) { it(); } });');
+        const result = getDirectStructureContext(
+            [{
+                hasReportedMixedStructure: false,
+                hasSeenSuite: false,
+                hasSeenTestCase: false,
+                highestSeenKind: null,
+                scopeNode: suiteBody as never
+            }],
+            {
+                interface: 'BDD',
+                modifier: null,
+                name: 'it',
+                node: nestedMochaCall,
+                type: 'testCase'
+            }
+        );
+
+        assert.strictEqual(result, null);
     });
 });

--- a/source/rules/consistent-structure.ts
+++ b/source/rules/consistent-structure.ts
@@ -65,7 +65,7 @@ function createStructureLayer(scopeNode: StructureLayer['scopeNode']): Readonly<
     };
 }
 
-function isNestedStatementBoundary(node: Rule.Node): boolean {
+export function isNestedStatementBoundary(node: Rule.Node): boolean {
     return node.type.endsWith('Statement') || node.type.endsWith('Declaration') || isFunction(node);
 }
 
@@ -85,7 +85,7 @@ function isDirectStatementInScope(scopeNode: StructureLayer['scopeNode'], node: 
     return current.type === 'ExpressionStatement';
 }
 
-function getTopLevelMochaExpression(node: Rule.Node): Rule.Node {
+export function getTopLevelMochaExpression(node: Rule.Node): Rule.Node {
     const parent = getParentNode(node);
 
     if (isMemberExpression(parent)) {
@@ -95,7 +95,7 @@ function getTopLevelMochaExpression(node: Rule.Node): Rule.Node {
     return node;
 }
 
-function getStructureEntityKind(visitorContext: Readonly<VisitorContext>): StructureEntityKind {
+export function getStructureEntityKind(visitorContext: Readonly<VisitorContext>): StructureEntityKind {
     if (visitorContext.type === 'suite' || visitorContext.type === 'testCase' || visitorContext.type === 'hook') {
         return visitorContext.type;
     }
@@ -175,7 +175,7 @@ function replaceCurrentLayer(layers: StructureLayer[], nextLayer: Readonly<Struc
     layers.splice(-1, 1, nextLayer);
 }
 
-function getDirectStructureContext(
+export function getDirectStructureContext(
     layers: readonly StructureLayer[],
     visitorContext: Readonly<VisitorContext>
 ): Readonly<DirectStructureContext> | null {

--- a/source/rules/consistent-structure.ts
+++ b/source/rules/consistent-structure.ts
@@ -1,0 +1,295 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors, type VisitorContext } from '../ast/mocha-visitors.js';
+import {
+    type AnyFunction,
+    getParentNode,
+    isBlockStatement,
+    isFunction,
+    isMemberExpression
+} from '../ast/node-types.js';
+import { getLastOrThrow } from '../list.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
+
+const optionSchema = {
+    type: 'object',
+    properties: {
+        order: {
+            type: 'string',
+            enum: ['hooks-tests-suites', 'off']
+        },
+        disallowMixedTestsAndSuites: {
+            type: 'boolean'
+        }
+    },
+    additionalProperties: false
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+type ResolvedOption = Option & {
+    order: 'hooks-tests-suites' | 'off';
+    disallowMixedTestsAndSuites: boolean;
+};
+type StructureEntityKind = 'hook' | 'suite' | 'testCase';
+type StructureLayer = {
+    hasReportedMixedStructure: boolean;
+    hasSeenSuite: boolean;
+    hasSeenTestCase: boolean;
+    highestSeenKind: StructureEntityKind | null;
+    scopeNode: AnyFunction['body'];
+};
+type DirectStructureContext = {
+    currentKind: StructureEntityKind;
+    currentLayer: Readonly<StructureLayer>;
+};
+type TrackedStructureContext = DirectStructureContext & {
+    visitorContext: Readonly<VisitorContext>;
+};
+
+const defaultOption: ResolvedOption = {
+    order: 'off',
+    disallowMixedTestsAndSuites: false
+};
+const entityRank: Readonly<Record<StructureEntityKind, number>> = {
+    hook: 0,
+    testCase: 1,
+    suite: 2
+};
+
+function createStructureLayer(scopeNode: StructureLayer['scopeNode']): Readonly<StructureLayer> {
+    return {
+        hasReportedMixedStructure: false,
+        hasSeenSuite: false,
+        hasSeenTestCase: false,
+        highestSeenKind: null,
+        scopeNode
+    };
+}
+
+function isNestedStatementBoundary(node: Rule.Node): boolean {
+    return node.type.endsWith('Statement') || node.type.endsWith('Declaration') || isFunction(node);
+}
+
+function isDirectStatementInScope(scopeNode: StructureLayer['scopeNode'], node: Rule.Node): boolean {
+    let current = node;
+
+    while (getParentNode(current) !== scopeNode) {
+        current = getParentNode(current);
+        if (
+            isNestedStatementBoundary(current) &&
+            !(current.type === 'ExpressionStatement' && getParentNode(current) === scopeNode)
+        ) {
+            return false;
+        }
+    }
+
+    return current.type === 'ExpressionStatement';
+}
+
+function getTopLevelMochaExpression(node: Rule.Node): Rule.Node {
+    const parent = getParentNode(node);
+
+    if (isMemberExpression(parent)) {
+        return getTopLevelMochaExpression(parent);
+    }
+
+    return node;
+}
+
+function getStructureEntityKind(visitorContext: Readonly<VisitorContext>): StructureEntityKind {
+    if (visitorContext.type === 'suite' || visitorContext.type === 'testCase' || visitorContext.type === 'hook') {
+        return visitorContext.type;
+    }
+
+    throw new Error(`Unexpected mocha entity type: ${visitorContext.type}`);
+}
+
+function reportUnexpectedOrder(
+    context: Readonly<Rule.RuleContext>,
+    visitorContext: Readonly<VisitorContext>,
+    highestSeenKind: StructureEntityKind
+): void {
+    const currentKind = getStructureEntityKind(visitorContext);
+
+    if (currentKind === 'hook') {
+        context.report({
+            node: visitorContext.node,
+            messageId: highestSeenKind === 'suite'
+                ? 'unexpectedHookAfterSuite'
+                : 'unexpectedHookAfterTest'
+        });
+        return;
+    }
+
+    if (currentKind === 'testCase' && highestSeenKind === 'suite') {
+        context.report({
+            node: visitorContext.node,
+            messageId: 'unexpectedTestAfterSuite'
+        });
+    }
+}
+
+function getHighestSeenKind(
+    highestSeenKind: StructureEntityKind | null,
+    currentKind: StructureEntityKind
+): StructureEntityKind {
+    if (highestSeenKind === null || entityRank[currentKind] > entityRank[highestSeenKind]) {
+        return currentKind;
+    }
+
+    return highestSeenKind;
+}
+
+function hasUnexpectedOrder(
+    configuredOrder: ResolvedOption['order'],
+    highestSeenKind: StructureEntityKind | null,
+    currentKind: StructureEntityKind
+): highestSeenKind is StructureEntityKind {
+    return configuredOrder === 'hooks-tests-suites' &&
+        highestSeenKind !== null &&
+        entityRank[currentKind] < entityRank[highestSeenKind];
+}
+
+function shouldReportMixedStructure(layer: Readonly<StructureLayer>, currentKind: StructureEntityKind): boolean {
+    return !layer.hasReportedMixedStructure &&
+        (
+            (currentKind === 'suite' && layer.hasSeenTestCase) ||
+            (currentKind === 'testCase' && layer.hasSeenSuite)
+        );
+}
+
+function createTrackedLayer(
+    layer: Readonly<StructureLayer>,
+    currentKind: StructureEntityKind,
+    hasReportedMixedStructure: boolean
+): Readonly<StructureLayer> {
+    return {
+        hasReportedMixedStructure: layer.hasReportedMixedStructure || hasReportedMixedStructure,
+        hasSeenSuite: layer.hasSeenSuite || currentKind === 'suite',
+        hasSeenTestCase: layer.hasSeenTestCase || currentKind === 'testCase',
+        highestSeenKind: getHighestSeenKind(layer.highestSeenKind, currentKind),
+        scopeNode: layer.scopeNode
+    };
+}
+
+function replaceCurrentLayer(layers: StructureLayer[], nextLayer: Readonly<StructureLayer>): void {
+    layers.splice(-1, 1, nextLayer);
+}
+
+function getDirectStructureContext(
+    layers: readonly StructureLayer[],
+    visitorContext: Readonly<VisitorContext>
+): Readonly<DirectStructureContext> | null {
+    if (layers.length === 0) {
+        return null;
+    }
+
+    const currentLayer = getLastOrThrow(layers);
+
+    if (!isDirectStatementInScope(currentLayer.scopeNode, getTopLevelMochaExpression(visitorContext.node))) {
+        return null;
+    }
+
+    return {
+        currentKind: getStructureEntityKind(visitorContext),
+        currentLayer
+    };
+}
+
+function reportMixedStructure(context: Readonly<Rule.RuleContext>, visitorContext: Readonly<VisitorContext>): void {
+    context.report({
+        node: visitorContext.node,
+        messageId: 'unexpectedMixedTestsAndSuites'
+    });
+}
+
+function trackStructureLayer(
+    context: Readonly<Rule.RuleContext>,
+    layers: StructureLayer[],
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    disallowMixedTestsAndSuites: boolean
+): void {
+    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
+    const reportsMixedStructure = disallowMixedTestsAndSuites &&
+        shouldReportMixedStructure(currentLayer, currentKind);
+
+    if (reportsMixedStructure) {
+        reportMixedStructure(context, visitorContext);
+    }
+
+    replaceCurrentLayer(layers, createTrackedLayer(currentLayer, currentKind, reportsMixedStructure));
+}
+
+export const consistentStructureRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'suggestion',
+        languages: ['js/js'],
+        docs: {
+            description: 'Require consistent structure for Mocha test entities',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/consistent-structure.md'
+        },
+        defaultOptions: [defaultOption],
+        messages: {
+            unexpectedHookAfterSuite: 'Unexpected hook after a child suite.',
+            unexpectedHookAfterTest: 'Unexpected hook after a test case.',
+            unexpectedMixedTestsAndSuites: 'Unexpected mix of test cases and child suites at the same level.',
+            unexpectedTestAfterSuite: 'Unexpected test case after a child suite.'
+        },
+        schema: [optionSchema]
+    },
+    create(context) {
+        const { order, disallowMixedTestsAndSuites } = getRuleOption<ResolvedOption>(context);
+        const layers: StructureLayer[] = [];
+
+        function registerStructure(visitorContext: Readonly<VisitorContext>): void {
+            const directStructureContext = getDirectStructureContext(layers, visitorContext);
+
+            if (directStructureContext === null) {
+                return;
+            }
+
+            const { currentKind, currentLayer } = directStructureContext;
+            const { highestSeenKind } = currentLayer;
+
+            if (hasUnexpectedOrder(order, highestSeenKind, currentKind)) {
+                reportUnexpectedOrder(context, visitorContext, highestSeenKind);
+            }
+
+            trackStructureLayer(
+                context,
+                layers,
+                { ...directStructureContext, visitorContext },
+                disallowMixedTestsAndSuites
+            );
+        }
+
+        return createMochaVisitors(context, {
+            suite(visitorContext) {
+                registerStructure(visitorContext);
+            },
+
+            suiteCallback(visitorContext) {
+                const { node } = visitorContext;
+
+                if (isFunction(node) && isBlockStatement(node.body)) {
+                    layers.push(createStructureLayer(node.body));
+                }
+            },
+
+            'suiteCallback:exit'(visitorContext) {
+                const { node } = visitorContext;
+
+                if (isFunction(node) && isBlockStatement(node.body)) {
+                    layers.pop();
+                }
+            },
+
+            testCase(visitorContext) {
+                registerStructure(visitorContext);
+            },
+
+            hook(visitorContext) {
+                registerStructure(visitorContext);
+            }
+        });
+    }
+};


### PR DESCRIPTION
Add mocha/consistent-structure to cover the sibling ordering from #35 and the mixed tests/suites check from #104.

Fixes #35 
Fixes #104