### PR TITLE
Move shared title rule logic out of rules directory

### DIFF
--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -10,14 +10,34 @@ const { pathname: currentFolderName } = new URL('.', import.meta.url);
 const rulesDir = path.join(currentFolderName, './rules/');
 const documentationDir = path.join(currentFolderName, '../../../documentation/rules/');
 
+async function importModuleExports(filePath: string): Promise<Readonly<Record<string, unknown>>> {
+    return await import(filePath) as Readonly<Record<string, unknown>>;
+}
+
 async function determineAllRuleFiles(): Promise<string[]> {
-    const ruleFiles = await fs.promises.readdir(rulesDir);
+    const knownRuleFiles = await fs.promises.readdir(rulesDir);
+    const ruleFiles = knownRuleFiles.filter((file) => {
+        return !file.endsWith('.test.js') && file.endsWith('.js');
+    });
+
     if (rulesDir.length === 0) {
         throw new Error('Failed to read rules folder');
     }
-    return ruleFiles.filter((file) => {
-        return !file.endsWith('.test.js') && file.endsWith('.js');
-    });
+
+    const publicRuleFiles: string[] = [];
+
+    for (const file of ruleFiles) {
+        // Only public rule modules should count here.
+        // This keeps the test stable when stale generated files remain after rule moves.
+        const importedRuleModule = await importModuleExports(path.join(rulesDir, file));
+        const ruleName = path.basename(file, '.js');
+
+        if (importedRuleModule[`${camelCase(ruleName)}Rule`] !== undefined) {
+            publicRuleFiles.push(file);
+        }
+    }
+
+    return publicRuleFiles;
 }
 
 async function determineAllDocumentationFiles(): Promise<string[]> {
@@ -44,9 +64,7 @@ describe('eslint-plugin-mocha', function () {
         for (const file of ruleFiles) {
             const ruleName = path.basename(file, '.js');
             assert.ok(ruleName in plugin.rules);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ok
-            const importedRuleModule = await import(path.join(rulesDir, file));
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- ok
+            const importedRuleModule = await importModuleExports(path.join(rulesDir, file));
             const importedRule = importedRuleModule[`${camelCase(ruleName)}Rule`];
 
             assert.notStrictEqual(importedRule, undefined);

--- a/source/rules/valid-suite-title.ts
+++ b/source/rules/valid-suite-title.ts
@@ -1,92 +1,12 @@
-import { getStringIfConstant } from '@eslint-community/eslint-utils';
 import type { Rule } from 'eslint';
-import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
-import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
-
-type NormalizedOptions = {
-    pattern: RegExp;
-    message: string | undefined;
-};
-
-const optionSchema = {
-    type: 'object',
-    properties: {
-        pattern: {
-            type: 'string'
-        },
-        message: {
-            type: 'string'
-        }
-    },
-    additionalProperties: false
-} as const satisfies RuleSchema;
-
-type Option = InferSchemaOption<typeof optionSchema>;
-type ResolvedOption = Option & { pattern: string; };
-const defaultOption: ResolvedOption = { pattern: '' };
-
-function objectOptions(options: Readonly<ResolvedOption>): Readonly<NormalizedOptions> {
-    const { pattern: stringPattern, message } = options;
-    const pattern = new RegExp(stringPattern, 'u');
-
-    return { pattern, message: typeof message === 'string' ? message : undefined };
-}
+import { createTitlePatternRule } from '../title-pattern-rule.js';
 
 export const validSuiteTitleRule: Readonly<Rule.RuleModule> = {
-    meta: {
-        type: 'suggestion',
-        languages: ['js/js'],
-        docs: {
-            description: 'Require suite descriptions to match a pre-configured regular expression',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/valid-suite-title.md'
-        },
-        defaultOptions: [defaultOption],
-        messages: {
-            invalidSuiteTitle: 'Invalid "{{name}}" description found.'
-        },
-        schema: [optionSchema]
-    },
-    create(context) {
-        const options = getRuleOption<ResolvedOption>(context);
-        const { pattern, message } = objectOptions(options);
-
-        function hasValidSuiteDescription(mochaCallExpression: Readonly<CallExpression>): boolean {
-            const args = mochaCallExpression.arguments;
-            const descriptionArgument = args[0];
-            if (descriptionArgument !== undefined) {
-                const description = getStringIfConstant(
-                    descriptionArgument,
-                    context.sourceCode.getScope(mochaCallExpression)
-                );
-
-                if (description !== null) {
-                    return pattern.test(description);
-                }
-            }
-
-            return true;
-        }
-
-        function hasValidOrNoSuiteDescription(mochaCallExpression: Readonly<CallExpression>): boolean {
-            const args = mochaCallExpression.arguments;
-            const hasNoSuiteDescription = args.length === 0;
-
-            return hasNoSuiteDescription || hasValidSuiteDescription(mochaCallExpression);
-        }
-
-        return createMochaVisitors(context, {
-            suite(visitorContext) {
-                const { node, name } = visitorContext;
-
-                if (isCallExpression(node) && !hasValidOrNoSuiteDescription(node)) {
-                    context.report(
-                        message === undefined
-                            ? { node, messageId: 'invalidSuiteTitle', data: { name } }
-                            : { node, message }
-                    );
-                }
-            }
-        });
-    }
+    ...createTitlePatternRule({
+        defaultPattern: '',
+        description: 'Require suite descriptions to match a pre-configured regular expression',
+        documentationFile: 'valid-suite-title',
+        messageId: 'invalidSuiteTitle',
+        target: 'suite'
+    })
 };

--- a/source/rules/valid-test-title.ts
+++ b/source/rules/valid-test-title.ts
@@ -1,93 +1,12 @@
-import { getStringIfConstant } from '@eslint-community/eslint-utils';
 import type { Rule } from 'eslint';
-import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
-import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
-
-type NormalizedOptions = {
-    pattern: RegExp;
-    message: string | undefined;
-};
-
-const optionSchema = {
-    type: 'object',
-    properties: {
-        pattern: {
-            type: 'string'
-        },
-        message: {
-            type: 'string'
-        }
-    },
-    additionalProperties: false
-} as const satisfies RuleSchema;
-
-type Option = InferSchemaOption<typeof optionSchema>;
-type ResolvedOption = Option & { pattern: string; };
-const defaultOption: ResolvedOption = { pattern: '^should' };
-
-function objectOptions(options: Readonly<ResolvedOption>): Readonly<NormalizedOptions> {
-    const { pattern: stringPattern, message } = options;
-    const pattern = new RegExp(stringPattern, 'u');
-
-    return { pattern, message: typeof message === 'string' ? message : undefined };
-}
+import { createTitlePatternRule } from '../title-pattern-rule.js';
 
 export const validTestTitleRule: Readonly<Rule.RuleModule> = {
-    meta: {
-        type: 'suggestion',
-        languages: ['js/js'],
-        docs: {
-            description: 'Require test descriptions to match a pre-configured regular expression',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/valid-test-title.md'
-        },
-        defaultOptions: [defaultOption],
-        messages: {
-            invalidTestTitle: 'Invalid "{{name}}" description found.'
-        },
-        schema: [optionSchema]
-    },
-    create(context) {
-        const options = getRuleOption<ResolvedOption>(context);
-        const { pattern, message } = objectOptions(options);
-
-        function hasValidTestDescription(mochaCallExpression: Readonly<CallExpression>): boolean {
-            const args = mochaCallExpression.arguments;
-            const testDescriptionArgument = args[0];
-
-            if (testDescriptionArgument !== undefined) {
-                const description = getStringIfConstant(
-                    testDescriptionArgument,
-                    context.sourceCode.getScope(mochaCallExpression)
-                );
-
-                if (description !== null) {
-                    return pattern.test(description);
-                }
-            }
-
-            return true;
-        }
-
-        function hasValidOrNoTestDescription(mochaCallExpression: Readonly<CallExpression>): boolean {
-            const args = mochaCallExpression.arguments;
-            const hasNoTestDescription = args.length === 0;
-
-            return hasNoTestDescription || hasValidTestDescription(mochaCallExpression);
-        }
-
-        return createMochaVisitors(context, {
-            testCase(visitorContext) {
-                const { node, name } = visitorContext;
-
-                if (isCallExpression(node) && !hasValidOrNoTestDescription(node)) {
-                    context.report(
-                        message === undefined
-                            ? { node, messageId: 'invalidTestTitle', data: { name } }
-                            : { node, message }
-                    );
-                }
-            }
-        });
-    }
+    ...createTitlePatternRule({
+        defaultPattern: '^should',
+        description: 'Require test descriptions to match a pre-configured regular expression',
+        documentationFile: 'valid-test-title',
+        messageId: 'invalidTestTitle',
+        target: 'testCase'
+    })
 };

--- a/source/title-pattern-rule.ts
+++ b/source/title-pattern-rule.ts
@@ -1,0 +1,106 @@
+import { getStringIfConstant } from '@eslint-community/eslint-utils';
+import type { Rule } from 'eslint';
+import { createMochaVisitors, type VisitorContext } from './ast/mocha-visitors.js';
+import { type CallExpression, isCallExpression } from './ast/node-types.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from './rule-options.js';
+
+type NormalizedOptions = {
+    pattern: RegExp;
+    message: string | undefined;
+};
+
+const optionSchema = {
+    type: 'object',
+    properties: {
+        pattern: {
+            type: 'string'
+        },
+        message: {
+            type: 'string'
+        }
+    },
+    additionalProperties: false
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+type ResolvedOption = Option & { pattern: string; };
+type TitleTarget = 'suite' | 'testCase';
+
+type TitlePatternRuleDefinition = {
+    defaultPattern: string;
+    description: string;
+    documentationFile: string;
+    messageId: string;
+    target: TitleTarget;
+};
+
+function normalizeOptions(options: Readonly<ResolvedOption>): Readonly<NormalizedOptions> {
+    const { pattern: stringPattern, message } = options;
+    const pattern = new RegExp(stringPattern, 'u');
+
+    return { pattern, message: typeof message === 'string' ? message : undefined };
+}
+
+function hasValidOrNoDescription(
+    context: Readonly<Rule.RuleContext>,
+    mochaCallExpression: Readonly<CallExpression>,
+    pattern: Readonly<RegExp>
+): boolean {
+    const descriptionArgument = mochaCallExpression.arguments[0];
+
+    if (descriptionArgument === undefined) {
+        return true;
+    }
+
+    const description = getStringIfConstant(
+        descriptionArgument,
+        context.sourceCode.getScope(mochaCallExpression)
+    );
+
+    return description === null || pattern.test(description);
+}
+
+export function createTitlePatternRule(
+    definition: Readonly<TitlePatternRuleDefinition>
+): Readonly<Rule.RuleModule> {
+    const defaultOptions: [ResolvedOption] = [{ pattern: definition.defaultPattern }];
+    const messages = {
+        [definition.messageId]: 'Invalid "{{name}}" description found.'
+    };
+
+    return {
+        meta: {
+            type: 'suggestion',
+            languages: ['js/js'],
+            docs: {
+                description: definition.description,
+                url: `https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/${definition.documentationFile}.md`
+            },
+            defaultOptions,
+            messages,
+            schema: [optionSchema]
+        },
+        create(context) {
+            const options = getRuleOption<ResolvedOption>(context);
+            const { pattern, message } = normalizeOptions(options);
+
+            function checkTitle(visitorContext: Readonly<VisitorContext>): void {
+                const { node, name } = visitorContext;
+
+                if (!isCallExpression(node) || hasValidOrNoDescription(context, node, pattern)) {
+                    return;
+                }
+
+                context.report(
+                    message === undefined
+                        ? { node, messageId: definition.messageId, data: { name } }
+                        : { node, message }
+                );
+            }
+
+            return definition.target === 'suite'
+                ? createMochaVisitors(context, { suite: checkTitle })
+                : createMochaVisitors(context, { testCase: checkTitle });
+        }
+    };
+}


### PR DESCRIPTION
Move the shared title-pattern implementation out of `source/rules`.
Keep `valid-suite-title` and `valid-test-title` as the public rule modules.
Make `plugin.test` ignore non-rule helper modules when enumerating public rules.