### PR TITLE
Rename no-hooks-for-single-case to no-hooks-for-single-child

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |
 | [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |    |
-| [no-hooks-for-single-case](documentation/rules/no-hooks-for-single-case.md)                   | Disallow hooks for a single test or test suite                          |    |    | ✅  |    |    |
+| [no-hooks-for-single-child](documentation/rules/no-hooks-for-single-child.md)                 | Disallow hooks with a single direct child                               |    |    | ✅  |    |    |
 | [no-identical-title](documentation/rules/no-identical-title.md)                               | Disallow identical titles                                               | ✅  |    |    |    |    |
 | [no-mocha-arrows](documentation/rules/no-mocha-arrows.md)                                     | Disallow arrow functions as arguments to mocha functions                | ✅  |    |    | 🔧 |    |
 | [no-nested-suites](documentation/rules/no-nested-suites.md)                                   | Disallow suites to be nested within other suites                        |    |    | ✅  |    |    |

--- a/documentation/rules/no-hooks-for-single-child.md
+++ b/documentation/rules/no-hooks-for-single-child.md
@@ -1,20 +1,20 @@
-# Disallow hooks for a single test or test suite (`mocha/no-hooks-for-single-case`)
+# Disallow hooks with a single direct child (`mocha/no-hooks-for-single-child`)
 
 🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 
-Mocha proposes hooks that allow code to be run before or after every or all tests. This helps define a common setup or teardown process for every test. These hooks are not useful when there is only one test case, as it would then make more sense to move the hooks' operations in the test directly.
+Mocha proposes hooks that allow code to be run before or after every or all tests. This helps define a common setup or teardown process for every test. These hooks are not useful when there is only one direct child test or suite at the same level, because it is usually clearer to move the setup or teardown closer to that child.
 
 ## Rule Details
 
-This rule looks for every call to `before`, `after`, `beforeEach` and `afterEach` and reports them if they are called when there is less than two tests and/or tests suites in the same test suite.
+This rule looks for every call to `before`, `after`, `beforeEach` and `afterEach` and reports them when the surrounding suite level has only one direct child test or direct child suite.
 
 The following patterns are considered warnings:
 
 ```js
 describe('foo', function () {
-    before(function () {/* ... */}); // Not allowed as there is only a test suite next to this hook.
+    before(function () {/* ... */}); // Not allowed because there is only one direct child suite next to this hook.
 
     describe('bar', function () {
         /* ... */
@@ -22,7 +22,7 @@ describe('foo', function () {
 });
 
 describe('foo', function () {
-    after(function () {/* ... */}); // Not allowed as there is only a test case next to this hook.
+    after(function () {/* ... */}); // Not allowed because there is only one direct child test next to this hook.
 
     it('should XYZ', function () {
         /* ... */
@@ -30,7 +30,7 @@ describe('foo', function () {
 });
 
 describe('foo', function () {
-    beforeEach(function () {/* ... */}); // Not allowed as there is no test suites or cases next to this hook.
+    beforeEach(function () {/* ... */}); // Not allowed because there are no direct child tests or suites next to this hook.
 });
 ```
 
@@ -71,7 +71,7 @@ This rule supports the following options:
 ```json
 {
     "rules": {
-        "mocha/no-hooks-for-single-case": ["error", { "allow": ["after"] }]
+        "mocha/no-hooks-for-single-child": ["error", { "allow": ["after"] }]
     }
 }
 ```

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -11,7 +11,7 @@ import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
 import { noExportsRule } from './rules/no-exports.js';
-import { noHooksForSingleCaseRule } from './rules/no-hooks-for-single-case.js';
+import { noHooksForSingleChildRule } from './rules/no-hooks-for-single-child.js';
 import { noHooksRule } from './rules/no-hooks.js';
 import { noIdenticalTitleRule } from './rules/no-identical-title.js';
 import { noMochaArrowsRule } from './rules/no-mocha-arrows.js';
@@ -43,7 +43,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
     'mocha/no-hooks': 'error',
-    'mocha/no-hooks-for-single-case': 'error',
+    'mocha/no-hooks-for-single-child': 'error',
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',
     'mocha/no-nested-suites': 'error',
@@ -72,7 +72,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
     'mocha/no-hooks': 'off',
-    'mocha/no-hooks-for-single-case': 'off',
+    'mocha/no-hooks-for-single-child': 'off',
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',
     'mocha/no-nested-suites': 'off',
@@ -101,7 +101,7 @@ const rules = {
     'no-exports': noExportsRule,
     'no-top-level-tests': noTopLevelTestsRule,
     'no-hooks': noHooksRule,
-    'no-hooks-for-single-case': noHooksForSingleCaseRule,
+    'no-hooks-for-single-child': noHooksForSingleChildRule,
     'no-identical-title': noIdenticalTitleRule,
     'no-mocha-arrows': noMochaArrowsRule,
     'no-nested-suites': noNestedSuitesRule,

--- a/source/rules/no-hooks-for-single-child.test.ts
+++ b/source/rules/no-hooks-for-single-child.test.ts
@@ -1,9 +1,13 @@
 import { type Rule, RuleTester } from 'eslint';
 import assert from 'node:assert';
-import { noHooksForSingleCaseRule } from './no-hooks-for-single-case.js';
+import { noHooksForSingleChildRule } from './no-hooks-for-single-child.js';
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 
-ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
+function singleChildError(name: string): string {
+    return `Unexpected use of Mocha \`${name}\` hook with only one direct child.`;
+}
+
+ruleTester.run('no-hooks-for-single-child', noHooksForSingleChildRule, {
     valid: [
         [
             'describe(function() {',
@@ -207,7 +211,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -217,7 +221,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -227,7 +231,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 3 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 3 }]
         },
         {
             code: [
@@ -237,7 +241,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `after()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('after()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -248,7 +252,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
             ]
                 .join('\n'),
             errors: [
-                { message: 'Unexpected use of Mocha `beforeEach()` hook for a single test case', column: 5, line: 2 }
+                { message: singleChildError('beforeEach()'), column: 5, line: 2 }
             ]
         },
         {
@@ -260,7 +264,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
             ]
                 .join('\n'),
             errors: [
-                { message: 'Unexpected use of Mocha `afterEach()` hook for a single test case', column: 5, line: 2 }
+                { message: singleChildError('afterEach()'), column: 5, line: 2 }
             ]
         },
         {
@@ -269,7 +273,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 'it(function() {});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 1, line: 1 }]
+            errors: [{ message: singleChildError('before()'), column: 1, line: 1 }]
         },
         {
             code: [
@@ -279,7 +283,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -289,7 +293,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -299,7 +303,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -313,7 +317,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                 '});'
             ]
                 .join('\n'),
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 9, line: 5 }]
+            errors: [{ message: singleChildError('before()'), column: 9, line: 5 }]
         },
         {
             code: [
@@ -324,7 +328,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
             ]
                 .join('\n'),
             options: [{ allow: ['before'] }],
-            errors: [{ message: 'Unexpected use of Mocha `after()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('after()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -338,7 +342,7 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
                     additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
                 }
             },
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         },
         {
             code: [
@@ -350,15 +354,15 @@ ruleTester.run('no-hooks-for-single-case', noHooksForSingleCaseRule, {
             settings: {
                 'mocha/additionalCustomNames': [{ name: 'foo', type: 'suite', interface: 'BDD' }]
             },
-            errors: [{ message: 'Unexpected use of Mocha `before()` hook for a single test case', column: 5, line: 2 }]
+            errors: [{ message: singleChildError('before()'), column: 5, line: 2 }]
         }
     ]
 });
 
-describe('no-hooks-for-single-case create()', function () {
+describe('no-hooks-for-single-child create()', function () {
     it('normalizes non-string allow entries when invoked directly', function () {
-        noHooksForSingleCaseRule.create({
-            id: 'no-hooks-for-single-case',
+        noHooksForSingleChildRule.create({
+            id: 'no-hooks-for-single-child',
             options: [{ allow: [42] }],
             settings: {},
             sourceCode: {

--- a/source/rules/no-hooks-for-single-child.ts
+++ b/source/rules/no-hooks-for-single-child.ts
@@ -46,17 +46,17 @@ function ensureEndsWithParens(value: unknown): string {
     return value;
 }
 
-export const noHooksForSingleCaseRule: Readonly<Rule.RuleModule> = {
+export const noHooksForSingleChildRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'suggestion',
         languages: ['js/js'],
         docs: {
-            description: 'Disallow hooks for a single test or test suite',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-hooks-for-single-case.md'
+            description: 'Disallow hooks with a single direct child',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-hooks-for-single-child.md'
         },
         defaultOptions: [defaultOption],
         messages: {
-            unexpectedHookForSingleTest: 'Unexpected use of Mocha `{{name}}` hook for a single test case'
+            unexpectedHookForSingleChild: 'Unexpected use of Mocha `{{name}}` hook with only one direct child.'
         },
         schema: [optionSchema]
     },
@@ -87,7 +87,7 @@ export const noHooksForSingleCaseRule: Readonly<Rule.RuleModule> = {
                         .forEach((hookNode) => {
                             context.report({
                                 node: hookNode.node,
-                                messageId: 'unexpectedHookForSingleTest',
+                                messageId: 'unexpectedHookForSingleChild',
                                 data: { name: hookNode.name }
                             });
                         });


### PR DESCRIPTION
Rename the rule to match what it actually counts.
Update the error text and docs to describe a single direct child instead of a single test case.
