### PR TITLE
Add no-nested-suites rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |    |
 | [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
 | [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |    |
+| [no-nested-suites](documentation/rules/no-nested-suites.md)                                   | Disallow suites to be nested within other suites                        |    |    | ✅  |    |    |
 | [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |    |
 | [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    | 💡 |
 | [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |

--- a/documentation/rules/no-nested-suites.md
+++ b/documentation/rules/no-nested-suites.md
@@ -1,0 +1,38 @@
+# Disallow suites to be nested within other suites (`mocha/no-nested-suites`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Nested suites are a valid Mocha pattern, but some projects prefer flatter files where each suite stays at the top level.
+
+## Rule Details
+
+This rule reports suite calls inside another suite. It applies to all supported suite names, including configured custom suite names.
+
+The following patterns are considered warnings:
+
+```js
+describe('root', function () {
+    describe('nested', function () {});
+});
+
+suite('root', function () {
+    suite('nested', function () {});
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('root', function () {
+    it('works', function () {});
+});
+
+describe('first', function () {});
+describe('second', function () {});
+```
+
+## When Not To Use It
+
+If your project uses nested suites to structure tests, or if `mocha/consistent-structure` already expresses the level of nesting discipline you want.

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -14,6 +14,7 @@ import { noHooksForSingleCaseRule } from './rules/no-hooks-for-single-case.js';
 import { noHooksRule } from './rules/no-hooks.js';
 import { noIdenticalTitleRule } from './rules/no-identical-title.js';
 import { noMochaArrowsRule } from './rules/no-mocha-arrows.js';
+import { noNestedSuitesRule } from './rules/no-nested-suites.js';
 import { noNestedTestsRule } from './rules/no-nested-tests.js';
 import { noPendingTestsRule } from './rules/no-pending-tests.js';
 import { noReturnAndCallbackRule } from './rules/no-return-and-callback.js';
@@ -43,6 +44,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-hooks-for-single-case': 'error',
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',
+    'mocha/no-nested-suites': 'error',
     'mocha/no-nested-tests': 'error',
     'mocha/no-pending-tests': 'error',
     'mocha/no-return-and-callback': 'error',
@@ -70,6 +72,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-hooks-for-single-case': 'off',
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',
+    'mocha/no-nested-suites': 'off',
     'mocha/no-nested-tests': 'error',
     'mocha/no-pending-tests': 'warn',
     'mocha/no-return-and-callback': 'error',
@@ -97,6 +100,7 @@ const rules = {
     'no-hooks-for-single-case': noHooksForSingleCaseRule,
     'no-identical-title': noIdenticalTitleRule,
     'no-mocha-arrows': noMochaArrowsRule,
+    'no-nested-suites': noNestedSuitesRule,
     'no-nested-tests': noNestedTestsRule,
     'no-pending-tests': noPendingTestsRule,
     'no-return-and-callback': noReturnAndCallbackRule,

--- a/source/rules/no-nested-suites.test.ts
+++ b/source/rules/no-nested-suites.test.ts
@@ -1,0 +1,77 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { noNestedSuitesRule } from './no-nested-suites.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+
+ruleTester.run('no-nested-suites', noNestedSuitesRule, {
+    valid: [
+        'describe("", function () { it(); });',
+        'describe(""); describe("");',
+        'it("", function () { it(); });',
+        withInterface('TDD', 'suite("", function () { test(); });'),
+        {
+            code: 'foo("", function () { it(); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
+                }
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'describe("", function () { describe(); });',
+            errors: [{
+                message: 'Unexpected suite nested within another suite.',
+                line: 1,
+                column: 28
+            }]
+        },
+        {
+            code: 'context("", function () { describe(); });',
+            errors: [{
+                message: 'Unexpected suite nested within another suite.',
+                line: 1,
+                column: 27
+            }]
+        },
+        withInterface('TDD', {
+            code: 'suite("", function () { suite(); });',
+            errors: [{
+                message: 'Unexpected suite nested within another suite.',
+                line: 1,
+                column: 25
+            }]
+        }),
+        {
+            code: 'describe("", function () { describe("", function () { describe(); }); });',
+            errors: [
+                {
+                    message: 'Unexpected suite nested within another suite.',
+                    line: 1,
+                    column: 28
+                },
+                {
+                    message: 'Unexpected suite nested within another suite.',
+                    line: 1,
+                    column: 55
+                }
+            ]
+        },
+        {
+            code: 'describe("", function () { foo(); });',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
+                }
+            },
+            errors: [{
+                message: 'Unexpected suite nested within another suite.',
+                line: 1,
+                column: 28
+            }]
+        }
+    ]
+});

--- a/source/rules/no-nested-suites.ts
+++ b/source/rules/no-nested-suites.ts
@@ -1,0 +1,37 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+
+export const noNestedSuitesRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'suggestion',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow suites to be nested within other suites',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-nested-suites.md'
+        },
+        messages: {
+            nestedSuite: 'Unexpected suite nested within another suite.'
+        },
+        schema: []
+    },
+    create(context) {
+        let suiteNesting = 0;
+
+        return createMochaVisitors(context, {
+            suite(visitorContext) {
+                if (suiteNesting > 0) {
+                    context.report({
+                        messageId: 'nestedSuite',
+                        node: visitorContext.node
+                    });
+                }
+
+                suiteNesting += 1;
+            },
+
+            'suite:exit'() {
+                suiteNesting -= 1;
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a dedicated mocha/no-nested-suites rule
- enable it in mocha/all and keep it disabled in mocha/recommended
- cover BDD, TDD, and custom suite names, and document the new rule

Closes #83