### PR TITLE
Add rule for async operations in synchronous tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
+| [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |

--- a/documentation/rules/no-async-in-sync-tests.md
+++ b/documentation/rules/no-async-in-sync-tests.md
@@ -1,0 +1,70 @@
+# Disallow async operations in synchronous tests or hooks (`mocha/no-async-in-sync-tests`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Mocha only waits for asynchronous work when a test or hook uses one of Mocha's async entry points: a `done` callback, an `async` function, or a returned promise.
+
+This rule catches suspicious async work inside callbacks that Mocha still treats as synchronous.
+
+## Rule Details
+
+The rule checks synchronous Mocha tests and hooks for two patterns:
+
+- Promise-based work that is started without being returned.
+- Callback-based work where an inline callback starts with an `err` or `error` parameter.
+
+When TypeScript parser services with type information are available, promise detection uses the exact `PromiseLike` return type of the expression. Without type information, the rule falls back to `.then()`, `.catch()`, and `.finally()` call chains.
+
+The following patterns are considered warnings:
+
+```js
+it('loads data', function () {
+    loadData(function (error, result) {
+        expect(error).to.not.exist;
+        expect(result).to.deep.equal({ ok: true });
+    });
+});
+
+it('loads data', function () {
+    loadData().then(function (result) {
+        expect(result).to.deep.equal({ ok: true });
+    });
+});
+
+before(function () {
+    initialize().finally(cleanup);
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+it('loads data', function (done) {
+    loadData(function (error, result) {
+        expect(error).to.not.exist;
+        expect(result).to.deep.equal({ ok: true });
+        done();
+    });
+});
+
+it('loads data', async function () {
+    expect(await loadData()).to.deep.equal({ ok: true });
+});
+
+it('loads data', function () {
+    return loadData().then(function (result) {
+        expect(result).to.deep.equal({ ok: true });
+    });
+});
+```
+
+## When Not To Use It
+
+- If your project intentionally mixes synchronous Mocha callbacks with background async work.
+- If the JavaScript fallback heuristics are too noisy for your codebase.
+
+## Further Reading
+
+- [Asynchronous code](https://mochajs.org/#asynchronous-code)

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -6,6 +6,7 @@ import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-b
 import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
+import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
@@ -36,6 +37,7 @@ const allRules: Linter.RulesRecord = {
     ],
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': 'error',
+    'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-exports': 'error',
@@ -64,6 +66,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-structure': ['error', { disallowDuplicateHooks: true }],
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
+    'mocha/no-async-in-sync-tests': 'off',
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
@@ -92,6 +95,7 @@ const rules = {
     'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
+    'no-async-in-sync-tests': noAsyncInSyncTestsRule,
     'no-async-suite': noAsyncSuiteRule,
     'no-exclusive-tests': noExclusiveTestsRule,
     'no-exports': noExportsRule,

--- a/source/rules/no-async-in-sync-tests.test.ts
+++ b/source/rules/no-async-in-sync-tests.test.ts
@@ -1,0 +1,210 @@
+import * as typescriptParser from '@typescript-eslint/parser';
+import { RuleTester, type SourceCode } from 'eslint';
+import assert from 'node:assert';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { isRecord } from '../record.js';
+import {
+    collectCandidateExpressions,
+    getParserServicesWithTypeInformation,
+    hasPromiseLikeType,
+    noAsyncInSyncTestsRule,
+    unwrapChainExpression
+} from './no-async-in-sync-tests.js';
+
+const slowTypedTestTimeout = 30_000;
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const { pathname: projectRoot } = new URL('../../', import.meta.url);
+const { pathname: typescriptFilename } = new URL('./no-async-in-sync-tests.fixture.ts', import.meta.url);
+const typescriptLanguageOptions = {
+    parser: typescriptParser,
+    parserOptions: {
+        projectService: { allowDefaultProject: ['source/rules/*.fixture.ts'] },
+        tsconfigRootDir: projectRoot
+    },
+    sourceType: 'module'
+} as const;
+type RuleTesterTestFunction = (testName: string, callback: () => void) => unknown;
+type TimedTest = {
+    timeout: (duration: number) => void;
+};
+
+function getRuleTesterTestFunction(testFn: typeof RuleTester.it): RuleTesterTestFunction {
+    if (testFn === null) {
+        throw new Error('Expected RuleTester.it to be available.');
+    }
+
+    return testFn;
+}
+
+const defaultIt = getRuleTesterTestFunction(RuleTester.it);
+const defaultItOnly = getRuleTesterTestFunction(RuleTester.itOnly);
+
+function hasTimeoutMethod(value: unknown): value is TimedTest {
+    return isRecord(value) && typeof value.timeout === 'function';
+}
+
+function withLongerTimeout(testFn: RuleTesterTestFunction): RuleTesterTestFunction {
+    return function runWithLongerTimeout(testName, callback): void {
+        const testCase = testFn(testName, callback);
+
+        if (hasTimeoutMethod(testCase)) {
+            testCase.timeout(slowTypedTestTimeout);
+        }
+    };
+}
+
+RuleTester.it = withLongerTimeout(defaultIt);
+RuleTester.itOnly = withLongerTimeout(defaultItOnly);
+
+ruleTester.run('no-async-in-sync-tests', noAsyncInSyncTestsRule, {
+    valid: [
+        'it("", function () {});',
+        'it("", function (done) { load(function (error) { done(error); }); });',
+        'it("", async function () { await load(); });',
+        'it("", function () { return load().then(function () {}); });',
+        'it("", () => load().then(function () {}));',
+        'it("", function () { promise[method](cleanup); });',
+        'it("", function () { return 42; });',
+        'before(function () { return task().finally(cleanup); });',
+        'describe("", function () { load().then(function () {}); });',
+        {
+            code: 'it("", function () { queryBuilder().catch(function (reason) {}); });\n' +
+                'declare function queryBuilder(): { catch(callback: (reason: unknown) => number): number; };',
+            filename: typescriptFilename,
+            languageOptions: typescriptLanguageOptions
+        },
+        {
+            code: 'it("", function () { return returnsPromise(); });\n' +
+                'declare function returnsPromise(): Promise<number>;',
+            filename: typescriptFilename,
+            languageOptions: typescriptLanguageOptions
+        },
+        withInterface('TDD', 'test("", function () { return task().then(function () {}); });')
+    ],
+
+    invalid: [
+        {
+            code: 'it("", function () { load(function (error) {}); });',
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { load(function (err, result) { use(result); }); });',
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { return load(function (error) {}); });',
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { load().then(function () {}); });',
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { something(load().catch(function (reason) {})); });',
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { promise["then"](cleanup); });',
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { promise?.then(cleanup); });',
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", () => load(function (error) {}));',
+            languageOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        {
+            code: 'before(function () { initialize(function (error) {}); });',
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        withInterface('TDD', {
+            code: 'test("", function () { task().finally(cleanup); });',
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        }),
+        {
+            code: 'it("", function () { returnsPromise(); });\n' +
+                'declare function returnsPromise(): Promise<number>;',
+            filename: typescriptFilename,
+            languageOptions: typescriptLanguageOptions,
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { load(function (error) {}); });\n' +
+                'declare function load(callback: (error: Error | null) => void): void;',
+            filename: typescriptFilename,
+            languageOptions: typescriptLanguageOptions,
+            errors: [{ messageId: 'unexpectedCallbackAsyncOperation' }]
+        },
+        {
+            code: 'it("", function (this: Mocha.Context) { returnsPromise(); });\n' +
+                'declare function returnsPromise(): Promise<number>;',
+            filename: typescriptFilename,
+            languageOptions: typescriptLanguageOptions,
+            errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        }
+    ]
+});
+
+RuleTester.it = defaultIt;
+RuleTester.itOnly = defaultItOnly;
+
+describe('no-async-in-sync-tests helpers', function () {
+    it('getParserServicesWithTypeInformation() ignores non-object parser services', function () {
+        const result = getParserServicesWithTypeInformation({
+            parserServices: null
+        } as unknown as SourceCode);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it('getParserServicesWithTypeInformation() ignores parser services without typed accessors', function () {
+        const result = getParserServicesWithTypeInformation({
+            parserServices: {}
+        } as unknown as SourceCode);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it('hasPromiseLikeType() returns false when typed access throws', function () {
+        const result = hasPromiseLikeType({
+            getTypeAtLocation() {
+                throw new Error('boom');
+            },
+            program: {
+                getTypeChecker() {
+                    return {
+                        getPromisedTypeOfPromise() {
+                            return true;
+                        }
+                    };
+                }
+            }
+        }, { type: 'Identifier' } as never);
+
+        assert.strictEqual(result, false);
+    });
+
+    it('collectCandidateExpressions() ignores nodes without configured visitor keys', function () {
+        const result = collectCandidateExpressions({
+            visitorKeys: {}
+        } as unknown as SourceCode, {
+            type: 'BlockStatement',
+            body: [{ type: 'UnknownStatement' }]
+        } as never);
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('unwrapChainExpression() returns the inner expression for optional chains', function () {
+        const result = unwrapChainExpression({
+            type: 'ChainExpression',
+            expression: { type: 'Identifier', name: 'promise' }
+        } as never);
+
+        assert.deepStrictEqual(result, { type: 'Identifier', name: 'promise' });
+    });
+});

--- a/source/rules/no-async-in-sync-tests.ts
+++ b/source/rules/no-async-in-sync-tests.ts
@@ -1,0 +1,368 @@
+import type { Rule, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type AnyFunction, isFunction, isIdentifier } from '../ast/node-types.js';
+import { asRuleNode } from '../done-callback-paths.js';
+import { isRecord } from '../record.js';
+
+type TraversableNode = Except<Rule.Node, 'parent'>;
+type CallExpression = Extract<TraversableNode, { type: 'CallExpression'; }>;
+type UnexpectedAsyncOperation = {
+    messageId: 'unexpectedCallbackAsyncOperation' | 'unexpectedPromiseAsyncOperation';
+    node: TraversableNode;
+};
+
+type TypeCheckerLike = {
+    getPromisedTypeOfPromise: (type: unknown) => unknown;
+};
+
+type ProgramLike = {
+    getTypeChecker: () => Readonly<TypeCheckerLike>;
+};
+
+type ParserServicesWithTypeInformation = {
+    program: Readonly<ProgramLike>;
+    getTypeAtLocation: (node: Readonly<Rule.Node>) => unknown;
+};
+
+const errorCallbackNames = new Set(['err', 'error']);
+const promiseMethodNames = new Set(['then', 'catch', 'finally']);
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
+
+function visitChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (isNode(item)) {
+                    visitor(item);
+                }
+            });
+        } else if (isNode(value)) {
+            visitor(value);
+        }
+    }
+}
+
+function visitWithoutNestedFunctions(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    visitor(node);
+
+    if (isFunction(node)) {
+        return;
+    }
+
+    visitChildNodes(sourceCode, node, (childNode) => {
+        visitWithoutNestedFunctions(sourceCode, childNode, visitor);
+    });
+}
+
+export function collectCandidateExpressions(
+    sourceCode: Readonly<SourceCode>,
+    body: Readonly<AnyFunction['body']>
+): TraversableNode[] {
+    if (body.type !== 'BlockStatement') {
+        return [body];
+    }
+
+    const expressions: TraversableNode[] = [];
+
+    for (const statement of body.body) {
+        visitWithoutNestedFunctions(sourceCode, statement, (node) => {
+            if (node.type === 'ExpressionStatement') {
+                expressions.push(node.expression);
+            } else if (node.type === 'ReturnStatement' && node.argument !== null && node.argument !== undefined) {
+                expressions.push(node.argument);
+            }
+        });
+    }
+
+    return expressions;
+}
+
+function collectReturnedExpressions(
+    sourceCode: Readonly<SourceCode>,
+    body: Readonly<AnyFunction['body']>
+): readonly TraversableNode[] {
+    if (body.type !== 'BlockStatement') {
+        return [body];
+    }
+
+    const expressions: TraversableNode[] = [];
+
+    for (const statement of body.body) {
+        visitWithoutNestedFunctions(sourceCode, statement, (node) => {
+            if (node.type === 'ReturnStatement' && node.argument !== null && node.argument !== undefined) {
+                expressions.push(node.argument);
+            }
+        });
+    }
+
+    return expressions;
+}
+
+function isGetPromisedTypeOfPromise(value: unknown): value is TypeCheckerLike['getPromisedTypeOfPromise'] {
+    return typeof value === 'function';
+}
+
+function isTypeCheckerLike(value: unknown): value is TypeCheckerLike {
+    return isRecord(value) && isGetPromisedTypeOfPromise(value.getPromisedTypeOfPromise);
+}
+
+function isGetTypeChecker(value: unknown): value is ProgramLike['getTypeChecker'] {
+    return typeof value === 'function';
+}
+
+function isProgramLike(value: unknown): value is ProgramLike {
+    return isRecord(value) &&
+        isGetTypeChecker(value.getTypeChecker) &&
+        isTypeCheckerLike(value.getTypeChecker());
+}
+
+function isGetTypeAtLocation(value: unknown): value is ParserServicesWithTypeInformation['getTypeAtLocation'] {
+    return typeof value === 'function';
+}
+
+export function getParserServicesWithTypeInformation(
+    sourceCode: Readonly<SourceCode>
+): Readonly<ParserServicesWithTypeInformation> | undefined {
+    const services: unknown = sourceCode.parserServices;
+
+    if (!isRecord(services)) {
+        return undefined;
+    }
+
+    if (!isGetTypeAtLocation(services.getTypeAtLocation) || !isProgramLike(services.program)) {
+        return undefined;
+    }
+
+    return {
+        program: services.program,
+        getTypeAtLocation: services.getTypeAtLocation
+    };
+}
+
+export function hasPromiseLikeType(
+    parserServices: Readonly<ParserServicesWithTypeInformation>,
+    expression: Readonly<TraversableNode>
+): boolean {
+    try {
+        const type = parserServices.getTypeAtLocation(asRuleNode(expression));
+        return parserServices.program.getTypeChecker().getPromisedTypeOfPromise(type) !== undefined;
+    } catch {
+        return false;
+    }
+}
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
+    return param !== undefined && isIdentifier(param) && param.name === 'this';
+}
+
+function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = node.params;
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
+}
+
+function hasDoneCallbackParameter(node: Readonly<AnyFunction>): boolean {
+    return getFirstMeaningfulParameter(node) !== undefined;
+}
+
+export function unwrapChainExpression(node: Readonly<TraversableNode>): Readonly<TraversableNode> {
+    return node.type === 'ChainExpression' ? node.expression : node;
+}
+
+function getNamedPropertyName(
+    node: Readonly<Extract<TraversableNode, { type: 'MemberExpression'; }>>
+): string | undefined {
+    return !node.computed && node.property.type === 'Identifier' ? node.property.name : undefined;
+}
+
+function getComputedStringPropertyName(
+    node: Readonly<Extract<TraversableNode, { type: 'MemberExpression'; }>>
+): string | undefined {
+    return node.computed && node.property.type === 'Literal' && typeof node.property.value === 'string'
+        ? node.property.value
+        : undefined;
+}
+
+function getStaticPropertyName(node: Readonly<TraversableNode>): string | undefined {
+    if (node.type !== 'MemberExpression') {
+        return undefined;
+    }
+
+    return getNamedPropertyName(node) ?? getComputedStringPropertyName(node);
+}
+
+function isPromiseMethodCall(node: Readonly<CallExpression>): boolean {
+    const callee = unwrapChainExpression(node.callee);
+
+    return promiseMethodNames.has(getStaticPropertyName(callee) ?? '');
+}
+
+function collectCallExpressions(
+    sourceCode: Readonly<SourceCode>,
+    expression: Readonly<TraversableNode>
+): readonly Readonly<CallExpression>[] {
+    const callExpressions: CallExpression[] = [];
+
+    visitWithoutNestedFunctions(sourceCode, expression, (node) => {
+        if (node.type === 'CallExpression') {
+            callExpressions.push(node);
+        }
+    });
+
+    return callExpressions;
+}
+
+function findPromiseMethodCall(
+    sourceCode: Readonly<SourceCode>,
+    expression: Readonly<TraversableNode>
+): Readonly<CallExpression | undefined> {
+    return collectCallExpressions(sourceCode, expression).find(isPromiseMethodCall);
+}
+
+function hasErrorFirstCallback(node: Readonly<AnyFunction>): boolean {
+    const firstParam = getFirstMeaningfulParameter(node);
+
+    return firstParam !== undefined &&
+        firstParam.type === 'Identifier' &&
+        errorCallbackNames.has(firstParam.name);
+}
+
+function hasInlineErrorFirstCallback(node: Readonly<CallExpression>): boolean {
+    return node.arguments.some((argument) => {
+        return isFunction(argument) && hasErrorFirstCallback(argument);
+    });
+}
+
+function findCallbackBasedAsyncCall(
+    sourceCode: Readonly<SourceCode>,
+    expression: Readonly<TraversableNode>
+): Readonly<CallExpression | undefined> {
+    return collectCallExpressions(sourceCode, expression).find(hasInlineErrorFirstCallback);
+}
+
+function returnsPromiseToMocha(
+    sourceCode: Readonly<SourceCode>,
+    parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
+    node: Readonly<AnyFunction>
+): boolean {
+    return collectReturnedExpressions(sourceCode, node.body).some((expression) => {
+        return parserServices === undefined
+            ? findPromiseMethodCall(sourceCode, expression) !== undefined
+            : hasPromiseLikeType(parserServices, expression);
+    });
+}
+
+function isSynchronousMochaCallback(
+    sourceCode: Readonly<SourceCode>,
+    parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
+    node: Readonly<AnyFunction>
+): boolean {
+    return node.async !== true &&
+        !hasDoneCallbackParameter(node) &&
+        !returnsPromiseToMocha(sourceCode, parserServices, node);
+}
+
+function findUnexpectedAsyncOperation(
+    sourceCode: Readonly<SourceCode>,
+    parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
+    expression: Readonly<TraversableNode>
+): Readonly<UnexpectedAsyncOperation> | undefined {
+    if (parserServices !== undefined && hasPromiseLikeType(parserServices, expression)) {
+        return {
+            node: expression,
+            messageId: 'unexpectedPromiseAsyncOperation'
+        };
+    }
+
+    const promiseMethodCall = parserServices === undefined
+        ? findPromiseMethodCall(sourceCode, expression)
+        : undefined;
+
+    if (promiseMethodCall !== undefined) {
+        return {
+            node: promiseMethodCall,
+            messageId: 'unexpectedPromiseAsyncOperation'
+        };
+    }
+
+    const callbackBasedAsyncCall = findCallbackBasedAsyncCall(sourceCode, expression);
+
+    return callbackBasedAsyncCall === undefined
+        ? undefined
+        : {
+            node: callbackBasedAsyncCall,
+            messageId: 'unexpectedCallbackAsyncOperation'
+        };
+}
+
+function reportUnexpectedAsyncOperation(
+    context: Readonly<Rule.RuleContext>,
+    unexpectedAsyncOperation: Readonly<UnexpectedAsyncOperation>
+): void {
+    context.report({
+        node: asRuleNode(unexpectedAsyncOperation.node),
+        messageId: unexpectedAsyncOperation.messageId
+    });
+}
+
+export const noAsyncInSyncTestsRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'problem',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow async operations in synchronous tests or hooks',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-in-sync-tests.md'
+        },
+        messages: {
+            unexpectedCallbackAsyncOperation:
+                'Unexpected callback-based async operation in a synchronous test or hook.',
+            unexpectedPromiseAsyncOperation: 'Unexpected promise-based async operation in a synchronous test or hook.'
+        },
+        schema: []
+    },
+    create(context) {
+        const { sourceCode } = context;
+        const parserServices = getParserServicesWithTypeInformation(sourceCode);
+
+        function reportUnexpectedAsyncOperations(node: Readonly<Rule.Node>): void {
+            if (!isFunction(node) || !isSynchronousMochaCallback(sourceCode, parserServices, node)) {
+                return;
+            }
+
+            for (const expression of collectCandidateExpressions(sourceCode, node.body)) {
+                const unexpectedAsyncOperation = findUnexpectedAsyncOperation(sourceCode, parserServices, expression);
+
+                if (unexpectedAsyncOperation !== undefined) {
+                    reportUnexpectedAsyncOperation(context, unexpectedAsyncOperation);
+                }
+            }
+        }
+
+        return createMochaVisitors(context, {
+            anyTestEntityCallback(visitorContext) {
+                if (visitorContext.type !== 'testCase' && visitorContext.type !== 'hook') {
+                    return;
+                }
+
+                reportUnexpectedAsyncOperations(visitorContext.node);
+            }
+        });
+    }
+};


### PR DESCRIPTION
Closes #5.

- add `no-async-in-sync-tests`
- use typed Promise detection when type information is available
- fall back to promise-chain and error-first callback heuristics otherwise
