### PR TITLE
Allow commented skips in no-pending-tests

### DIFF
--- a/documentation/rules/no-pending-tests.md
+++ b/documentation/rules/no-pending-tests.md
@@ -10,6 +10,22 @@ Mocha supports pending tests. These are tests with no implementation, such as `i
 
 This rule intentionally does not support the `--fix` CLI option. Many editors apply ESLint fixes on save, and silently enabling skipped tests again would be a bad default while debugging. For direct `.skip` and `xdescribe()`-style calls, the rule does provide ESLint suggestions so you can remove the pending modifier explicitly.
 
+## Options
+
+This rule supports the following options:
+
+- `allowSkippedWithComment`: Allows explicit skip forms when they have an immediately preceding comment with no blank line. This applies to `.skip`, `xdescribe()`, `xit()`, and equivalent configured custom names. It does not allow bare pending tests such as `it('name');`. Defaults to `false`.
+
+```json
+{
+    "rules": {
+        "mocha/no-pending-tests": ["error", {
+            "allowSkippedWithComment": true
+        }]
+    }
+}
+```
+
 ## Rule Details
 
 This rule looks for `it`, `test`, and `specify` function calls with only one argument, where the argument is a string literal.
@@ -50,6 +66,16 @@ suite('foo', function () {});
 test('foo', function () {});
 suite.only('bar', function () {});
 test.only('bar', function () {});
+```
+
+With `{ "allowSkippedWithComment": true }`, these explicit skip forms are also allowed:
+
+```js
+// SKIP pending #201
+it.skip('foo', function () {});
+
+/* SKIP pending #202 */
+xdescribe('bar', function () {});
 ```
 
 ## When Not To Use It

--- a/source/rules/no-pending-tests.leading-comment.test.ts
+++ b/source/rules/no-pending-tests.leading-comment.test.ts
@@ -1,0 +1,139 @@
+import type { Rule, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import { hasAdjacentLeadingComment } from './no-pending-tests.js';
+
+function asRuleNode(node: Record<string, unknown>): Rule.Node {
+    return node as unknown as Rule.Node;
+}
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+describe('no-pending-tests leading comment helpers', function () {
+    it('hasAdjacentLeadingComment() returns true for an adjacent leading comment', function () {
+        const comment = {
+            type: 'Line',
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 19 }
+            }
+        };
+
+        const result = hasAdjacentLeadingComment(
+            asSourceCode({
+                getCommentsBefore() {
+                    return [comment];
+                },
+                getTokenBefore() {
+                    return null;
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                loc: {
+                    start: { line: 2, column: 0 },
+                    end: { line: 2, column: 10 }
+                }
+            })
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    it('hasAdjacentLeadingComment() returns false when there is no leading comment', function () {
+        const result = hasAdjacentLeadingComment(
+            asSourceCode({
+                getCommentsBefore() {
+                    return [];
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                loc: {
+                    start: { line: 2, column: 0 },
+                    end: { line: 2, column: 10 }
+                }
+            })
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasAdjacentLeadingComment() returns false when the comment is missing location data', function () {
+        const result = hasAdjacentLeadingComment(
+            asSourceCode({
+                getCommentsBefore() {
+                    return [{ type: 'Line', loc: undefined }];
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                loc: {
+                    start: { line: 2, column: 0 },
+                    end: { line: 2, column: 10 }
+                }
+            })
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasAdjacentLeadingComment() returns false when the node is missing location data', function () {
+        const result = hasAdjacentLeadingComment(
+            asSourceCode({
+                getCommentsBefore() {
+                    return [{
+                        type: 'Line',
+                        loc: {
+                            start: { line: 1, column: 0 },
+                            end: { line: 1, column: 19 }
+                        }
+                    }];
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                loc: undefined
+            })
+        );
+
+        assert.strictEqual(result, false);
+    });
+
+    it('hasAdjacentLeadingComment() returns false for a trailing comment on another statement', function () {
+        const comment = {
+            type: 'Line',
+            loc: {
+                start: { line: 1, column: 13 },
+                end: { line: 1, column: 32 }
+            }
+        };
+
+        const result = hasAdjacentLeadingComment(
+            asSourceCode({
+                getCommentsBefore() {
+                    return [comment];
+                },
+                getTokenBefore() {
+                    return {
+                        type: 'Punctuator',
+                        loc: {
+                            start: { line: 1, column: 11 },
+                            end: { line: 1, column: 12 }
+                        }
+                    };
+                }
+            }),
+            asRuleNode({
+                type: 'CallExpression',
+                loc: {
+                    start: { line: 2, column: 0 },
+                    end: { line: 2, column: 10 }
+                }
+            })
+        );
+
+        assert.strictEqual(result, false);
+    });
+});

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -11,6 +11,8 @@ import {
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const expectedErrorMessage = 'Unexpected pending mocha test.';
+const expectedMissingCommentMessage = 'Unexpected skipped mocha test without a preceding comment.';
+const allowSkippedWithCommentOption = { allowSkippedWithComment: true };
 
 function asRuleContext(ruleContext: Record<string, unknown>): Rule.RuleContext {
     return ruleContext as unknown as Rule.RuleContext;
@@ -54,11 +56,30 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
         'var calledOnly = it.skip; calledOnly.call(it)',
         withInterface('TDD', 'var dynamicOnly = "ski"; dynamicOnly += String.fromCharCode(112); suite[dynamicOnly]()'),
         {
+            code: '// SKIP pending #201\nit.skip("works", function() {})',
+            options: [allowSkippedWithCommentOption]
+        },
+        {
+            code: '/* SKIP pending #201 */ xdescribe("works", function() {})',
+            options: [allowSkippedWithCommentOption]
+        },
+        withInterface('TDD', {
+            code: '// SKIP pending #201\ntest.skip("works", function() {})',
+            options: [allowSkippedWithCommentOption]
+        }),
+        {
             code: 'xcustom()',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'TDD' }]
                 }
+            }
+        },
+        {
+            code: '// SKIP pending #201\nxcustom()',
+            options: [allowSkippedWithCommentOption],
+            settings: {
+                'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
             }
         }
     ],
@@ -289,6 +310,60 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
             }]
         },
+        {
+            code: 'it("is pending")',
+            options: [allowSkippedWithCommentOption],
+            errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
+        },
+        {
+            code: 'it.skip("works", function() {})',
+            options: [allowSkippedWithCommentOption],
+            errors: [{
+                message: expectedMissingCommentMessage,
+                column: 4,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'it("works", function() {})' }]
+            }]
+        },
+        {
+            code: '// SKIP pending #201\n\nit.skip("works", function() {})',
+            options: [allowSkippedWithCommentOption],
+            errors: [{
+                message: expectedMissingCommentMessage,
+                column: 4,
+                line: 3,
+                suggestions: [{
+                    messageId: 'removePendingModifier',
+                    output: '// SKIP pending #201\n\nit("works", function() {})'
+                }]
+            }]
+        },
+        {
+            code: 'something(); // SKIP pending #201\nit.skip("works", function() {})',
+            options: [allowSkippedWithCommentOption],
+            errors: [{
+                message: expectedMissingCommentMessage,
+                column: 4,
+                line: 2,
+                suggestions: [{
+                    messageId: 'removePendingModifier',
+                    output: 'something(); // SKIP pending #201\nit("works", function() {})'
+                }]
+            }]
+        },
+        {
+            code: 'xcustom()',
+            options: [allowSkippedWithCommentOption],
+            settings: {
+                'mocha/additionalCustomNames': [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+            },
+            errors: [{
+                message: expectedMissingCommentMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
+            }]
+        },
         withInterface('TDD', {
             code: 'var dynamicOnly = "skip"; suite[dynamicOnly]()',
             errors: [{ message: expectedErrorMessage, column: 33, line: 1 }]
@@ -309,7 +384,8 @@ describe('no-pending-tests helpers', function () {
             {
                 modifier: null,
                 node: asRuleNode({ type: 'Identifier' })
-            }
+            },
+            { allowSkippedWithComment: false }
         );
 
         assert.deepStrictEqual(reports, []);
@@ -327,7 +403,8 @@ describe('no-pending-tests helpers', function () {
             {
                 modifier: 'pending',
                 node: asRuleNode({ type: 'Identifier' })
-            }
+            },
+            { allowSkippedWithComment: false }
         );
 
         assert.deepStrictEqual(reports, []);

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -316,6 +316,16 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
             errors: [{ message: expectedErrorMessage, column: 1, line: 1 }]
         },
         {
+            code: 'xdescribe("works", function() {})',
+            options: [allowSkippedWithCommentOption],
+            errors: [{
+                message: expectedMissingCommentMessage,
+                column: 1,
+                line: 1,
+                suggestions: [{ messageId: 'removePendingModifier', output: 'describe("works", function() {})' }]
+            }]
+        },
+        {
             code: 'it.skip("works", function() {})',
             options: [allowSkippedWithCommentOption],
             errors: [{

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -47,6 +47,7 @@ type Locatable = {
 type KnownLocation = Locatable & {
     readonly loc: NonNullable<Locatable['loc']>;
 };
+type KnownLocationComment = EstreeComment & KnownLocation;
 
 export function isCallbackMissing(node: CallExpression): boolean {
     const [firstArgument] = node.arguments;
@@ -123,11 +124,7 @@ function isAdjacentToComment(comment: EstreeComment, node: Readonly<Rule.Node>):
         node.loc.start.line - comment.loc.end.line <= 1;
 }
 
-function isStandaloneLeadingComment(sourceCode: Readonly<SourceCode>, comment: EstreeComment): boolean {
-    if (!hasKnownLocation(comment)) {
-        return false;
-    }
-
+function isStandaloneLeadingComment(sourceCode: Readonly<SourceCode>, comment: KnownLocationComment): boolean {
     const tokenBeforeComment = sourceCode.getTokenBefore(comment, { includeComments: true });
 
     return tokenBeforeComment === null ||
@@ -142,6 +139,7 @@ export function hasAdjacentLeadingComment(
     const lastComment = sourceCode.getCommentsBefore(node).at(-1);
 
     return lastComment !== undefined &&
+        hasKnownLocation(lastComment) &&
         isAdjacentToComment(lastComment, node) &&
         isStandaloneLeadingComment(sourceCode, lastComment);
 }

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -1,4 +1,5 @@
 import type { Rule, SourceCode } from 'eslint';
+import type { Comment as EstreeComment } from 'estree';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 import {
     type CallExpression,
@@ -8,10 +9,43 @@ import {
     isMemberExpression,
     type MemberExpression
 } from '../ast/node-types.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
+
+const optionSchema = {
+    type: 'object',
+    properties: {
+        allowSkippedWithComment: {
+            type: 'boolean'
+        }
+    },
+    additionalProperties: false
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+type ResolvedOption = Option & { allowSkippedWithComment: boolean; };
+type PendingRuleConfiguration = {
+    readonly allowSkippedWithComment: boolean;
+};
+
+const defaultOption: ResolvedOption = {
+    allowSkippedWithComment: false
+};
 
 type PendingVisitorContext = {
     readonly node: Rule.Node;
     readonly modifier: string | null;
+};
+type Locatable = {
+    readonly loc?:
+        | {
+            readonly start: { readonly line: number; };
+            readonly end: { readonly line: number; };
+        }
+        | null
+        | undefined;
+};
+type KnownLocation = Locatable & {
+    readonly loc: NonNullable<Locatable['loc']>;
 };
 
 export function isCallbackMissing(node: CallExpression): boolean {
@@ -77,12 +111,61 @@ function canSuggestPendingTest(node: Readonly<CallExpression>): boolean {
     return (isIdentifier(node.callee) && node.callee.name.startsWith('x')) || isPendingMemberExpression(node.callee);
 }
 
-export function reportSkipped(context: Readonly<Rule.RuleContext>, node: CallExpression): void {
+function hasKnownLocation(
+    value: Locatable
+): value is KnownLocation {
+    return value.loc !== undefined && value.loc !== null;
+}
+
+function isAdjacentToComment(comment: EstreeComment, node: Readonly<Rule.Node>): boolean {
+    return hasKnownLocation(comment) &&
+        hasKnownLocation(node) &&
+        node.loc.start.line - comment.loc.end.line <= 1;
+}
+
+function isStandaloneLeadingComment(sourceCode: Readonly<SourceCode>, comment: EstreeComment): boolean {
+    if (!hasKnownLocation(comment)) {
+        return false;
+    }
+
+    const tokenBeforeComment = sourceCode.getTokenBefore(comment, { includeComments: true });
+
+    return tokenBeforeComment === null ||
+        !hasKnownLocation(tokenBeforeComment) ||
+        tokenBeforeComment.loc.end.line < comment.loc.start.line;
+}
+
+export function hasAdjacentLeadingComment(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<Rule.Node>
+): boolean {
+    const lastComment = sourceCode.getCommentsBefore(node).at(-1);
+
+    return lastComment !== undefined &&
+        isAdjacentToComment(lastComment, node) &&
+        isStandaloneLeadingComment(sourceCode, lastComment);
+}
+
+function shouldAllowSkippedWithComment(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    configuration: Readonly<PendingRuleConfiguration>
+): boolean {
+    return configuration.allowSkippedWithComment &&
+        canSuggestPendingTest(node) &&
+        hasAdjacentLeadingComment(context.sourceCode, node);
+}
+
+export function reportSkipped(
+    context: Readonly<Rule.RuleContext>,
+    node: CallExpression,
+    messageId: 'unexpectedPendingTest' | 'unexpectedSkippedTestWithoutComment'
+): void {
     const nodeToReport = node.callee.type === 'MemberExpression' ? node.callee.property : node.callee;
 
     context.report({
         node: nodeToReport,
-        messageId: 'unexpectedPendingTest',
+        messageId,
         ...(canSuggestPendingTest(node)
             ? {
                 suggest: [{
@@ -98,7 +181,8 @@ export function reportSkipped(context: Readonly<Rule.RuleContext>, node: CallExp
 
 export function checkPendingTestCase(
     context: Readonly<Rule.RuleContext>,
-    visitorContext: PendingVisitorContext
+    visitorContext: PendingVisitorContext,
+    configuration: Readonly<PendingRuleConfiguration>
 ): void {
     if (!isCallExpression(visitorContext.node)) {
         return;
@@ -110,20 +194,37 @@ export function checkPendingTestCase(
             messageId: 'unexpectedPendingTest'
         });
     } else if (visitorContext.modifier === 'pending') {
-        reportSkipped(context, visitorContext.node);
+        if (shouldAllowSkippedWithComment(context, visitorContext.node, configuration)) {
+            return;
+        }
+
+        reportSkipped(
+            context,
+            visitorContext.node,
+            configuration.allowSkippedWithComment ? 'unexpectedSkippedTestWithoutComment' : 'unexpectedPendingTest'
+        );
     }
 }
 
 export function checkPendingSuite(
     context: Readonly<Rule.RuleContext>,
-    visitorContext: PendingVisitorContext
+    visitorContext: PendingVisitorContext,
+    configuration: Readonly<PendingRuleConfiguration>
 ): void {
     if (!isCallExpression(visitorContext.node)) {
         return;
     }
 
     if (visitorContext.modifier === 'pending') {
-        reportSkipped(context, visitorContext.node);
+        if (shouldAllowSkippedWithComment(context, visitorContext.node, configuration)) {
+            return;
+        }
+
+        reportSkipped(
+            context,
+            visitorContext.node,
+            configuration.allowSkippedWithComment ? 'unexpectedSkippedTestWithoutComment' : 'unexpectedPendingTest'
+        );
     }
 }
 
@@ -135,21 +236,25 @@ export const noPendingTestsRule: Rule.RuleModule = {
             description: 'Disallow pending tests',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-pending-tests.md'
         },
+        defaultOptions: [defaultOption],
         hasSuggestions: true,
         messages: {
             unexpectedPendingTest: 'Unexpected pending mocha test.',
+            unexpectedSkippedTestWithoutComment: 'Unexpected skipped mocha test without a preceding comment.',
             removePendingModifier: 'Remove the pending modifier from this Mocha call.'
         },
-        schema: []
+        schema: [optionSchema]
     },
     create(context) {
+        const configuration = getRuleOption<ResolvedOption>(context);
+
         return createMochaVisitors(context, {
             testCase(visitorContext) {
-                checkPendingTestCase(context, visitorContext);
+                checkPendingTestCase(context, visitorContext, configuration);
             },
 
             suite(visitorContext) {
-                checkPendingSuite(context, visitorContext);
+                checkPendingSuite(context, visitorContext, configuration);
             }
         });
     }


### PR DESCRIPTION
Closes #201.

Adds an allowSkippedWithComment option to mocha/no-pending-tests.
It allows explicit skip forms when they have an immediately preceding comment,
while keeping bare pending tests disallowed.