### PR TITLE
handle-done-callback: require done callback handling in every branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |    |
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
-| [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests                          | ✅  |    |    |    |    |
+| [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |

--- a/documentation/rules/handle-done-callback.md
+++ b/documentation/rules/handle-done-callback.md
@@ -1,4 +1,4 @@
-# Enforces handling of callbacks for async tests (`mocha/handle-done-callback`)
+# Enforces handling of callbacks for async tests in every branch (`mocha/handle-done-callback`)
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
@@ -23,6 +23,7 @@ In this example, the `done` callback is never called, so the test times out.
 ## Rule Details
 
 This rule checks functions passed to `it`, `test`, `specify`, and the standard Mocha hooks.
+The callback must be called or handed off on every reachable path that completes normally.
 
 The following patterns are considered warnings:
 
@@ -33,6 +34,12 @@ it('foo', function (done) {
     asyncFunction(function (err, result) {
         expect(err).to.not.exist;
     });
+});
+
+it('foo', function (done) {
+    if (ready) {
+        done();
+    }
 });
 
 before(function (done) {
@@ -47,6 +54,14 @@ These patterns would not be considered warnings:
 ```js
 it('foo', function (done) {
     done();
+});
+
+it('foo', function (done) {
+    if (ready) {
+        done();
+    } else {
+        setTimeout(done, 0);
+    }
 });
 
 it('foo', function (done) {
@@ -67,6 +82,8 @@ before(function (done) {
     });
 });
 ```
+
+Declaring a nested function that calls `done` does not count unless the current path actually calls or hands off the callback.
 
 When linting TypeScript, a typed `this` parameter is not treated as a `done` callback:
 

--- a/source/done-callback-paths.test.ts
+++ b/source/done-callback-paths.test.ts
@@ -1,0 +1,483 @@
+import type { Rule, Scope, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import {
+    asRuleNodeOrNull,
+    getMemberExpressionBindingAndProperty,
+    hasUnhandledReturnPath,
+    haveSameTrackedBindings,
+    haveSameTrackedContainerProperties,
+    type Operation
+} from './done-callback-paths.js';
+
+type MutableSegment = {
+    id: string;
+    nextSegments: MutableSegment[];
+    prevSegments: MutableSegment[];
+};
+
+type CallOperationNode = Extract<Operation, { type: 'call'; }>['node'];
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
+type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type ObjectExpressionNode = Parameters<Exclude<Rule.RuleListener['ObjectExpression'], undefined>>[0];
+type CallExpressionNode = Parameters<Exclude<Rule.RuleListener['CallExpression'], undefined>>[0];
+type IdentifierNode = Parameters<Exclude<Rule.RuleListener['Identifier'], undefined>>[0];
+type SpreadElementNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'SpreadElement'; }>;
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function createSourceCode(): SourceCode {
+    const scope = {
+        childScopes: [],
+        set: new Map(),
+        upper: null
+    } as unknown as Scope.Scope;
+
+    return asSourceCode({
+        getScope() {
+            return scope;
+        }
+    });
+}
+
+function identifier(name: string): IdentifierNode {
+    return { type: 'Identifier', name } as unknown as IdentifierNode;
+}
+
+function literal(value: number | string | null): Rule.Node {
+    return { type: 'Literal', value } as unknown as Rule.Node;
+}
+
+function privateIdentifier(name: string): Rule.Node {
+    return { type: 'PrivateIdentifier', name } as unknown as Rule.Node;
+}
+
+function memberExpression(
+    object: Readonly<Rule.Node>,
+    propertyNode: Readonly<Rule.Node>,
+    computed = false
+): MemberExpressionNode {
+    return {
+        computed,
+        object,
+        property: propertyNode,
+        type: 'MemberExpression'
+    } as unknown as MemberExpressionNode;
+}
+
+function property(
+    key: Readonly<Rule.Node>,
+    value: Readonly<Rule.Node>,
+    computed = false
+): PropertyNode {
+    return {
+        computed,
+        key,
+        kind: 'init',
+        type: 'Property',
+        value
+    } as unknown as PropertyNode;
+}
+
+function objectExpression(properties: readonly Readonly<PropertyNode>[]): ObjectExpressionNode {
+    return { properties, type: 'ObjectExpression' } as unknown as ObjectExpressionNode;
+}
+
+function callExpression(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): CallExpressionNode {
+    return {
+        arguments: args,
+        callee,
+        type: 'CallExpression'
+    } as unknown as CallExpressionNode;
+}
+
+function spreadElement(argument: Readonly<Rule.Node>): SpreadElementNode {
+    return { argument, type: 'SpreadElement' } as unknown as SpreadElementNode;
+}
+
+function createSegment(id: string): MutableSegment {
+    return { id, nextSegments: [], prevSegments: [] };
+}
+
+function linkSegments(previous: MutableSegment, next: MutableSegment): void {
+    previous.nextSegments.push(next);
+    next.prevSegments.push(previous);
+}
+
+function asCodePathSegment(segment: MutableSegment): Rule.CodePathSegment {
+    return segment as unknown as Rule.CodePathSegment;
+}
+
+function createCodePath(initialSegment: MutableSegment, returnedSegments: readonly MutableSegment[]): Rule.CodePath {
+    return {
+        initialSegment: asCodePathSegment(initialSegment),
+        returnedSegments: returnedSegments.map(asCodePathSegment)
+    } as unknown as Rule.CodePath;
+}
+
+function bindingAssignment(target: string, source: Readonly<Rule.Node> | null): Operation {
+    return { source, target, type: 'bindingAssignment' };
+}
+
+function containerPropertyAssignment(
+    target: string,
+    propertyName: string | undefined,
+    source: Readonly<Rule.Node> | null
+): Operation {
+    return {
+        propertyName,
+        source,
+        target,
+        type: 'containerPropertyAssignment'
+    };
+}
+
+function callOperation(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): Operation {
+    return {
+        node: callExpression(callee, args) as CallOperationNode,
+        type: 'call'
+    };
+}
+
+function analyzeOperations(
+    operationsBySegmentId: ReadonlyMap<string, readonly Operation[]>,
+    codePath: Readonly<Rule.CodePath>
+): boolean {
+    return hasUnhandledReturnPath({
+        callbackBinding: 'done',
+        codePath,
+        operationsBySegmentId,
+        sourceCode: createSourceCode()
+    });
+}
+
+describe('done callback path helpers', function () {
+    it('asRuleNodeOrNull() preserves nullish values', function () {
+        assert.strictEqual(asRuleNodeOrNull(null), null);
+        assert.strictEqual(asRuleNodeOrNull(undefined), null);
+    });
+
+    it('getMemberExpressionBindingAndProperty() resolves static and computed properties', function () {
+        const sourceCode = createSourceCode();
+
+        assert.deepStrictEqual(
+            getMemberExpressionBindingAndProperty(sourceCode, memberExpression(identifier('obj'), identifier('done'))),
+            { binding: 'obj', propertyName: 'done' }
+        );
+        assert.deepStrictEqual(
+            getMemberExpressionBindingAndProperty(
+                sourceCode,
+                memberExpression(identifier('obj'), literal('done'), true)
+            ),
+            { binding: 'obj', propertyName: 'done' }
+        );
+        assert.deepStrictEqual(
+            getMemberExpressionBindingAndProperty(
+                sourceCode,
+                memberExpression(identifier('obj'), identifier('key'), true)
+            ),
+            { binding: 'obj', propertyName: undefined }
+        );
+        assert.deepStrictEqual(
+            getMemberExpressionBindingAndProperty(
+                sourceCode,
+                memberExpression(identifier('obj'), privateIdentifier('done'))
+            ),
+            { binding: 'obj', propertyName: undefined }
+        );
+        assert.strictEqual(
+            getMemberExpressionBindingAndProperty(
+                sourceCode,
+                memberExpression(callExpression(identifier('factory'), []), identifier('done'))
+            ),
+            undefined
+        );
+    });
+
+    it('hasUnhandledReturnPath() keeps aliases shared by every branch', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const right = createSegment('right');
+        const end = createSegment('end');
+
+        linkSegments(start, left);
+        linkSegments(start, right);
+        linkSegments(left, end);
+        linkSegments(right, end);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [bindingAssignment('next', identifier('done'))]],
+                ['right', [bindingAssignment('next', identifier('done'))]],
+                ['end', [callOperation(identifier('foo'), [identifier('next')])]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasUnhandledReturnPath() drops aliases missing from one branch', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const right = createSegment('right');
+        const end = createSegment('end');
+
+        linkSegments(start, left);
+        linkSegments(start, right);
+        linkSegments(left, end);
+        linkSegments(right, end);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [bindingAssignment('next', identifier('done'))]],
+                ['end', [callOperation(identifier('foo'), [identifier('next')])]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasUnhandledReturnPath() keeps shared container properties across branches', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const right = createSegment('right');
+        const end = createSegment('end');
+
+        linkSegments(start, left);
+        linkSegments(start, right);
+        linkSegments(left, end);
+        linkSegments(right, end);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [containerPropertyAssignment('obj', 'someFunc', identifier('done'))]],
+                ['right', [containerPropertyAssignment('obj', 'someFunc', identifier('done'))]],
+                ['end', [callOperation(identifier('foo'), [identifier('obj')])]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasUnhandledReturnPath() drops container properties when branches diverge', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const right = createSegment('right');
+        const end = createSegment('end');
+
+        linkSegments(start, left);
+        linkSegments(start, right);
+        linkSegments(left, end);
+        linkSegments(right, end);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [containerPropertyAssignment('obj', 'someFunc', identifier('done'))]],
+                ['right', [containerPropertyAssignment('obj', 'otherFunc', identifier('done'))]],
+                ['end', [callOperation(identifier('foo'), [identifier('obj')])]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasUnhandledReturnPath() handles inline callback containers with static keys', function () {
+        const start = createSegment('start');
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        callOperation(identifier('foo'), [
+                            objectExpression([property(literal('someFunc'), identifier('done'))])
+                        ])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasUnhandledReturnPath() ignores inline callback containers with dynamic keys', function () {
+        const start = createSegment('start');
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        callOperation(identifier('foo'), [
+                            objectExpression([property(identifier('someFunc'), identifier('done'), true)])
+                        ])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasUnhandledReturnPath() tracks and clears dynamic container properties', function () {
+        const start = createSegment('start');
+
+        const trackedResult = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        containerPropertyAssignment('obj', undefined, identifier('done')),
+                        callOperation(identifier('foo'), [memberExpression(identifier('obj'), identifier('key'), true)])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+        const clearedResult = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        containerPropertyAssignment('obj', undefined, identifier('done')),
+                        containerPropertyAssignment('obj', undefined, null),
+                        callOperation(identifier('foo'), [memberExpression(identifier('obj'), identifier('key'), true)])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(trackedResult, false);
+        assert.strictEqual(clearedResult, true);
+    });
+
+    it('hasUnhandledReturnPath() treats spread callback handoffs as handled', function () {
+        const start = createSegment('start');
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        callOperation(identifier('foo'), [spreadElement(identifier('done'))])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasUnhandledReturnPath() ignores untracked property handoffs', function () {
+        const start = createSegment('start');
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        bindingAssignment('next', null),
+                        callOperation(identifier('foo'), [
+                            memberExpression(callExpression(identifier('factory'), []), identifier('someFunc'))
+                        ]),
+                        callOperation(identifier('foo'), [memberExpression(identifier('obj'), identifier('someFunc'))])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasUnhandledReturnPath() treats missing predecessor states as handled', function () {
+        const start = createSegment('start');
+        const missing = createSegment('missing');
+        const end = createSegment('end');
+
+        linkSegments(start, end);
+        end.prevSegments.push(missing);
+
+        const result = analyzeOperations(new Map(), createCodePath(start, [end]));
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasUnhandledReturnPath() ignores returned segments without exit state', function () {
+        const start = createSegment('start');
+        const missing = createSegment('missing');
+
+        const result = analyzeOperations(new Map(), createCodePath(start, [missing]));
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasUnhandledReturnPath() reuses unchanged loop state', function () {
+        const start = createSegment('start');
+
+        linkSegments(start, start);
+
+        const result = analyzeOperations(
+            new Map([
+                ['start', [containerPropertyAssignment('obj', 'someFunc', identifier('done'))]]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('haveSameTrackedBindings() detects different binding counts', function () {
+        assert.strictEqual(haveSameTrackedBindings(new Set(['done']), new Set()), false);
+    });
+
+    it('haveSameTrackedContainerProperties() detects different tracked properties', function () {
+        assert.strictEqual(
+            haveSameTrackedContainerProperties(
+                new Map([
+                    ['obj', new Set(['someFunc'])]
+                ]),
+                new Map()
+            ),
+            false
+        );
+        assert.strictEqual(
+            haveSameTrackedContainerProperties(
+                new Map([
+                    ['obj', new Set(['someFunc'])]
+                ]),
+                new Map([
+                    ['other', new Set(['someFunc'])],
+                    ['obj', new Set(['someFunc'])]
+                ])
+            ),
+            false
+        );
+        assert.strictEqual(
+            haveSameTrackedContainerProperties(
+                new Map([
+                    ['obj', new Set(['someFunc'])]
+                ]),
+                new Map([
+                    ['obj', new Set(['someFunc', 'otherFunc'])]
+                ])
+            ),
+            false
+        );
+    });
+});

--- a/source/done-callback-paths.ts
+++ b/source/done-callback-paths.ts
@@ -1,0 +1,580 @@
+import { findVariable, getStringIfConstant } from '@eslint-community/eslint-utils';
+import type { Rule, Scope, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
+
+type CallExpressionNode = Parameters<Exclude<Rule.RuleListener['CallExpression'], undefined>>[0];
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
+type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type IdentifierNode = Parameters<Exclude<Rule.RuleListener['Identifier'], undefined>>[0];
+type ObjectExpressionNode = Parameters<Exclude<Rule.RuleListener['ObjectExpression'], undefined>>[0];
+type NodeWithoutParent = Except<Rule.Node, 'parent'>;
+type IdentifierLike = Readonly<Pick<IdentifierNode, 'name' | 'type'>>;
+type MemberExpressionLike = Readonly<Pick<MemberExpressionNode, 'computed' | 'object' | 'property' | 'type'>>;
+type PropertyLike = Readonly<Pick<PropertyNode, 'computed' | 'key' | 'type'>>;
+
+const dynamicPropertyName = '<dynamic>';
+
+export type TrackedBinding = Scope.Variable | string;
+
+export type Operation =
+    | {
+        node: Readonly<CallExpressionNode>;
+        type: 'call';
+    }
+    | {
+        propertyName: string | undefined;
+        source: Readonly<Rule.Node> | null;
+        target: TrackedBinding;
+        type: 'containerPropertyAssignment';
+    }
+    | {
+        source: Readonly<Rule.Node> | null;
+        target: TrackedBinding;
+        type: 'bindingAssignment';
+    };
+
+type PendingPathState = {
+    aliasBindings: Set<TrackedBinding>;
+    containerPropertiesByBinding: Map<TrackedBinding, Set<string>>;
+    hasUnhandledPath: boolean;
+};
+
+type AnalysisContext = {
+    callbackBinding: TrackedBinding;
+    codePath: Readonly<Rule.CodePath>;
+    operationsBySegmentId: ReadonlyMap<string, readonly Operation[]>;
+    sourceCode: Readonly<SourceCode>;
+};
+
+export function asRuleNode(node: unknown): Rule.Node {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- eslint core nodes have parent at runtime
+    return node as Rule.Node;
+}
+
+export function asRuleNodeOrNull(node: Readonly<NodeWithoutParent> | null | undefined): Rule.Node | null {
+    return node === null || node === undefined ? null : asRuleNode(node);
+}
+
+export function getTrackedBinding(sourceCode: Readonly<SourceCode>, node: IdentifierLike): TrackedBinding {
+    return findVariable(sourceCode.getScope(asRuleNode(node)), node.name) ?? node.name;
+}
+
+type BindingAndProperty = {
+    binding: TrackedBinding;
+    propertyName: string | undefined;
+};
+type NonEmptyPendingPathStates = readonly [Readonly<PendingPathState>, ...Readonly<PendingPathState>[]];
+
+function hasPendingPathStates(
+    states: readonly Readonly<PendingPathState>[]
+): states is NonEmptyPendingPathStates {
+    return states.length > 0;
+}
+
+function getComputedPropertyName(
+    sourceCode: Readonly<SourceCode>,
+    node: MemberExpressionLike | PropertyLike
+): string | undefined {
+    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
+
+    return getStringIfConstant(keyNode, sourceCode.getScope(asRuleNode(node))) ?? undefined;
+}
+
+function getNamedPropertyName(node: MemberExpressionLike | PropertyLike): string | undefined {
+    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
+
+    if (keyNode.type === 'Identifier') {
+        return keyNode.name;
+    }
+    if (keyNode.type === 'Literal' && keyNode.value !== null) {
+        return String(keyNode.value);
+    }
+
+    return undefined;
+}
+
+function getStaticPropertyName(
+    sourceCode: Readonly<SourceCode>,
+    node: MemberExpressionLike | PropertyLike
+): string | undefined {
+    return node.computed
+        ? getComputedPropertyName(sourceCode, node)
+        : getNamedPropertyName(node);
+}
+
+export function getMemberExpressionBindingAndProperty(
+    sourceCode: Readonly<SourceCode>,
+    node: MemberExpressionLike
+): Readonly<BindingAndProperty> | undefined {
+    if (node.object.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return {
+        binding: getTrackedBinding(sourceCode, node.object),
+        propertyName: getStaticPropertyName(sourceCode, node)
+    };
+}
+
+function createHandledState(): PendingPathState {
+    return {
+        aliasBindings: new Set(),
+        containerPropertiesByBinding: new Map(),
+        hasUnhandledPath: false
+    };
+}
+
+function createInitialState(callbackBinding: TrackedBinding): PendingPathState {
+    return {
+        aliasBindings: new Set([callbackBinding]),
+        containerPropertiesByBinding: new Map(),
+        hasUnhandledPath: true
+    };
+}
+
+function copyState(state: Readonly<PendingPathState>): PendingPathState {
+    return {
+        aliasBindings: new Set(state.aliasBindings),
+        containerPropertiesByBinding: new Map(
+            Array.from(state.containerPropertiesByBinding, ([binding, properties]) => {
+                return [binding, new Set(properties)] as const;
+            })
+        ),
+        hasUnhandledPath: state.hasUnhandledPath
+    };
+}
+
+export function haveSameTrackedBindings(
+    left: ReadonlySet<TrackedBinding>,
+    right: ReadonlySet<TrackedBinding>
+): boolean {
+    if (left.size !== right.size) {
+        return false;
+    }
+
+    return Array.from(left).every((binding) => {
+        return right.has(binding);
+    });
+}
+
+export function haveSameTrackedContainerProperties(
+    left: ReadonlyMap<TrackedBinding, ReadonlySet<string>>,
+    right: ReadonlyMap<TrackedBinding, ReadonlySet<string>>
+): boolean {
+    if (left.size !== right.size) {
+        return false;
+    }
+
+    return Array.from(left).every(([binding, properties]) => {
+        const otherProperties = right.get(binding);
+
+        if (otherProperties === undefined || properties.size !== otherProperties.size) {
+            return false;
+        }
+
+        return Array.from(properties).every((property) => {
+            return otherProperties.has(property);
+        });
+    });
+}
+
+function sameState(left: Readonly<PendingPathState> | undefined, right: Readonly<PendingPathState>): boolean {
+    return left !== undefined &&
+        left.hasUnhandledPath === right.hasUnhandledPath &&
+        haveSameTrackedBindings(left.aliasBindings, right.aliasBindings) &&
+        haveSameTrackedContainerProperties(
+            left.containerPropertiesByBinding,
+            right.containerPropertiesByBinding
+        );
+}
+
+function intersectBindingSets(states: NonEmptyPendingPathStates): Set<TrackedBinding> {
+    const [firstState, ...otherStates] = states;
+    const bindings = new Set(firstState?.aliasBindings);
+
+    for (const binding of Array.from(bindings)) {
+        const isSharedBinding = otherStates.every((state) => {
+            return state.aliasBindings.has(binding);
+        });
+
+        if (!isSharedBinding) {
+            bindings.delete(binding);
+        }
+    }
+
+    return bindings;
+}
+
+function sharedPropertiesForBinding(
+    binding: TrackedBinding,
+    firstProperties: ReadonlySet<string>,
+    otherStates: readonly Readonly<PendingPathState>[]
+): Set<string> {
+    const sharedProperties = new Set(firstProperties);
+
+    for (const property of Array.from(sharedProperties)) {
+        const isSharedProperty = otherStates.every((state) => {
+            return state.containerPropertiesByBinding.get(binding)?.has(property) === true;
+        });
+
+        if (!isSharedProperty) {
+            sharedProperties.delete(property);
+        }
+    }
+
+    return sharedProperties;
+}
+
+function intersectPropertyMaps(states: NonEmptyPendingPathStates): Map<TrackedBinding, Set<string>> {
+    const [firstState, ...otherStates] = states;
+    const sharedPropertiesByBinding = new Map<TrackedBinding, Set<string>>();
+
+    for (const [binding, properties] of firstState.containerPropertiesByBinding) {
+        const sharedProperties = sharedPropertiesForBinding(binding, properties, otherStates);
+
+        if (sharedProperties.size > 0) {
+            sharedPropertiesByBinding.set(binding, sharedProperties);
+        }
+    }
+
+    return sharedPropertiesByBinding;
+}
+
+function mergeIncomingStates(previousStates: readonly Readonly<PendingPathState>[]): PendingPathState {
+    const unhandledStates = previousStates.filter((state) => {
+        return state.hasUnhandledPath;
+    });
+
+    if (!hasPendingPathStates(unhandledStates)) {
+        return createHandledState();
+    }
+
+    return {
+        aliasBindings: intersectBindingSets(unhandledStates),
+        containerPropertiesByBinding: intersectPropertyMaps(unhandledStates),
+        hasUnhandledPath: true
+    };
+}
+
+function getContainerProperties(
+    state: Readonly<PendingPathState>,
+    binding: TrackedBinding
+): ReadonlySet<string> | undefined {
+    return state.containerPropertiesByBinding.get(binding);
+}
+
+function isTrackedPropertyAccess(
+    sourceCode: Readonly<SourceCode>,
+    node: MemberExpressionLike,
+    state: Readonly<PendingPathState>
+): boolean {
+    const bindingAndProperty = getMemberExpressionBindingAndProperty(sourceCode, node);
+
+    if (bindingAndProperty === undefined) {
+        return false;
+    }
+
+    const properties = getContainerProperties(state, bindingAndProperty.binding);
+
+    if (properties === undefined) {
+        return false;
+    }
+
+    if (bindingAndProperty.propertyName === undefined) {
+        return properties.has(dynamicPropertyName);
+    }
+
+    return properties.has(bindingAndProperty.propertyName);
+}
+
+function isCallbackExpression(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<Rule.Node>,
+    state: Readonly<PendingPathState>
+): boolean {
+    if (node.type === 'Identifier') {
+        return state.aliasBindings.has(getTrackedBinding(sourceCode, node));
+    }
+
+    return node.type === 'MemberExpression' && isTrackedPropertyAccess(sourceCode, node, state);
+}
+
+function collectTrackedObjectProperties(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<ObjectExpressionNode>,
+    state: Readonly<PendingPathState>
+): Set<string> {
+    const trackedProperties = new Set<string>();
+
+    for (const property of node.properties) {
+        if (property.type === 'Property' && property.kind === 'init') {
+            const propertyName = getStaticPropertyName(sourceCode, property);
+            const isTrackedCallback = propertyName !== undefined &&
+                isCallbackExpression(sourceCode, asRuleNode(property.value), state);
+
+            if (isTrackedCallback) {
+                trackedProperties.add(propertyName);
+            }
+        }
+    }
+
+    return trackedProperties;
+}
+
+function getContainerPropertiesFromExpression(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<Rule.Node>,
+    state: Readonly<PendingPathState>
+): Set<string> | undefined {
+    if (node.type === 'Identifier') {
+        const properties = getContainerProperties(state, getTrackedBinding(sourceCode, node));
+
+        return properties === undefined ? undefined : new Set(properties);
+    }
+
+    if (node.type === 'ObjectExpression') {
+        const trackedProperties = collectTrackedObjectProperties(sourceCode, node, state);
+
+        return trackedProperties.size > 0 ? trackedProperties : undefined;
+    }
+
+    return undefined;
+}
+
+function isHandledHandoffExpression(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<Rule.Node>,
+    state: Readonly<PendingPathState>
+): boolean {
+    if (isCallbackExpression(sourceCode, node, state)) {
+        return true;
+    }
+
+    return (getContainerPropertiesFromExpression(sourceCode, node, state)?.size ?? 0) > 0;
+}
+
+function callFinishesPendingPaths(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<CallExpressionNode>,
+    state: Readonly<PendingPathState>
+): boolean {
+    if (isCallbackExpression(sourceCode, asRuleNode(node.callee), state)) {
+        return true;
+    }
+
+    return node.arguments.some((argument) => {
+        const candidate = argument.type === 'SpreadElement' ? argument.argument : argument;
+        return isHandledHandoffExpression(sourceCode, asRuleNode(candidate), state);
+    });
+}
+
+function applyBindingSourceValue(
+    sourceCode: Readonly<SourceCode>,
+    state: PendingPathState,
+    operation: Extract<Operation, { type: 'bindingAssignment'; }>
+): PendingPathState {
+    if (operation.source === null) {
+        return state;
+    }
+
+    if (isCallbackExpression(sourceCode, operation.source, state)) {
+        state.aliasBindings.add(operation.target);
+        return state;
+    }
+
+    const containerProperties = getContainerPropertiesFromExpression(sourceCode, operation.source, state);
+
+    if (containerProperties !== undefined) {
+        state.containerPropertiesByBinding.set(operation.target, containerProperties);
+    }
+
+    return state;
+}
+
+function applyBindingAssignment(
+    sourceCode: Readonly<SourceCode>,
+    state: Readonly<PendingPathState>,
+    operation: Extract<Operation, { type: 'bindingAssignment'; }>
+): PendingPathState {
+    const nextState = copyState(state);
+
+    nextState.aliasBindings.delete(operation.target);
+    nextState.containerPropertiesByBinding.delete(operation.target);
+
+    return applyBindingSourceValue(sourceCode, nextState, operation);
+}
+
+function nextPropertiesForAssignment(
+    currentProperties: ReadonlySet<string> | undefined,
+    propertyName: string | undefined
+): Set<string> {
+    const nextProperties = new Set(currentProperties);
+
+    if (propertyName === undefined) {
+        nextProperties.clear();
+    } else {
+        nextProperties.delete(propertyName);
+    }
+
+    return nextProperties;
+}
+
+function applyContainerPropertyAssignment(
+    sourceCode: Readonly<SourceCode>,
+    state: Readonly<PendingPathState>,
+    operation: Extract<Operation, { type: 'containerPropertyAssignment'; }>
+): PendingPathState {
+    const nextState = copyState(state);
+    const nextProperties = nextPropertiesForAssignment(
+        nextState.containerPropertiesByBinding.get(operation.target),
+        operation.propertyName
+    );
+    const shouldTrackProperty = operation.source !== null &&
+        isCallbackExpression(sourceCode, operation.source, nextState);
+
+    if (shouldTrackProperty) {
+        nextProperties.add(operation.propertyName ?? dynamicPropertyName);
+    }
+
+    if (nextProperties.size === 0) {
+        nextState.containerPropertiesByBinding.delete(operation.target);
+    } else {
+        nextState.containerPropertiesByBinding.set(operation.target, nextProperties);
+    }
+
+    return nextState;
+}
+
+function applyOperation(
+    sourceCode: Readonly<SourceCode>,
+    state: Readonly<PendingPathState>,
+    operation: Operation
+): PendingPathState {
+    if (operation.type === 'bindingAssignment') {
+        return applyBindingAssignment(sourceCode, state, operation);
+    }
+
+    if (operation.type === 'call') {
+        return callFinishesPendingPaths(sourceCode, operation.node, state) ? createHandledState() : copyState(state);
+    }
+
+    return applyContainerPropertyAssignment(sourceCode, state, operation);
+}
+
+function runOperations(
+    sourceCode: Readonly<SourceCode>,
+    entryState: Readonly<PendingPathState>,
+    operations: readonly Operation[]
+): PendingPathState {
+    let nextState = copyState(entryState);
+
+    for (const operation of operations) {
+        if (nextState.hasUnhandledPath) {
+            nextState = applyOperation(sourceCode, nextState, operation);
+        }
+    }
+
+    return nextState;
+}
+
+function computeEntryState(
+    callbackBinding: TrackedBinding,
+    initialSegmentId: string,
+    segment: Readonly<Rule.CodePathSegment>,
+    exitStatesBySegmentId: ReadonlyMap<string, Readonly<PendingPathState>>
+): PendingPathState {
+    if (segment.id === initialSegmentId) {
+        return createInitialState(callbackBinding);
+    }
+
+    return mergeIncomingStates(segment.prevSegments.map((previousSegment) => {
+        return exitStatesBySegmentId.get(previousSegment.id) ?? createHandledState();
+    }));
+}
+
+function enqueueNextSegments(
+    nextSegments: readonly Readonly<Rule.CodePathSegment>[],
+    pendingSegments: Rule.CodePathSegment[],
+    queuedSegmentIds: Set<string>
+): void {
+    for (const nextSegment of nextSegments) {
+        if (!queuedSegmentIds.has(nextSegment.id)) {
+            pendingSegments.push(nextSegment);
+            queuedSegmentIds.add(nextSegment.id);
+        }
+    }
+}
+
+function segmentHasUnhandledReturnPath(
+    exitStatesBySegmentId: ReadonlyMap<string, Readonly<PendingPathState>>,
+    segment: Readonly<Rule.CodePathSegment>
+): boolean {
+    return (exitStatesBySegmentId.get(segment.id) ?? createHandledState()).hasUnhandledPath;
+}
+
+type PendingSegmentQueue = {
+    exitStatesBySegmentId: Map<string, Readonly<PendingPathState>>;
+    pendingSegments: Rule.CodePathSegment[];
+    queuedSegmentIds: Set<string>;
+};
+
+function processPendingSegment(
+    context: Readonly<AnalysisContext>,
+    segment: Readonly<Rule.CodePathSegment>,
+    exitStatesBySegmentId: Map<string, Readonly<PendingPathState>>
+): Readonly<PendingPathState> {
+    const entryState = computeEntryState(
+        context.callbackBinding,
+        context.codePath.initialSegment.id,
+        segment,
+        exitStatesBySegmentId
+    );
+
+    return runOperations(
+        context.sourceCode,
+        entryState,
+        context.operationsBySegmentId.get(segment.id) ?? []
+    );
+}
+
+function hasUnprocessedSegments(pendingSegments: readonly Rule.CodePathSegment[]): boolean {
+    return pendingSegments.length > 0;
+}
+
+function createPendingSegmentQueue(context: Readonly<AnalysisContext>): PendingSegmentQueue {
+    return {
+        exitStatesBySegmentId: new Map<string, Readonly<PendingPathState>>(),
+        pendingSegments: [context.codePath.initialSegment],
+        queuedSegmentIds: new Set([context.codePath.initialSegment.id])
+    };
+}
+
+function processAllPendingSegments(
+    context: Readonly<AnalysisContext>,
+    queue: PendingSegmentQueue
+): void {
+    while (hasUnprocessedSegments(queue.pendingSegments)) {
+        const segment = queue.pendingSegments.shift();
+
+        if (segment !== undefined) {
+            queue.queuedSegmentIds.delete(segment.id);
+
+            const nextState = processPendingSegment(context, segment, queue.exitStatesBySegmentId);
+
+            if (!sameState(queue.exitStatesBySegmentId.get(segment.id), nextState)) {
+                queue.exitStatesBySegmentId.set(segment.id, nextState);
+                enqueueNextSegments(segment.nextSegments, queue.pendingSegments, queue.queuedSegmentIds);
+            }
+        }
+    }
+}
+
+export function hasUnhandledReturnPath(context: Readonly<AnalysisContext>): boolean {
+    const queue = createPendingSegmentQueue(context);
+
+    processAllPendingSegments(context, queue);
+
+    return context.codePath.returnedSegments.some((segment) => {
+        return segmentHasUnhandledReturnPath(queue.exitStatesBySegmentId, segment);
+    });
+}

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -17,14 +17,29 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         'it("", function (done) { done(); });',
         'it("", function () { callback(); });',
         'it("", function (callback) { callback(); });',
-        'it("", function (done) { if (a) { done(); } });',
-        'it("", function (done) { function foo() { done(); } });',
+        'it("", function (done) { if (a) { done(); } else { done(); } });',
+        'it("", function (done) { if (a) { setTimeout(done, 300); } else { done(); } });',
+        'it("", function (done) { if (a) { var next = done; next(); } else { done(); } });',
+        'it("", function (done) { var next; if (a) { next = done; } else { next = done; } next(); });',
         'it("", function (done) { setTimeout(done, 300); });',
         'it("", function (done) { var obj = { someFunc: done }; somethingThatCallsSomeFuncOnObj(obj); });',
+        'it("", function (done) { var obj = {}; if (a) { obj.someFunc = done; } else { obj.someFunc = done; } somethingThatCallsSomeFuncOnObj(obj); });',
         'it("", function (done) { somethingThatCallsSomeFuncOnObj({ someFunc: done }); });',
+        'it("", function (done) { somethingThatCallsSomeFuncOnObj({ "someFunc": done }); });',
         'it("", function (done) { obj.someFunc = done; somethingThatCallsSomeFuncOnObj(obj); });',
+        'it("", function (done) { var key = "someFunc"; var obj = {}; obj[key] = done; somethingThatCallsSomeFuncOnObj(obj[key]); });',
+        'it("", function (done) { var obj = {}; obj["someFunc"] = done; somethingThatCallsSomeFuncOnObj(obj); });',
         'it("", function (done) { done(new Error("foo")); });',
         'it("", function (done) { promise.then(done).catch(done); });',
+        'it("", function (done) { var [next] = [done]; done(); });',
+        'it("", function (done) { ({ current: next } = source); done(); });',
+        'it("", function (done) { factory().someFunc = done; done(); });',
+        'it("", function (done) { var count = 0; count++; done(); });',
+        'it("", function (done) { var obj = { someFunc: done }; obj.someFunc++; done(); });',
+        'it("", function (done) { factory().someFunc++; done(); });',
+        'it("", function (done) { typeof done; done(); });',
+        'it("", function (done) { delete factory().someFunc; done(); });',
+        'it("", function (done) { var obj = { someFunc: done }; delete obj.someFunc; done(); });',
         'it.only("", function (done) { done(); });',
         withInterface('TDD', 'test("", function (done) { done(); });'),
         withInterface('TDD', 'test.only("", function (done) { done(); });'),
@@ -40,6 +55,10 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         {
             code: 'it.skip("", function (done) { });',
             options: [{ ignorePending: true }]
+        },
+        {
+            code: 'it("", function (done) { (done as number)++; done(); });',
+            languageOptions: typescriptLanguageOptions
         },
         {
             code: 'before(async function setupApplication(this: Mocha.Context) { this.timeout(6000); });',
@@ -70,6 +89,44 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         },
         {
             code: 'it("", function (done) { asyncFunction(function (error) { expect(error).to.be.null; }); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { if (a) { done(); } });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { function foo() { done(); } });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { if (a) { setTimeout(done, 300); } });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { var next; if (a) { next = done; } next(); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { done = other; done(); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { var obj = {}; if (a) { obj.someFunc = done; } ' +
+                'somethingThatCallsSomeFuncOnObj(obj); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { somethingThatCallsSomeFuncOnObj({ [someFunc]: done }); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { var key = "someFunc"; var obj = {}; obj[key] = done; ' +
+                'delete obj[key]; somethingThatCallsSomeFuncOnObj(obj[key]); });',
+            errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
+        },
+        {
+            code: 'it("", function (done) { somethingThatCallsSomeFuncOnObj(obj.someFunc); });',
             errors: [{ message: 'Expected "done" callback to be handled.', column: 18, line: 1 }]
         },
         {
@@ -134,6 +191,17 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
 });
 
 describe('handle-done-callback helpers', function () {
+    it('findParamInScope() returns parameter variables', function () {
+        const variable = { defs: [{ type: 'Parameter' }] };
+        const result = findParamInScope('done', {
+            set: new Map([
+                ['done', variable]
+            ])
+        } as unknown as Scope.Scope);
+
+        assert.strictEqual(result, variable);
+    });
+
     it('findParamInScope() ignores non-parameter variables', function () {
         const result = findParamInScope('done', {
             set: new Map([

--- a/source/rules/handle-done-callback.ts
+++ b/source/rules/handle-done-callback.ts
@@ -1,7 +1,16 @@
 import type { Rule, Scope } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { getParentNode, isIdentifier } from '../ast/node-types.js';
-import type { FunctionExpression } from '../ast/node-types.js';
+import { isFunction, isIdentifier } from '../ast/node-types.js';
+import type { AnyFunction } from '../ast/node-types.js';
+import {
+    asRuleNode,
+    asRuleNodeOrNull,
+    getMemberExpressionBindingAndProperty,
+    getTrackedBinding,
+    hasUnhandledReturnPath,
+    type Operation,
+    type TrackedBinding
+} from '../done-callback-paths.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 const optionSchema = {
@@ -18,6 +27,20 @@ type Option = InferSchemaOption<typeof optionSchema>;
 type ResolvedOption = Option & { ignorePending: boolean; };
 const defaultOption: ResolvedOption = { ignorePending: false };
 
+type TrackedFunctionState = {
+    callback: Rule.Node;
+    callbackBinding: TrackedBinding;
+    callbackName: string;
+    codePath: Readonly<Rule.CodePath>;
+    currentSegments: Set<Rule.CodePathSegment>;
+    operationsBySegmentId: Map<string, Operation[]>;
+};
+
+type FunctionState = {
+    tracked: TrackedFunctionState | undefined;
+    upper: FunctionState | null;
+};
+
 export function findParamInScope(
     paramName: string,
     scope: Readonly<Scope.Scope>
@@ -27,13 +50,13 @@ export function findParamInScope(
     return variable?.defs[0]?.type === 'Parameter' ? variable : undefined;
 }
 
-function isTypeScriptThisParameter(param: FunctionExpression['params'][number]): boolean {
+function isTypeScriptThisParameter(param: AnyFunction['params'][number]): boolean {
     return isIdentifier(param) && param.name === 'this';
 }
 
 function getDoneCallback(
-    functionExpression: Readonly<FunctionExpression>
-): FunctionExpression['params'][number] | undefined {
+    functionExpression: Readonly<AnyFunction>
+): AnyFunction['params'][number] | undefined {
     const [firstParam, secondParam] = functionExpression.params;
 
     if (firstParam === undefined) {
@@ -43,12 +66,75 @@ function getDoneCallback(
     return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
 }
 
+function pushOperation(
+    operationsBySegmentId: Map<string, Operation[]>,
+    segmentId: string,
+    operation: Readonly<Operation>
+): void {
+    const operations = operationsBySegmentId.get(segmentId);
+
+    if (operations === undefined) {
+        operationsBySegmentId.set(segmentId, [operation]);
+        return;
+    }
+
+    operations.push(operation);
+}
+
+function createTrackedFunctionState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    trackedCallbackNodes: Readonly<WeakSet<Rule.Node>>,
+    codePath: Readonly<Rule.CodePath>,
+    node: Readonly<Rule.Node>
+): TrackedFunctionState | undefined {
+    if (!trackedCallbackNodes.has(node) || !isFunction(node)) {
+        return undefined;
+    }
+
+    const callback = getDoneCallback(node);
+
+    if (callback === undefined || callback.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return {
+        callback: asRuleNode(callback),
+        callbackBinding: getTrackedBinding(sourceCode, callback),
+        callbackName: callback.name,
+        codePath,
+        currentSegments: new Set(),
+        operationsBySegmentId: new Map()
+    };
+}
+
+function reportUnhandledDoneCallback(
+    context: Readonly<Rule.RuleContext>,
+    trackedFunction: Readonly<TrackedFunctionState>
+): void {
+    const hasUnhandledPath = hasUnhandledReturnPath({
+        callbackBinding: trackedFunction.callbackBinding,
+        codePath: trackedFunction.codePath,
+        operationsBySegmentId: trackedFunction.operationsBySegmentId,
+        sourceCode: context.sourceCode
+    });
+
+    if (!hasUnhandledPath) {
+        return;
+    }
+
+    context.report({
+        node: trackedFunction.callback,
+        messageId: 'expectedCallback',
+        data: { name: trackedFunction.callbackName }
+    });
+}
+
 export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
         languages: ['js/js'],
         docs: {
-            description: 'Enforces handling of callbacks for async tests',
+            description: 'Enforces handling of callbacks for async tests in every branch',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/handle-done-callback.md'
         },
         defaultOptions: [defaultOption],
@@ -59,41 +145,23 @@ export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
     },
     create(context) {
         const { ignorePending } = getRuleOption<ResolvedOption>(context);
+        const trackedCallbackNodes = new WeakSet<Rule.Node>();
+        let currentFunction: FunctionState | null = null;
 
-        function isReferenceHandled(reference: Readonly<Scope.Reference>): boolean {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- eslint core typing omits parent
-            const node = reference.identifier as Rule.Node;
-            const parent = getParentNode(node);
+        function recordOperation(operation: Readonly<Operation>): void {
+            const trackedFunction = currentFunction?.tracked;
 
-            return (
-                parent.type === 'CallExpression' ||
-                (parent.type === 'Property' && parent.value === node) ||
-                (parent.type === 'AssignmentExpression' && parent.right === node)
-            );
-        }
-
-        function hasHandledReferences(references: readonly Scope.Reference[]): boolean {
-            return references.some(isReferenceHandled);
-        }
-
-        function checkAsyncMochaFunction(functionExpression: Readonly<FunctionExpression>): void {
-            const scope = context.sourceCode.getScope(functionExpression);
-            const callback = getDoneCallback(functionExpression);
-
-            if (callback === undefined || callback.type !== 'Identifier') {
+            if (trackedFunction === undefined) {
                 return;
             }
 
-            const callbackName = callback.name;
-            const callbackVariable = findParamInScope(callbackName, scope);
-
-            if (callbackVariable !== undefined && !hasHandledReferences(callbackVariable.references)) {
-                context.report({
-                    node: callback,
-                    messageId: 'expectedCallback',
-                    data: { name: callbackName }
-                });
+            for (const segment of trackedFunction.currentSegments) {
+                pushOperation(trackedFunction.operationsBySegmentId, segment.id, operation);
             }
+        }
+
+        function trackMochaCallback(node: Readonly<Rule.Node>): void {
+            trackedCallbackNodes.add(node);
         }
 
         return createMochaVisitors(context, {
@@ -102,13 +170,127 @@ export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
                     return;
                 }
 
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ok in this case
-                checkAsyncMochaFunction(visitorContext.node as FunctionExpression);
+                trackMochaCallback(visitorContext.node);
             },
 
             hookCallback(visitorContext) {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ok in this case
-                checkAsyncMochaFunction(visitorContext.node as FunctionExpression);
+                trackMochaCallback(visitorContext.node);
+            },
+
+            onCodePathStart(codePath, node) {
+                currentFunction = {
+                    tracked: createTrackedFunctionState(context.sourceCode, trackedCallbackNodes, codePath, node),
+                    upper: currentFunction
+                };
+            },
+
+            onCodePathEnd() {
+                const trackedFunction = currentFunction?.tracked;
+
+                if (trackedFunction !== undefined) {
+                    reportUnhandledDoneCallback(context, trackedFunction);
+                }
+
+                currentFunction = currentFunction?.upper ?? null;
+            },
+
+            onCodePathSegmentStart(segment) {
+                currentFunction?.tracked?.currentSegments.add(segment);
+            },
+
+            onCodePathSegmentEnd(segment) {
+                currentFunction?.tracked?.currentSegments.delete(segment);
+            },
+
+            'CallExpression:exit'(node) {
+                recordOperation({ node, type: 'call' });
+            },
+
+            'VariableDeclarator:exit'(node) {
+                if (node.id.type !== 'Identifier') {
+                    return;
+                }
+
+                recordOperation({
+                    source: asRuleNodeOrNull(node.init),
+                    target: getTrackedBinding(context.sourceCode, node.id),
+                    type: 'bindingAssignment'
+                });
+            },
+
+            'AssignmentExpression:exit'(node) {
+                if (node.left.type === 'Identifier') {
+                    recordOperation({
+                        source: asRuleNode(node.right),
+                        target: getTrackedBinding(context.sourceCode, node.left),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.left.type !== 'MemberExpression') {
+                    return;
+                }
+
+                const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.left);
+
+                if (bindingAndProperty === undefined) {
+                    return;
+                }
+
+                recordOperation({
+                    propertyName: bindingAndProperty.propertyName,
+                    source: asRuleNode(node.right),
+                    target: bindingAndProperty.binding,
+                    type: 'containerPropertyAssignment'
+                });
+            },
+
+            'UpdateExpression:exit'(node) {
+                if (node.argument.type === 'Identifier') {
+                    recordOperation({
+                        source: null,
+                        target: getTrackedBinding(context.sourceCode, node.argument),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.argument.type !== 'MemberExpression') {
+                    return;
+                }
+
+                const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                if (bindingAndProperty === undefined) {
+                    return;
+                }
+
+                recordOperation({
+                    propertyName: bindingAndProperty.propertyName,
+                    source: null,
+                    target: bindingAndProperty.binding,
+                    type: 'containerPropertyAssignment'
+                });
+            },
+
+            'UnaryExpression:exit'(node) {
+                if (node.operator !== 'delete' || node.argument.type !== 'MemberExpression') {
+                    return;
+                }
+
+                const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                if (bindingAndProperty === undefined) {
+                    return;
+                }
+
+                recordOperation({
+                    propertyName: bindingAndProperty.propertyName,
+                    source: null,
+                    target: bindingAndProperty.binding,
+                    type: 'containerPropertyAssignment'
+                });
             }
         });
     }


### PR DESCRIPTION
Require `mocha/handle-done-callback` to handle the callback on every reachable normal-return path.

This switches the rule to code path analysis, keeps callback handoffs branch-complete, and updates tests and docs for the stricter default behavior.

Fixes #19.