### PR TITLE
Fix no-empty-title docs for suite titles and message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
-| [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |
+| [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty suite and test descriptions                              | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |
 | [no-hooks](documentation/rules/no-hooks.md)                                                   | Disallow hooks                                                          |    |    | ✅  |    |    |

--- a/documentation/rules/no-empty-title.md
+++ b/documentation/rules/no-empty-title.md
@@ -1,18 +1,22 @@
-# Disallow empty test descriptions (`mocha/no-empty-title`)
+# Disallow empty suite and test descriptions (`mocha/no-empty-title`)
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 
-This rule enforces you to specify the suite/test descriptions for each test.
+This rule enforces non-empty descriptions for Mocha suites and test cases.
 
 ## Rule Details
 
-This rule checks each mocha test function to have a non-empty description.
+This rule checks suite and test descriptions when they can be evaluated statically.
 
 The following patterns are considered problems:
 
 ```js
+describe();
+
+describe('   ', function () {});
+
 it();
 
 suite('');
@@ -32,16 +36,22 @@ describe('foo', function () {
 suite('foo', function () {
     test('bar');
 });
+
+const dynamicTitle = getTitle();
+it(dynamicTitle, function () {});
 ```
 
 ## Options
 
-Example of a custom rule configuration:
+This rule accepts one optional object:
+
+- `message`: a custom error message to use instead of the default message
+
+Example:
 
 ```js
 rules: {
     "mocha/no-empty-title": [ "warn", {
-        testNames: ["it", "specify", "test", "mytestname"],
         message: 'custom error message'
     } ]
 }

--- a/source/rules/no-empty-title.ts
+++ b/source/rules/no-empty-title.ts
@@ -61,7 +61,7 @@ export const noEmptyTitleRule: Readonly<Rule.RuleModule> = {
         type: 'suggestion',
         languages: ['js/js'],
         docs: {
-            description: 'Disallow empty test descriptions',
+            description: 'Disallow empty suite and test descriptions',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-empty-title.md'
         },
         defaultOptions: [defaultOption],


### PR DESCRIPTION
Document that no-empty-title applies to both suite and test descriptions.
Remove the nonexistent testNames option from the docs and document the supported message option instead.
