### PR TITLE
Rename no-setup-in-describe to no-setup-in-suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
 | [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
 | [no-root-hooks](documentation/rules/no-root-hooks.md)                                         | Disallow root hooks                                                     |    | ✅  |    |    |    |
-| [no-setup-in-describe](documentation/rules/no-setup-in-describe.md)                           | Disallow setup in describe blocks                                       | ✅  |    |    |    |    |
+| [no-setup-in-suite](documentation/rules/no-setup-in-suite.md)                                 | Disallow setup in suite blocks                                          | ✅  |    |    |    |    |
 | [no-synchronous-tests](documentation/rules/no-synchronous-tests.md)                           | Disallow synchronous tests                                              |    |    | ✅  |    |    |
 | [no-top-level-tests](documentation/rules/no-top-level-tests.md)                               | Disallow top-level tests                                                | ✅  |    |    |    |    |
 | [prefer-arrow-callback](documentation/rules/prefer-arrow-callback.md)                         | Require using arrow functions for callbacks                             |    |    | ✅  | 🔧 |    |

--- a/documentation/rules/no-setup-in-suite.md
+++ b/documentation/rules/no-setup-in-suite.md
@@ -1,10 +1,10 @@
-# Disallow setup in describe blocks (`mocha/no-setup-in-describe`)
+# Disallow setup in suite blocks (`mocha/no-setup-in-suite`)
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 
-Setup for test cases in mocha should be done in `before`, `beforeEach`, or `it` blocks. Unfortunately there is nothing stopping you from doing setup directly inside a `describe` block.
+Setup for test cases in mocha should be done in `before`, `beforeEach`, or `it` blocks. Unfortunately there is nothing stopping you from doing setup directly inside a suite block.
 
 ```js
 describe('something', function () {
@@ -16,10 +16,10 @@ describe('something', function () {
 });
 ```
 
-Any setup directly in a `describe` is run before all tests execute. This is undesirable primarily for two reasons:
+Any setup directly in a suite body is run before all tests execute. This is undesirable primarily for two reasons:
 
 1. When doing TDD in a large codebase, all setup is run for tests that don't have `only` set. This can add a substantial amount of time per iteration.
-2. If global state is altered by the setup of another describe block, your test may be affected.
+2. If global state is altered by the setup of another suite block, your test may be affected.
 
 For this rule, "setup" means code that executes immediately while the suite callback itself is evaluated. That includes work done directly in the suite body before any tests run, even when the code looks harmless.
 
@@ -31,7 +31,7 @@ If you're using [dynamically generated tests](https://mochajs.org/#dynamically-g
 
 ## Rule Details
 
-This rule looks for all function calls and use of the dot operator which are nested directly in a describe block.
+This rule looks for all function calls and use of the dot operator which are nested directly in a suite block.
 
 The following patterns are considered problems:
 
@@ -91,7 +91,7 @@ Entries may be written with or without `()`. Dotted names are supported.
 ```json
 {
     "rules": {
-        "mocha/no-setup-in-describe": ["error", {
+        "mocha/no-setup-in-suite": ["error", {
             "allow": ["Symbol", "Object.freeze"]
         }]
     }

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -21,7 +21,7 @@ import { noPendingTestsRule } from './rules/no-pending-tests.js';
 import { noReturnAndCallbackRule } from './rules/no-return-and-callback.js';
 import { noReturnFromAsyncRule } from './rules/no-return-from-async.js';
 import { noRootHooksRule } from './rules/no-root-hooks.js';
-import { noSetupInDescribeRule } from './rules/no-setup-in-describe.js';
+import { noSetupInSuiteRule } from './rules/no-setup-in-suite.js';
 import { noSynchronousTestsRule } from './rules/no-synchronous-tests.js';
 import { noTopLevelTestsRule } from './rules/no-top-level-tests.js';
 import { preferArrowCallbackRule } from './rules/prefer-arrow-callback.js';
@@ -51,7 +51,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-pending-tests': 'error',
     'mocha/no-return-and-callback': 'error',
     'mocha/no-return-from-async': 'error',
-    'mocha/no-setup-in-describe': 'error',
+    'mocha/no-setup-in-suite': 'error',
     'mocha/no-synchronous-tests': 'error',
     'mocha/no-root-hooks': 'error',
     'mocha/prefer-arrow-callback': 'error',
@@ -80,7 +80,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-pending-tests': 'warn',
     'mocha/no-return-and-callback': 'error',
     'mocha/no-return-from-async': 'off',
-    'mocha/no-setup-in-describe': 'error',
+    'mocha/no-setup-in-suite': 'error',
     'mocha/no-synchronous-tests': 'off',
     'mocha/no-root-hooks': 'warn',
     'mocha/prefer-arrow-callback': 'off',
@@ -109,7 +109,7 @@ const rules = {
     'no-pending-tests': noPendingTestsRule,
     'no-return-and-callback': noReturnAndCallbackRule,
     'no-return-from-async': noReturnFromAsyncRule,
-    'no-setup-in-describe': noSetupInDescribeRule,
+    'no-setup-in-suite': noSetupInSuiteRule,
     'no-synchronous-tests': noSynchronousTestsRule,
     'no-root-hooks': noRootHooksRule,
     'prefer-arrow-callback': preferArrowCallbackRule,

--- a/source/rules/no-setup-in-suite.test.ts
+++ b/source/rules/no-setup-in-suite.test.ts
@@ -1,13 +1,13 @@
 import { type Rule, RuleTester } from 'eslint';
 import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
-import { noSetupInDescribeRule } from './no-setup-in-describe.js';
+import { noSetupInSuiteRule } from './no-setup-in-suite.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
-const memberExpressionError = 'Unexpected member expression in describe block. ' +
+const memberExpressionError = 'Unexpected member expression in suite block. ' +
     'Member expressions may call functions via getters.';
 
-ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
+ruleTester.run('no-setup-in-suite', noSetupInSuiteRule, {
     valid: [
         'it()',
         'it(); it(); it()',
@@ -131,7 +131,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'suite("", function () { this.timeout(42); a(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 43
                 }
@@ -141,7 +141,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'suite("", function () { a(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 25
                 }
@@ -151,7 +151,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'describe("", function () { a(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 }
@@ -162,7 +162,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             languageOptions: { ecmaVersion: 2015 },
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 22
                 }
@@ -179,7 +179,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             },
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 23
                 }
@@ -233,7 +233,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'describe("", function () { this.a(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 },
@@ -265,7 +265,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'describe("", function () { it("", function () {}).a(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 },
@@ -275,7 +275,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
                     column: 28
                 },
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 }
@@ -285,7 +285,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'describe("", function () { something("", function () {}).timeout(); });',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 },
@@ -295,7 +295,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
                     column: 28
                 },
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 28
                 }
@@ -305,7 +305,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             code: 'describe("", function () { const token = Symbol("bar"); it(); })',
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 42
                 }
@@ -316,7 +316,7 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
             options: [{ allow: ['Symbol'] }],
             errors: [
                 {
-                    message: 'Unexpected function call in describe block.',
+                    message: 'Unexpected function call in suite block.',
                     line: 1,
                     column: 57
                 }
@@ -336,10 +336,10 @@ ruleTester.run('no-setup-in-describe', noSetupInDescribeRule, {
     ]
 });
 
-describe('no-setup-in-describe create()', function () {
+describe('no-setup-in-suite create()', function () {
     it('normalizes non-string allow entries when invoked directly', function () {
-        noSetupInDescribeRule.create({
-            id: 'no-setup-in-describe',
+        noSetupInSuiteRule.create({
+            id: 'no-setup-in-suite',
             options: [{ allow: [42] }],
             settings: {},
             sourceCode: {

--- a/source/rules/no-setup-in-suite.ts
+++ b/source/rules/no-setup-in-suite.ts
@@ -8,7 +8,7 @@ import { convertNameToPathArray, isSamePath } from '../mocha/path.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 const FUNCTION = 1;
-const DESCRIBE = 2;
+const SUITE = 2;
 const optionSchema = {
     type: 'object',
     properties: {
@@ -26,10 +26,10 @@ type Option = InferSchemaOption<typeof optionSchema>;
 type ResolvedOption = Option & { allow: string[]; };
 const defaultOption: ResolvedOption = { allow: [] };
 
-function isNestedInDescribeBlock(nesting: readonly number[]): boolean {
+function isNestedInSuiteBlock(nesting: readonly number[]): boolean {
     return (
         nesting.length > 0 &&
-        nesting.lastIndexOf(FUNCTION) < nesting.lastIndexOf(DESCRIBE)
+        nesting.lastIndexOf(FUNCTION) < nesting.lastIndexOf(SUITE)
     );
 }
 
@@ -69,19 +69,19 @@ function normalizeAllowedCall(value: unknown): readonly string[] {
     return [...path.slice(0, -1), ensureEndsWithParens(lastPathSegment)];
 }
 
-export const noSetupInDescribeRule: Readonly<Rule.RuleModule> = {
+export const noSetupInSuiteRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
         languages: ['js/js'],
         docs: {
-            description: 'Disallow setup in describe blocks',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-setup-in-describe.md'
+            description: 'Disallow setup in suite blocks',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-setup-in-suite.md'
         },
         defaultOptions: [defaultOption],
         messages: {
-            unexpectedFunctionCall: 'Unexpected function call in describe block.',
+            unexpectedFunctionCall: 'Unexpected function call in suite block.',
             unexpectedMemberExpression:
-                'Unexpected member expression in describe block. Member expressions may call functions via getters.'
+                'Unexpected member expression in suite block. Member expressions may call functions via getters.'
         },
         schema: [optionSchema]
     },
@@ -108,15 +108,15 @@ export const noSetupInDescribeRule: Readonly<Rule.RuleModule> = {
             return node.parent.type === 'CallExpression' && node.parent.callee === node && isAllowedCall(node.parent);
         }
 
-        function handleCallExpressionInDescribe(node: Readonly<CallExpression>): void {
-            if (isNestedInDescribeBlock(nesting) && !isSuiteConfigCall(node) && !isAllowedCall(node)) {
+        function handleCallExpressionInSuite(node: Readonly<CallExpression>): void {
+            if (isNestedInSuiteBlock(nesting) && !isSuiteConfigCall(node) && !isAllowedCall(node)) {
                 reportCallExpression(context, node);
             }
         }
 
         return createMochaVisitors(context, {
             suite(visitorContext) {
-                nesting.push(DESCRIBE);
+                nesting.push(SUITE);
                 suiteNodes.add(visitorContext.node);
             },
 
@@ -128,13 +128,13 @@ export const noSetupInDescribeRule: Readonly<Rule.RuleModule> = {
                 if (nesting.length === 0) {
                     return;
                 }
-                handleCallExpressionInDescribe(node);
+                handleCallExpressionInSuite(node);
             },
 
             nonMochaMemberExpression(node) {
                 if (
                     !suiteNodes.has(node.parent) &&
-                    isNestedInDescribeBlock(nesting) &&
+                    isNestedInSuiteBlock(nesting) &&
                     !isSuiteConfigCall(node.parent) &&
                     !isAllowedCallMemberExpression(node)
                 ) {


### PR DESCRIPTION
Rename the rule to use the plugin suite terminology instead of the BDD-specific describe name.
Update the exported rule id, tests, docs, and generated rule list accordingly.
