### PR TITLE
Rename no-synchronous-tests option to allowedAsyncMethods

### DIFF
--- a/documentation/rules/no-synchronous-tests.md
+++ b/documentation/rules/no-synchronous-tests.md
@@ -50,7 +50,7 @@ You can limit which async styles are allowed:
 
 ```js
 rules: {
-    "mocha/no-synchronous-tests": ["warn", { "allowed": ["async", "callback", "promise"] }]
+    "mocha/no-synchronous-tests": ["warn", { "allowedAsyncMethods": ["async", "callback", "promise"] }]
 },
 ```
 

--- a/source/rules/no-synchronous-tests.test.ts
+++ b/source/rules/no-synchronous-tests.test.ts
@@ -126,7 +126,7 @@ ruleTester.run('no-synchronous-tests', noSynchronousTestsRule, {
             errors: [{ message: 'Unexpected synchronous test.', column: 12, line: 1 }]
         },
         {
-            options: [{ allowed: ['callback', 'async'] }],
+            options: [{ allowedAsyncMethods: ['callback', 'async'] }],
             code: 'it("", function () { return promise(); });',
             errors: [{ message: 'Unexpected synchronous test.', column: 8, line: 1 }]
         }

--- a/source/rules/no-synchronous-tests.ts
+++ b/source/rules/no-synchronous-tests.ts
@@ -8,7 +8,7 @@ const asyncMethods = ['async', 'callback', 'promise'] as const;
 const optionSchema = {
     type: 'object',
     properties: {
-        allowed: {
+        allowedAsyncMethods: {
             type: 'array',
             items: {
                 type: 'string',
@@ -23,8 +23,8 @@ const optionSchema = {
 
 type Option = InferSchemaOption<typeof optionSchema>;
 type AsyncMethod = (typeof asyncMethods)[number];
-type ResolvedOption = Option & { allowed: AsyncMethod[]; };
-const defaultOption: ResolvedOption = { allowed: Array.from(asyncMethods) };
+type ResolvedOption = Option & { allowedAsyncMethods: AsyncMethod[]; };
+const defaultOption: ResolvedOption = { allowedAsyncMethods: Array.from(asyncMethods) };
 type AsyncCheck = (functionExpression: Readonly<Rule.Node>) => boolean;
 
 function hasAsyncCallback(functionExpression: Readonly<Rule.Node>): boolean {
@@ -83,7 +83,7 @@ export const noSynchronousTestsRule: Readonly<Rule.RuleModule> = {
         schema: [optionSchema]
     },
     create(context) {
-        const { allowed: allowedAsyncMethods } = getRuleOption<ResolvedOption>(context);
+        const { allowedAsyncMethods } = getRuleOption<ResolvedOption>(context);
         const asyncChecks = allowedAsyncMethods.map<AsyncCheck>((method) => {
             return asyncChecksByMethod[method];
         });


### PR DESCRIPTION
Rename the option to describe the async styles it configures.
Update the rule schema, tests, and docs to use allowedAsyncMethods consistently.
