### PR TITLE
Add `no-code-after-done` rule to reject code after done()

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
+| [no-code-after-done](documentation/rules/no-code-after-done.md)                               | Disallow executing code after calling a Mocha callback                  | ✅  |    |    |    |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty suite and test descriptions                              | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |

--- a/documentation/rules/no-code-after-done.md
+++ b/documentation/rules/no-code-after-done.md
@@ -1,0 +1,39 @@
+# Disallow executing code after calling a Mocha callback (`mocha/no-code-after-done`)
+
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Once a callback-style test or hook calls `done()`, Mocha treats that operation as completion. Assertions or side effects that run afterward can be ignored, misreported, or fail in confusing ways.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+it("reports too late", function (done) {
+    done();
+    expect(true).to.equal(false);
+});
+
+it("hides failures in nested callbacks", function (done) {
+    run(function () {
+        done();
+        expect(true).to.equal(false);
+    });
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it("finishes once", function (done) {
+    expect(true).to.equal(true);
+    done();
+});
+
+it("returns immediately after finishing", function (done) {
+    done();
+    return;
+});
+```

--- a/source/callback-handling-paths.test.ts
+++ b/source/callback-handling-paths.test.ts
@@ -1,0 +1,146 @@
+import type { Rule, Scope, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import {
+    collectCodeAfterCallbackHandlingNodes
+} from './callback-handling-paths.js';
+import type { CallbackHandlingOperation } from './callback-handling-state.js';
+
+type MutableSegment = {
+    id: string;
+    nextSegments: MutableSegment[];
+    prevSegments: MutableSegment[];
+};
+
+type CallExpressionNode = Extract<CallbackHandlingOperation, { type: 'call'; }>['node'];
+type IdentifierNode = Parameters<Exclude<Rule.RuleListener['Identifier'], undefined>>[0];
+type LiteralNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'Literal'; }> & Rule.Node;
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function createSourceCode(): SourceCode {
+    const scope = {
+        childScopes: [],
+        set: new Map(),
+        upper: null
+    } as unknown as Scope.Scope;
+
+    return asSourceCode({
+        getScope() {
+            return scope;
+        }
+    });
+}
+
+function identifier(name: string): IdentifierNode {
+    return { name, type: 'Identifier' } as unknown as IdentifierNode;
+}
+
+function literal(value: number | string | null): LiteralNode {
+    return { type: 'Literal', value } as unknown as LiteralNode;
+}
+
+function setParent(node: Readonly<Rule.Node> | null | undefined, parent: Readonly<Rule.Node>): void {
+    if (node !== null && node !== undefined) {
+        Reflect.set(node, 'parent', parent);
+    }
+}
+
+function callExpression(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): CallExpressionNode {
+    const node = {
+        arguments: args,
+        callee,
+        type: 'CallExpression'
+    } as unknown as CallExpressionNode;
+
+    setParent(callee, node);
+
+    for (const argument of args) {
+        setParent(argument as unknown as Rule.Node, node);
+    }
+
+    return node;
+}
+
+function createSegment(id: string): MutableSegment {
+    return { id, nextSegments: [], prevSegments: [] };
+}
+
+function asCodePathSegment(segment: MutableSegment): Rule.CodePathSegment {
+    return segment as unknown as Rule.CodePathSegment;
+}
+
+function createCodePath(initialSegment: MutableSegment, returnedSegments: readonly MutableSegment[]): Rule.CodePath {
+    return {
+        initialSegment: asCodePathSegment(initialSegment),
+        returnedSegments: returnedSegments.map(asCodePathSegment)
+    } as unknown as Rule.CodePath;
+}
+
+function bindingAssignment(
+    node: Readonly<Rule.Node>,
+    target: string,
+    source: Readonly<Rule.Node> | null
+): Extract<CallbackHandlingOperation, { type: 'bindingAssignment'; }> {
+    return { node, source, target, type: 'bindingAssignment' };
+}
+
+function callOperation(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): Extract<CallbackHandlingOperation, { type: 'call'; }> {
+    return {
+        node: callExpression(callee, args),
+        type: 'call'
+    };
+}
+
+function analyzeOperations(
+    operationsBySegmentId: ReadonlyMap<string, readonly CallbackHandlingOperation[]>,
+    codePath: Readonly<Rule.CodePath>
+): readonly Rule.Node[] {
+    return collectCodeAfterCallbackHandlingNodes({
+        callbackBinding: 'done',
+        codePath,
+        operationsBySegmentId,
+        sourceCode: createSourceCode()
+    });
+}
+
+describe('callback handling path helpers', function () {
+    it('collectCodeAfterCallbackHandlingNodes() returns no nodes when no callback is handled', function () {
+        const start = createSegment('start');
+        const result = analyzeOperations(new Map(), createCodePath(start, [start]));
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectCodeAfterCallbackHandlingNodes() reports code after the callback once across revisits', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const end = createSegment('end');
+        const right = createSegment('right');
+        const afterDoneNode = identifier('afterDone');
+
+        start.nextSegments.push(left, end, right);
+        left.prevSegments.push(start);
+        right.prevSegments.push(start);
+        left.nextSegments.push(end);
+        right.nextSegments.push(end);
+        end.prevSegments.push(left, right);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [callOperation(identifier('done'), [])]],
+                ['end', [bindingAssignment(afterDoneNode, 'finish', literal(0))]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.deepStrictEqual(result, [afterDoneNode]);
+    });
+});

--- a/source/callback-handling-paths.ts
+++ b/source/callback-handling-paths.ts
@@ -1,0 +1,122 @@
+import type { Rule } from 'eslint';
+import {
+    arePathStatesSame,
+    type CallbackHandlingContext,
+    clonePathState,
+    createEntryState,
+    getCodeAfterCallbackHandlingNode,
+    updatePathState
+} from './callback-handling-state.js';
+
+type PendingSegmentCollection = {
+    exitStatesBySegmentId: Map<string, ReturnType<typeof clonePathState>>;
+    pendingSegments: Rule.CodePathSegment[];
+    queuedSegmentIds: Set<string>;
+    reportedNodeSet: WeakSet<Rule.Node>;
+    reportedNodes: Rule.Node[];
+};
+
+function collectSegmentCodeAfterCallbackHandlingNodes(
+    context: Readonly<CallbackHandlingContext>,
+    entryState: ReturnType<typeof clonePathState>,
+    segment: Readonly<Rule.CodePathSegment>
+): readonly [Rule.Node[], ReturnType<typeof clonePathState>] {
+    const reportedNodes: Rule.Node[] = [];
+    let nextState = clonePathState(entryState);
+
+    for (const operation of context.operationsBySegmentId.get(segment.id) ?? []) {
+        const codeAfterCallbackHandlingNode = getCodeAfterCallbackHandlingNode(
+            context.sourceCode,
+            nextState,
+            operation
+        );
+
+        if (codeAfterCallbackHandlingNode !== undefined) {
+            reportedNodes.push(codeAfterCallbackHandlingNode);
+        }
+
+        nextState = updatePathState(context.sourceCode, nextState, operation);
+    }
+
+    return [reportedNodes, nextState];
+}
+
+function enqueueNextSegments(
+    nextSegments: readonly Readonly<Rule.CodePathSegment>[],
+    pendingSegments: Rule.CodePathSegment[],
+    queuedSegmentIds: Set<string>
+): void {
+    for (const nextSegment of nextSegments) {
+        if (!queuedSegmentIds.has(nextSegment.id)) {
+            pendingSegments.push(nextSegment);
+            queuedSegmentIds.add(nextSegment.id);
+        }
+    }
+}
+
+function recordReportedNodes(
+    reportedNodes: Rule.Node[],
+    reportedNodeSet: WeakSet<Rule.Node>,
+    segmentReportedNodes: readonly Rule.Node[]
+): void {
+    for (const reportedNode of segmentReportedNodes) {
+        if (!reportedNodeSet.has(reportedNode)) {
+            reportedNodeSet.add(reportedNode);
+            reportedNodes.push(reportedNode);
+        }
+    }
+}
+
+function shouldRevisitSegment(
+    collection: Readonly<PendingSegmentCollection>,
+    nextState: ReturnType<typeof clonePathState>,
+    segment: Readonly<Rule.CodePathSegment>,
+    segmentReportedNodes: readonly Rule.Node[]
+): boolean {
+    return segmentReportedNodes.length > 0 ||
+        !arePathStatesSame(collection.exitStatesBySegmentId.get(segment.id), nextState);
+}
+
+function processPendingSegment(
+    context: Readonly<CallbackHandlingContext>,
+    collection: PendingSegmentCollection,
+    segment: Readonly<Rule.CodePathSegment>
+): void {
+    collection.queuedSegmentIds.delete(segment.id);
+
+    const entryState = createEntryState(context, segment, collection.exitStatesBySegmentId);
+    const [segmentReportedNodes, nextState] = collectSegmentCodeAfterCallbackHandlingNodes(
+        context,
+        entryState,
+        segment
+    );
+
+    recordReportedNodes(collection.reportedNodes, collection.reportedNodeSet, segmentReportedNodes);
+
+    if (shouldRevisitSegment(collection, nextState, segment, segmentReportedNodes)) {
+        collection.exitStatesBySegmentId.set(segment.id, nextState);
+        enqueueNextSegments(segment.nextSegments, collection.pendingSegments, collection.queuedSegmentIds);
+    }
+}
+
+export function collectCodeAfterCallbackHandlingNodes(
+    context: Readonly<CallbackHandlingContext>
+): readonly Rule.Node[] {
+    const collection: PendingSegmentCollection = {
+        exitStatesBySegmentId: new Map(),
+        pendingSegments: [context.codePath.initialSegment],
+        queuedSegmentIds: new Set([context.codePath.initialSegment.id]),
+        reportedNodeSet: new WeakSet(),
+        reportedNodes: []
+    };
+
+    while (collection.pendingSegments.length > 0) {
+        const segment = collection.pendingSegments.shift();
+
+        if (segment !== undefined) {
+            processPendingSegment(context, collection, segment);
+        }
+    }
+
+    return collection.reportedNodes;
+}

--- a/source/callback-handling-state.test.ts
+++ b/source/callback-handling-state.test.ts
@@ -1,0 +1,462 @@
+import type { Rule, Scope, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import {
+    arePathStatesSame,
+    type CallbackHandlingContext,
+    type CallbackHandlingOperation,
+    type CallbackPathState,
+    clonePathState,
+    createEntryState,
+    getCodeAfterCallbackHandlingNode,
+    updatePathState
+} from './callback-handling-state.js';
+
+type MutableSegment = {
+    id: string;
+    nextSegments: MutableSegment[];
+    prevSegments: MutableSegment[];
+};
+
+type CallExpressionNode = Extract<CallbackHandlingOperation, { type: 'call'; }>['node'];
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
+type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type ObjectExpressionNode = Parameters<Exclude<Rule.RuleListener['ObjectExpression'], undefined>>[0];
+type IdentifierNode = Parameters<Exclude<Rule.RuleListener['Identifier'], undefined>>[0];
+type LiteralNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'Literal'; }> & Rule.Node;
+type SpreadElementNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'SpreadElement'; }>;
+type PathStateOverrides = {
+    callbackHandled: boolean;
+    handledAliases: readonly string[];
+    handledContainerProperties: readonly (readonly [string, readonly string[]])[];
+    unhandledAliases: readonly string[];
+    unhandledContainerProperties: readonly (readonly [string, readonly string[]])[];
+};
+
+const defaultPathStateOverrides: PathStateOverrides = {
+    callbackHandled: false,
+    handledAliases: [],
+    handledContainerProperties: [],
+    unhandledAliases: ['done'],
+    unhandledContainerProperties: []
+};
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function createSourceCode(): SourceCode {
+    const scope = {
+        childScopes: [],
+        set: new Map(),
+        upper: null
+    } as unknown as Scope.Scope;
+
+    return asSourceCode({
+        getScope() {
+            return scope;
+        }
+    });
+}
+
+function identifier(name: string): IdentifierNode {
+    return { name, type: 'Identifier' } as unknown as IdentifierNode;
+}
+
+function literal(value: number | string | null): LiteralNode {
+    return { type: 'Literal', value } as unknown as LiteralNode;
+}
+
+function setParent(node: Readonly<Rule.Node> | null | undefined, parent: Readonly<Rule.Node>): void {
+    if (node !== null && node !== undefined) {
+        Reflect.set(node, 'parent', parent);
+    }
+}
+
+function memberExpression(
+    object: Readonly<Rule.Node>,
+    propertyNode: Readonly<Rule.Node>,
+    computed = false
+): MemberExpressionNode {
+    const node = {
+        computed,
+        object,
+        property: propertyNode,
+        type: 'MemberExpression'
+    } as unknown as MemberExpressionNode;
+
+    setParent(object, node);
+    setParent(propertyNode, node);
+
+    return node;
+}
+
+function property(
+    key: Readonly<Rule.Node>,
+    value: Readonly<Rule.Node>,
+    computed = false
+): PropertyNode {
+    const node = {
+        computed,
+        key,
+        kind: 'init',
+        type: 'Property',
+        value
+    } as unknown as PropertyNode;
+
+    setParent(key, node);
+    setParent(value, node);
+
+    return node;
+}
+
+function objectExpression(properties: readonly Readonly<PropertyNode>[]): ObjectExpressionNode {
+    const node = { properties, type: 'ObjectExpression' } as unknown as ObjectExpressionNode;
+
+    for (const propertyNode of properties) {
+        setParent(propertyNode as unknown as Rule.Node, node);
+    }
+
+    return node;
+}
+
+function callExpression(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): CallExpressionNode {
+    const node = {
+        arguments: args,
+        callee,
+        type: 'CallExpression'
+    } as unknown as CallExpressionNode;
+
+    setParent(callee, node);
+
+    for (const argument of args) {
+        setParent(argument as unknown as Rule.Node, node);
+    }
+
+    return node;
+}
+
+function spreadElement(argument: Readonly<Rule.Node>): SpreadElementNode {
+    const node = { argument, type: 'SpreadElement' } as unknown as SpreadElementNode;
+
+    setParent(argument, node as unknown as Rule.Node);
+
+    return node;
+}
+
+function createSegment(id: string): MutableSegment {
+    return { id, nextSegments: [], prevSegments: [] };
+}
+
+function asCodePathSegment(segment: MutableSegment): Rule.CodePathSegment {
+    return segment as unknown as Rule.CodePathSegment;
+}
+
+function createCodePath(initialSegment: MutableSegment, returnedSegments: readonly MutableSegment[]): Rule.CodePath {
+    return {
+        initialSegment: asCodePathSegment(initialSegment),
+        returnedSegments: returnedSegments.map(asCodePathSegment)
+    } as unknown as Rule.CodePath;
+}
+
+function createContext(codePath: Readonly<Rule.CodePath>): CallbackHandlingContext {
+    return {
+        callbackBinding: 'done',
+        codePath,
+        operationsBySegmentId: new Map(),
+        sourceCode: createSourceCode()
+    };
+}
+
+function compareStrings(left: string, right: string): number {
+    return left.localeCompare(right);
+}
+
+function readStrings(values: Iterable<unknown>): string[] {
+    return Array.from(values, String);
+}
+
+function readSortedStrings(values: Iterable<unknown>): string[] {
+    return Array.from(values, String).toSorted(compareStrings);
+}
+
+function createReferenceState(
+    aliases: readonly string[],
+    containerProperties: readonly (readonly [string, readonly string[]])[] = []
+): CallbackPathState['handledReferences'] {
+    return {
+        aliasBindings: new Set(aliases),
+        containerPropertiesByBinding: new Map(
+            containerProperties.map(([binding, properties]) => {
+                return [binding, new Set(properties)] as const;
+            })
+        )
+    };
+}
+
+function createPathState(overrides: Readonly<Partial<PathStateOverrides>> = {}): CallbackPathState {
+    const resolvedOverrides = { ...defaultPathStateOverrides, ...overrides };
+
+    return {
+        callbackHandled: resolvedOverrides.callbackHandled,
+        handledReferences: createReferenceState(
+            resolvedOverrides.handledAliases,
+            resolvedOverrides.handledContainerProperties
+        ),
+        unhandledReferences: createReferenceState(
+            resolvedOverrides.unhandledAliases,
+            resolvedOverrides.unhandledContainerProperties
+        )
+    };
+}
+
+function bindingAssignment(
+    node: Readonly<Rule.Node>,
+    target: string,
+    source: Readonly<Rule.Node> | null
+): Extract<CallbackHandlingOperation, { type: 'bindingAssignment'; }> {
+    return { node, source, target, type: 'bindingAssignment' };
+}
+
+function containerPropertyAssignment(
+    node: Readonly<Rule.Node>,
+    target: string,
+    propertyName: string | undefined,
+    source: Readonly<Rule.Node> | null
+): Extract<CallbackHandlingOperation, { type: 'containerPropertyAssignment'; }> {
+    return {
+        node,
+        propertyName,
+        source,
+        target,
+        type: 'containerPropertyAssignment'
+    };
+}
+
+function callOperation(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): Extract<CallbackHandlingOperation, { type: 'call'; }> {
+    return {
+        node: callExpression(callee, args),
+        type: 'call'
+    };
+}
+
+describe('callback handling state helpers', function () {
+    it('clonePathState() deep-copies alias and container state', function () {
+        const state = createPathState({
+            callbackHandled: true,
+            handledAliases: ['done', 'finish'],
+            handledContainerProperties: [['callbacks', ['complete']]],
+            unhandledContainerProperties: [['nextCallbacks', ['finish']]]
+        });
+        const clone = clonePathState(state);
+
+        clone.handledReferences.aliasBindings.add('other');
+        clone.handledReferences.containerPropertiesByBinding.get('callbacks')?.add('secondary');
+
+        assert.deepStrictEqual(readSortedStrings(state.handledReferences.aliasBindings), ['done', 'finish']);
+        assert.deepStrictEqual(
+            readStrings(state.handledReferences.containerPropertiesByBinding.get('callbacks') ?? []),
+            ['complete']
+        );
+    });
+
+    it('arePathStatesSame() distinguishes missing and changed states', function () {
+        const state = createPathState({ handledAliases: ['done', 'finish'] });
+
+        assert.strictEqual(arePathStatesSame(undefined, state), false);
+        assert.strictEqual(arePathStatesSame(clonePathState(state), state), true);
+        assert.strictEqual(
+            arePathStatesSame(state, createPathState({ callbackHandled: true, handledAliases: ['done', 'finish'] })),
+            false
+        );
+    });
+
+    it('updatePathState() tracks aliased callback calls', function () {
+        const sourceCode = createSourceCode();
+        const aliasedState = updatePathState(
+            sourceCode,
+            createPathState(),
+            bindingAssignment(identifier('aliasAssignment'), 'finish', identifier('done'))
+        );
+        const handledState = updatePathState(sourceCode, aliasedState, callOperation(identifier('finish'), []));
+
+        assert.strictEqual(handledState.callbackHandled, true);
+        assert.deepStrictEqual(readSortedStrings(handledState.handledReferences.aliasBindings), ['done', 'finish']);
+    });
+
+    it('updatePathState() clears callback aliases on reassignment', function () {
+        const sourceCode = createSourceCode();
+        const nextState = updatePathState(
+            sourceCode,
+            createPathState({ unhandledAliases: ['done', 'finish'] }),
+            bindingAssignment(identifier('clearAlias'), 'finish', null)
+        );
+
+        assert.deepStrictEqual(readStrings(nextState.unhandledReferences.aliasBindings), ['done']);
+    });
+
+    it('updatePathState() copies callback container aliases through identifiers', function () {
+        const sourceCode = createSourceCode();
+        const nextState = updatePathState(
+            sourceCode,
+            updatePathState(
+                sourceCode,
+                createPathState(),
+                containerPropertyAssignment(identifier('trackContainer'), 'holder', 'complete', identifier('done'))
+            ),
+            bindingAssignment(identifier('copyContainer'), 'callbacks', identifier('holder'))
+        );
+
+        assert.deepStrictEqual(
+            readStrings(nextState.unhandledReferences.containerPropertiesByBinding.get('callbacks') ?? []),
+            ['complete']
+        );
+    });
+
+    it('updatePathState() keeps only static callback properties from object containers', function () {
+        const sourceCode = createSourceCode();
+        const nextState = updatePathState(
+            sourceCode,
+            createPathState(),
+            bindingAssignment(
+                identifier('trackObject'),
+                'callbacks',
+                objectExpression([
+                    property(literal('complete'), identifier('done'), true),
+                    property(literal('alias'), identifier('done')),
+                    property(identifier('dynamicName'), identifier('done'), true),
+                    property(literal(null), identifier('done'))
+                ])
+            )
+        );
+
+        assert.deepStrictEqual(
+            readSortedStrings(nextState.unhandledReferences.containerPropertiesByBinding.get('callbacks') ?? []),
+            ['alias', 'complete']
+        );
+    });
+
+    it('updatePathState() clears callback container properties on reassignment', function () {
+        const sourceCode = createSourceCode();
+        const nextState = updatePathState(
+            sourceCode,
+            createPathState({ unhandledContainerProperties: [['callbacks', ['complete']]] }),
+            containerPropertyAssignment(identifier('clearProperty'), 'callbacks', 'complete', null)
+        );
+
+        assert.strictEqual(nextState.unhandledReferences.containerPropertiesByBinding.has('callbacks'), false);
+    });
+
+    it('updatePathState() tracks dynamic callback container properties', function () {
+        const sourceCode = createSourceCode();
+        const trackedState = updatePathState(
+            sourceCode,
+            createPathState(),
+            containerPropertyAssignment(identifier('trackDynamicProperty'), 'callbacks', undefined, identifier('done'))
+        );
+        const dynamicCall = callOperation(memberExpression(identifier('callbacks'), identifier('name'), true), []);
+        const callbackHandledState = createPathState({
+            callbackHandled: true,
+            unhandledContainerProperties: [['callbacks', ['<dynamic>']]]
+        });
+
+        assert.deepStrictEqual(
+            readStrings(trackedState.unhandledReferences.containerPropertiesByBinding.get('callbacks') ?? []),
+            ['<dynamic>']
+        );
+        assert.strictEqual(getCodeAfterCallbackHandlingNode(sourceCode, callbackHandledState, dynamicCall), undefined);
+    });
+
+    it('updatePathState() treats delegated spread calls as callback handling', function () {
+        const nextState = updatePathState(
+            createSourceCode(),
+            createPathState(),
+            callOperation(identifier('setTimeout'), [spreadElement(identifier('done')), literal(0)])
+        );
+
+        assert.strictEqual(nextState.callbackHandled, true);
+        assert.deepStrictEqual(readStrings(nextState.handledReferences.aliasBindings), ['done']);
+    });
+
+    it('getCodeAfterCallbackHandlingNode() reports non-callback operations after the callback', function () {
+        const sourceCode = createSourceCode();
+        const state = createPathState({ callbackHandled: true, handledAliases: ['done'] });
+        const laterNode = identifier('laterStatement');
+        const laterBindingAssignment = bindingAssignment(laterNode, 'finish', literal(0));
+        const callbackCall = callOperation(identifier('done'), []);
+
+        assert.strictEqual(getCodeAfterCallbackHandlingNode(sourceCode, state, laterBindingAssignment), laterNode);
+        assert.strictEqual(getCodeAfterCallbackHandlingNode(sourceCode, state, callbackCall), undefined);
+    });
+
+    it('getCodeAfterCallbackHandlingNode() treats unsupported and untracked member calls as later code', function () {
+        const sourceCode = createSourceCode();
+        const state = createPathState({ callbackHandled: true, handledAliases: ['done'] });
+        const unsupportedCall = callOperation(
+            memberExpression(callExpression(identifier('getCallbacks'), []), identifier('complete')),
+            []
+        );
+        const untrackedCall = callOperation(memberExpression(identifier('callbacks'), identifier('complete')), []);
+
+        assert.strictEqual(getCodeAfterCallbackHandlingNode(sourceCode, state, unsupportedCall), unsupportedCall.node);
+        assert.strictEqual(getCodeAfterCallbackHandlingNode(sourceCode, state, untrackedCall), untrackedCall.node);
+    });
+
+    it('getCodeAfterCallbackHandlingNode() treats dynamic delegate paths as later code', function () {
+        const sourceCode = createSourceCode();
+        const state = createPathState({ callbackHandled: true, handledAliases: ['done'] });
+        const dynamicDelegateCall = callOperation(
+            memberExpression(identifier('globalThis'), identifier('delegateName'), true),
+            [identifier('done')]
+        );
+
+        assert.strictEqual(
+            getCodeAfterCallbackHandlingNode(sourceCode, state, dynamicDelegateCall),
+            dynamicDelegateCall.node
+        );
+    });
+
+    it('createEntryState() returns the initial callback state for initial and predecessor-less segments', function () {
+        const start = createSegment('start');
+        const orphan = createSegment('orphan');
+        const handlingContext = createContext(createCodePath(start, [start]));
+
+        const initialState = createEntryState(handlingContext, asCodePathSegment(start), new Map());
+        const orphanState = createEntryState(handlingContext, asCodePathSegment(orphan), new Map());
+
+        assert.deepStrictEqual(readStrings(initialState.unhandledReferences.aliasBindings), ['done']);
+        assert.deepStrictEqual(readStrings(orphanState.unhandledReferences.aliasBindings), ['done']);
+    });
+
+    it('createEntryState() merges previous states and missing predecessor fallbacks', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const missing = createSegment('missing');
+        const end = createSegment('end');
+        end.prevSegments.push(left, missing);
+
+        const entryState = createEntryState(
+            createContext(createCodePath(start, [end])),
+            asCodePathSegment(end),
+            new Map([
+                [
+                    'left',
+                    createPathState({
+                        callbackHandled: true,
+                        handledAliases: ['done'],
+                        unhandledAliases: ['done', 'finish']
+                    })
+                ]
+            ])
+        );
+
+        assert.strictEqual(entryState.callbackHandled, true);
+        assert.deepStrictEqual(readStrings(entryState.handledReferences.aliasBindings), ['done']);
+        assert.deepStrictEqual(readSortedStrings(entryState.unhandledReferences.aliasBindings), ['done', 'finish']);
+    });
+});

--- a/source/callback-handling-state.ts
+++ b/source/callback-handling-state.ts
@@ -20,8 +20,9 @@ const knownSingleCallbackDelegates = new Set(
         .split(' ')
 );
 
-type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
 type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type CallExpressionNode = Parameters<Exclude<Rule.RuleListener['CallExpression'], undefined>>[0];
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
 type CallbackReferenceState = {
     aliasBindings: Set<TrackedBinding>;
     containerPropertiesByBinding: Map<TrackedBinding, Set<string>>;
@@ -31,11 +32,13 @@ export type CallbackPathState = {
     handledReferences: CallbackReferenceState;
     unhandledReferences: CallbackReferenceState;
 };
-type PropertyLike =
-    | Readonly<Pick<MemberExpressionNode, 'computed' | 'object' | 'property' | 'type'>>
-    | Readonly<Pick<PropertyNode, 'computed' | 'key' | 'type'>>;
+type PropertyLike = Readonly<Pick<PropertyNode, 'computed' | 'key' | 'type'>>;
 
 export type CallbackHandlingOperation =
+    | {
+        node: CallExpressionNode;
+        type: 'call';
+    }
     | {
         node: Rule.Node;
         propertyName: string | undefined;
@@ -48,10 +51,6 @@ export type CallbackHandlingOperation =
         source: Readonly<Rule.Node> | null;
         target: TrackedBinding;
         type: 'bindingAssignment';
-    }
-    | {
-        node: Rule.Node;
-        type: 'call';
     };
 
 export type CallbackHandlingContext = {
@@ -118,7 +117,7 @@ export function arePathStatesSame(
 }
 
 function getNamedPropertyName(node: PropertyLike): string | undefined {
-    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
+    const keyNode = node.key;
 
     if (keyNode.type === 'Identifier') {
         return keyNode.name;
@@ -138,8 +137,7 @@ function getStaticPropertyName(
         return getNamedPropertyName(node);
     }
 
-    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
-    return getStringIfConstant(keyNode, sourceCode.getScope(asRuleNode(node))) ?? undefined;
+    return getStringIfConstant(node.key, sourceCode.getScope(asRuleNode(node))) ?? undefined;
 }
 
 function isTrackedPropertyAccess(
@@ -331,13 +329,9 @@ function getNormalizedCallPath(
 
 function isKnownSingleCallbackDelegateCall(
     sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
-    node: Readonly<Extract<CallbackHandlingOperation, { type: 'call'; }>['node']>,
+    node: Readonly<CallExpressionNode>,
     state: Readonly<CallbackReferenceState>
 ): boolean {
-    if (node.type !== 'CallExpression') {
-        return false;
-    }
-
     const normalizedCallPath = getNormalizedCallPath(sourceCode, asRuleNode(node.callee));
 
     if (normalizedCallPath === undefined || !knownSingleCallbackDelegates.has(normalizedCallPath)) {
@@ -355,10 +349,6 @@ function isCallbackHandlingCall(
     operation: Readonly<Extract<CallbackHandlingOperation, { type: 'call'; }>>,
     state: Readonly<CallbackReferenceState>
 ): boolean {
-    if (operation.node.type !== 'CallExpression') {
-        return false;
-    }
-
     return isCallbackExpression(sourceCode, asRuleNode(operation.node.callee), state) ||
         isKnownSingleCallbackDelegateCall(sourceCode, operation.node, state);
 }

--- a/source/callback-handling-state.ts
+++ b/source/callback-handling-state.ts
@@ -1,0 +1,499 @@
+import { getStringIfConstant } from '@eslint-community/eslint-utils';
+import type { Rule } from 'eslint';
+import { extractMemberExpressionPath, isConstantPath } from './ast/member-expression.js';
+import {
+    asRuleNode,
+    getMemberExpressionBindingAndProperty,
+    getTrackedBinding,
+    haveSameTrackedBindings,
+    haveSameTrackedContainerProperties,
+    type TrackedBinding
+} from './done-callback-paths.js';
+import { stripCallExpressions } from './mocha/name-details.js';
+
+const dynamicPropertyName = '<dynamic>';
+const knownSingleCallbackDelegates = new Set(
+    ('setImmediate setTimeout queueMicrotask process.nextTick ' +
+        'global.setImmediate global.setTimeout global.queueMicrotask ' +
+        'globalThis.setImmediate globalThis.setTimeout globalThis.queueMicrotask ' +
+        'window.queueMicrotask')
+        .split(' ')
+);
+
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
+type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type CallbackReferenceState = {
+    aliasBindings: Set<TrackedBinding>;
+    containerPropertiesByBinding: Map<TrackedBinding, Set<string>>;
+};
+export type CallbackPathState = {
+    callbackHandled: boolean;
+    handledReferences: CallbackReferenceState;
+    unhandledReferences: CallbackReferenceState;
+};
+type PropertyLike =
+    | Readonly<Pick<MemberExpressionNode, 'computed' | 'object' | 'property' | 'type'>>
+    | Readonly<Pick<PropertyNode, 'computed' | 'key' | 'type'>>;
+
+export type CallbackHandlingOperation =
+    | {
+        node: Rule.Node;
+        propertyName: string | undefined;
+        source: Readonly<Rule.Node> | null;
+        target: TrackedBinding;
+        type: 'containerPropertyAssignment';
+    }
+    | {
+        node: Rule.Node;
+        source: Readonly<Rule.Node> | null;
+        target: TrackedBinding;
+        type: 'bindingAssignment';
+    }
+    | {
+        node: Rule.Node;
+        type: 'call';
+    };
+
+export type CallbackHandlingContext = {
+    callbackBinding: TrackedBinding;
+    codePath: Readonly<Rule.CodePath>;
+    operationsBySegmentId: ReadonlyMap<string, readonly CallbackHandlingOperation[]>;
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>;
+};
+
+function createEmptyReferenceState(): CallbackReferenceState {
+    return { aliasBindings: new Set(), containerPropertiesByBinding: new Map() };
+}
+
+function createInitialPathState(callbackBinding: TrackedBinding): CallbackPathState {
+    return {
+        callbackHandled: false,
+        handledReferences: createEmptyReferenceState(),
+        unhandledReferences: {
+            aliasBindings: new Set([callbackBinding]),
+            containerPropertiesByBinding: new Map()
+        }
+    };
+}
+
+function cloneReferenceState(state: Readonly<CallbackReferenceState>): CallbackReferenceState {
+    return {
+        aliasBindings: new Set(state.aliasBindings),
+        containerPropertiesByBinding: new Map(
+            Array.from(state.containerPropertiesByBinding, ([binding, properties]) => {
+                return [binding, new Set(properties)] as const;
+            })
+        )
+    };
+}
+
+export function clonePathState(state: Readonly<CallbackPathState>): CallbackPathState {
+    return {
+        callbackHandled: state.callbackHandled,
+        handledReferences: cloneReferenceState(state.handledReferences),
+        unhandledReferences: cloneReferenceState(state.unhandledReferences)
+    };
+}
+
+function areReferenceStatesSame(
+    left: Readonly<CallbackReferenceState> | undefined,
+    right: Readonly<CallbackReferenceState>
+): boolean {
+    return left !== undefined &&
+        haveSameTrackedBindings(left.aliasBindings, right.aliasBindings) &&
+        haveSameTrackedContainerProperties(
+            left.containerPropertiesByBinding,
+            right.containerPropertiesByBinding
+        );
+}
+
+export function arePathStatesSame(
+    left: Readonly<CallbackPathState> | undefined,
+    right: Readonly<CallbackPathState>
+): boolean {
+    return left !== undefined &&
+        left.callbackHandled === right.callbackHandled &&
+        areReferenceStatesSame(left.handledReferences, right.handledReferences) &&
+        areReferenceStatesSame(left.unhandledReferences, right.unhandledReferences);
+}
+
+function getNamedPropertyName(node: PropertyLike): string | undefined {
+    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
+
+    if (keyNode.type === 'Identifier') {
+        return keyNode.name;
+    }
+    if (keyNode.type === 'Literal' && keyNode.value !== null) {
+        return String(keyNode.value);
+    }
+
+    return undefined;
+}
+
+function getStaticPropertyName(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: PropertyLike
+): string | undefined {
+    if (!node.computed) {
+        return getNamedPropertyName(node);
+    }
+
+    const keyNode = node.type === 'MemberExpression' ? node.property : node.key;
+    return getStringIfConstant(keyNode, sourceCode.getScope(asRuleNode(node))) ?? undefined;
+}
+
+function isTrackedPropertyAccess(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: MemberExpressionNode,
+    state: Readonly<CallbackReferenceState>
+): boolean {
+    const bindingAndProperty = getMemberExpressionBindingAndProperty(sourceCode, node);
+
+    if (bindingAndProperty === undefined) {
+        return false;
+    }
+
+    const trackedProperties = state.containerPropertiesByBinding.get(bindingAndProperty.binding);
+
+    if (trackedProperties === undefined) {
+        return false;
+    }
+
+    if (bindingAndProperty.propertyName === undefined) {
+        return trackedProperties.has(dynamicPropertyName);
+    }
+
+    return trackedProperties.has(bindingAndProperty.propertyName);
+}
+
+function isCallbackExpression(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: Readonly<Rule.Node>,
+    state: Readonly<CallbackReferenceState>
+): boolean {
+    if (node.type === 'Identifier') {
+        return state.aliasBindings.has(getTrackedBinding(sourceCode, node));
+    }
+
+    return node.type === 'MemberExpression' && isTrackedPropertyAccess(sourceCode, node, state);
+}
+
+function collectTrackedObjectProperties(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: Readonly<Extract<Rule.Node, { type: 'ObjectExpression'; }>>,
+    state: Readonly<CallbackReferenceState>
+): Set<string> {
+    const trackedProperties = new Set<string>();
+
+    for (const property of node.properties) {
+        const shouldTrackProperty = property.type === 'Property' &&
+            property.kind === 'init' &&
+            isCallbackExpression(sourceCode, asRuleNode(property.value), state);
+
+        if (shouldTrackProperty) {
+            const propertyName = getStaticPropertyName(sourceCode, property);
+
+            if (propertyName !== undefined) {
+                trackedProperties.add(propertyName);
+            }
+        }
+    }
+
+    return trackedProperties;
+}
+
+function getContainerPropertiesFromExpression(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: Readonly<Rule.Node>,
+    state: Readonly<CallbackReferenceState>
+): Set<string> | undefined {
+    if (node.type === 'Identifier') {
+        const trackedProperties = state.containerPropertiesByBinding.get(getTrackedBinding(sourceCode, node));
+
+        return trackedProperties === undefined ? undefined : new Set(trackedProperties);
+    }
+
+    if (node.type !== 'ObjectExpression') {
+        return undefined;
+    }
+
+    const trackedProperties = collectTrackedObjectProperties(sourceCode, node, state);
+    return trackedProperties.size > 0 ? trackedProperties : undefined;
+}
+
+function clearBindingReferenceState(
+    state: Readonly<CallbackReferenceState>,
+    target: TrackedBinding
+): CallbackReferenceState {
+    const nextState = cloneReferenceState(state);
+
+    nextState.aliasBindings.delete(target);
+    nextState.containerPropertiesByBinding.delete(target);
+
+    return nextState;
+}
+
+function addAliasBindingReferenceState(
+    state: Readonly<CallbackReferenceState>,
+    target: TrackedBinding
+): CallbackReferenceState {
+    const nextState = cloneReferenceState(state);
+
+    nextState.aliasBindings.add(target);
+
+    return nextState;
+}
+
+function addContainerPropertyReferenceState(
+    state: Readonly<CallbackReferenceState>,
+    target: TrackedBinding,
+    trackedProperties: ReadonlySet<string>
+): CallbackReferenceState {
+    const nextState = cloneReferenceState(state);
+
+    nextState.containerPropertiesByBinding.set(target, new Set(trackedProperties));
+
+    return nextState;
+}
+
+function assignBindingReferenceState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackReferenceState>,
+    source: Readonly<Rule.Node> | null,
+    target: TrackedBinding
+): CallbackReferenceState {
+    if (source === null) {
+        return cloneReferenceState(state);
+    }
+
+    if (isCallbackExpression(sourceCode, source, state)) {
+        return addAliasBindingReferenceState(state, target);
+    }
+
+    const trackedProperties = getContainerPropertiesFromExpression(sourceCode, source, state);
+
+    return trackedProperties === undefined
+        ? cloneReferenceState(state)
+        : addContainerPropertyReferenceState(state, target, trackedProperties);
+}
+
+function updateBindingReferenceState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackReferenceState>,
+    operation: Readonly<Extract<CallbackHandlingOperation, { type: 'bindingAssignment'; }>>
+): CallbackReferenceState {
+    const clearedState = clearBindingReferenceState(state, operation.target);
+
+    return assignBindingReferenceState(
+        sourceCode,
+        clearedState,
+        operation.source,
+        operation.target
+    );
+}
+
+function updateContainerPropertyReferenceState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackReferenceState>,
+    operation: Readonly<Extract<CallbackHandlingOperation, { type: 'containerPropertyAssignment'; }>>
+): CallbackReferenceState {
+    const nextState = cloneReferenceState(state);
+    const trackedProperty = operation.propertyName ?? dynamicPropertyName;
+    const nextProperties = new Set(nextState.containerPropertiesByBinding.get(operation.target));
+
+    nextProperties.delete(trackedProperty);
+
+    if (operation.source !== null && isCallbackExpression(sourceCode, operation.source, nextState)) {
+        nextProperties.add(trackedProperty);
+    }
+
+    if (nextProperties.size === 0) {
+        nextState.containerPropertiesByBinding.delete(operation.target);
+    } else {
+        nextState.containerPropertiesByBinding.set(operation.target, nextProperties);
+    }
+
+    return nextState;
+}
+
+function getNormalizedCallPath(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: Readonly<Rule.Node>
+): string | undefined {
+    const callPath = extractMemberExpressionPath(sourceCode, node);
+
+    if (!isConstantPath(callPath)) {
+        return undefined;
+    }
+
+    return stripCallExpressions(callPath).join('.');
+}
+
+function isKnownSingleCallbackDelegateCall(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    node: Readonly<Extract<CallbackHandlingOperation, { type: 'call'; }>['node']>,
+    state: Readonly<CallbackReferenceState>
+): boolean {
+    if (node.type !== 'CallExpression') {
+        return false;
+    }
+
+    const normalizedCallPath = getNormalizedCallPath(sourceCode, asRuleNode(node.callee));
+
+    if (normalizedCallPath === undefined || !knownSingleCallbackDelegates.has(normalizedCallPath)) {
+        return false;
+    }
+
+    return node.arguments.some((argument) => {
+        const candidate = argument.type === 'SpreadElement' ? argument.argument : argument;
+        return isCallbackExpression(sourceCode, asRuleNode(candidate), state);
+    });
+}
+
+function isCallbackHandlingCall(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    operation: Readonly<Extract<CallbackHandlingOperation, { type: 'call'; }>>,
+    state: Readonly<CallbackReferenceState>
+): boolean {
+    if (operation.node.type !== 'CallExpression') {
+        return false;
+    }
+
+    return isCallbackExpression(sourceCode, asRuleNode(operation.node.callee), state) ||
+        isKnownSingleCallbackDelegateCall(sourceCode, operation.node, state);
+}
+
+function mergeAliasBindings(states: readonly Readonly<CallbackReferenceState>[]): Set<TrackedBinding> {
+    const aliasBindings = new Set<TrackedBinding>();
+
+    for (const state of states) {
+        for (const binding of state.aliasBindings) {
+            aliasBindings.add(binding);
+        }
+    }
+
+    return aliasBindings;
+}
+
+function mergeContainerProperties(
+    states: readonly Readonly<CallbackReferenceState>[]
+): Map<TrackedBinding, Set<string>> {
+    const containerPropertiesByBinding = new Map<TrackedBinding, Set<string>>();
+
+    for (const state of states) {
+        for (const [binding, properties] of state.containerPropertiesByBinding) {
+            const currentProperties = containerPropertiesByBinding.get(binding) ?? new Set<string>();
+
+            for (const property of properties) {
+                currentProperties.add(property);
+            }
+
+            containerPropertiesByBinding.set(binding, currentProperties);
+        }
+    }
+
+    return containerPropertiesByBinding;
+}
+
+function mergeReferenceStates(
+    states: readonly Readonly<CallbackReferenceState>[]
+): CallbackReferenceState {
+    return {
+        aliasBindings: mergeAliasBindings(states),
+        containerPropertiesByBinding: mergeContainerProperties(states)
+    };
+}
+
+export function updatePathState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackPathState>,
+    operation: Readonly<CallbackHandlingOperation>
+): CallbackPathState {
+    if (operation.type === 'bindingAssignment') {
+        return {
+            callbackHandled: state.callbackHandled,
+            handledReferences: updateBindingReferenceState(sourceCode, state.handledReferences, operation),
+            unhandledReferences: updateBindingReferenceState(sourceCode, state.unhandledReferences, operation)
+        };
+    }
+
+    if (operation.type === 'containerPropertyAssignment') {
+        return {
+            callbackHandled: state.callbackHandled,
+            handledReferences: updateContainerPropertyReferenceState(sourceCode, state.handledReferences, operation),
+            unhandledReferences: updateContainerPropertyReferenceState(sourceCode, state.unhandledReferences, operation)
+        };
+    }
+
+    if (!isCallbackHandlingCall(sourceCode, operation, state.unhandledReferences)) {
+        return clonePathState(state);
+    }
+
+    return {
+        callbackHandled: true,
+        handledReferences: mergeReferenceStates([
+            state.handledReferences,
+            state.unhandledReferences
+        ]),
+        unhandledReferences: cloneReferenceState(state.unhandledReferences)
+    };
+}
+
+function isCallbackHandlingCallInAnyTrackedReferenceState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackPathState>,
+    operation: Readonly<CallbackHandlingOperation>
+): boolean {
+    return operation.type === 'call' && (
+        isCallbackHandlingCall(sourceCode, operation, state.handledReferences) ||
+        isCallbackHandlingCall(sourceCode, operation, state.unhandledReferences)
+    );
+}
+
+export function getCodeAfterCallbackHandlingNode(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    state: Readonly<CallbackPathState>,
+    operation: Readonly<CallbackHandlingOperation>
+): Rule.Node | undefined {
+    return state.callbackHandled && !isCallbackHandlingCallInAnyTrackedReferenceState(sourceCode, state, operation)
+        ? operation.node
+        : undefined;
+}
+
+function mergeIncomingPathStates(
+    callbackBinding: TrackedBinding,
+    previousStates: readonly Readonly<CallbackPathState>[]
+): CallbackPathState {
+    if (previousStates.length === 0) {
+        return createInitialPathState(callbackBinding);
+    }
+
+    return {
+        callbackHandled: previousStates.some((state) => {
+            return state.callbackHandled;
+        }),
+        handledReferences: mergeReferenceStates(previousStates.map((state) => {
+            return state.handledReferences;
+        })),
+        unhandledReferences: mergeReferenceStates(previousStates.map((state) => {
+            return state.unhandledReferences;
+        }))
+    };
+}
+
+export function createEntryState(
+    context: Readonly<CallbackHandlingContext>,
+    segment: Readonly<Rule.CodePathSegment>,
+    exitStatesBySegmentId: ReadonlyMap<string, Readonly<CallbackPathState>>
+): CallbackPathState {
+    if (segment.id === context.codePath.initialSegment.id) {
+        return createInitialPathState(context.callbackBinding);
+    }
+
+    return mergeIncomingPathStates(
+        context.callbackBinding,
+        segment.prevSegments.map((previousSegment) => {
+            return exitStatesBySegmentId.get(previousSegment.id) ?? createInitialPathState(context.callbackBinding);
+        })
+    );
+}

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -9,6 +9,7 @@ import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
 import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
 import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
+import { noCodeAfterDoneRule } from './rules/no-code-after-done.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
 import { noExportsRule } from './rules/no-exports.js';
@@ -41,6 +42,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
+    'mocha/no-code-after-done': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
@@ -71,6 +73,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'off',
     'mocha/no-async-suite': 'error',
+    'mocha/no-code-after-done': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
@@ -101,6 +104,7 @@ const rules = {
     'no-async-and-done': noAsyncAndDoneRule,
     'no-async-in-sync-tests': noAsyncInSyncTestsRule,
     'no-async-suite': noAsyncSuiteRule,
+    'no-code-after-done': noCodeAfterDoneRule,
     'no-exclusive-tests': noExclusiveTestsRule,
     'no-exports': noExportsRule,
     'no-top-level-tests': noTopLevelTestsRule,

--- a/source/rules/no-code-after-done.test.ts
+++ b/source/rules/no-code-after-done.test.ts
@@ -1,6 +1,5 @@
-import { type Rule, RuleTester } from 'eslint';
-import assert from 'node:assert';
-import { checkNodeForCodeAfterDone, noCodeAfterDoneRule } from './no-code-after-done.js';
+import { RuleTester } from 'eslint';
+import { noCodeAfterDoneRule } from './no-code-after-done.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const message = 'Do not execute code after calling the Mocha callback';
@@ -9,9 +8,10 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
     valid: [
         'it("title", function(done) { done(); });',
         'it("title", function(done) { return done(); });',
-        'it("title", function(done) { done(); return; });',
+        'it("title", function(done) { const foo = done; foo(); });',
+        'it("title", function(finish) { finish(); });',
         'it("title", function(done) { handler(function () { done(); return; }); });',
-        'it("title", function(done) { function later(done) { done(); expect(true).to.be.false; } });',
+        'it("title", function(done) { const foo = done; setTimeout(foo, 0); });',
         'it("title", async function() { await work(); });',
         'it("title", function() { work(); });',
         'notMocha("title", function(done) { done(); expect(true).to.be.false; });'
@@ -20,29 +20,23 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
     invalid: [
         {
             code: 'it("title", function(done) { done(); expect(true).to.be.true; });',
-            errors: [{ message, column: 38, line: 1 }]
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { const foo = done; foo(); expect(true).to.be.true; });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { const foo = done; setTimeout(foo, 0); expect(true).to.be.true; });',
+            errors: [{ message }]
         },
         {
             code: 'it("title", function(done) { handler(function () { done(); expect(true).to.be.true; }); });',
-            errors: [{ message, column: 60, line: 1 }]
+            errors: [{ message }]
         },
         {
             code: 'beforeEach(function(done) { done(); setupNextStep(); });',
-            errors: [{ message, column: 37, line: 1 }]
+            errors: [{ message }]
         }
     ]
-});
-
-describe('no-code-after-done helpers', function () {
-    it('checkNodeForCodeAfterDone() ignores non-function nodes', function () {
-        const reports: string[] = [];
-
-        checkNodeForCodeAfterDone({
-            report() {
-                reports.push('reported');
-            }
-        } as unknown as Rule.RuleContext, { type: 'Identifier' } as Rule.Node);
-
-        assert.deepStrictEqual(reports, []);
-    });
 });

--- a/source/rules/no-code-after-done.test.ts
+++ b/source/rules/no-code-after-done.test.ts
@@ -1,0 +1,48 @@
+import { type Rule, RuleTester } from 'eslint';
+import assert from 'node:assert';
+import { checkNodeForCodeAfterDone, noCodeAfterDoneRule } from './no-code-after-done.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const message = 'Do not execute code after calling the Mocha callback';
+
+ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
+    valid: [
+        'it("title", function(done) { done(); });',
+        'it("title", function(done) { return done(); });',
+        'it("title", function(done) { done(); return; });',
+        'it("title", function(done) { handler(function () { done(); return; }); });',
+        'it("title", function(done) { function later(done) { done(); expect(true).to.be.false; } });',
+        'it("title", async function() { await work(); });',
+        'it("title", function() { work(); });',
+        'notMocha("title", function(done) { done(); expect(true).to.be.false; });'
+    ],
+
+    invalid: [
+        {
+            code: 'it("title", function(done) { done(); expect(true).to.be.true; });',
+            errors: [{ message, column: 38, line: 1 }]
+        },
+        {
+            code: 'it("title", function(done) { handler(function () { done(); expect(true).to.be.true; }); });',
+            errors: [{ message, column: 60, line: 1 }]
+        },
+        {
+            code: 'beforeEach(function(done) { done(); setupNextStep(); });',
+            errors: [{ message, column: 37, line: 1 }]
+        }
+    ]
+});
+
+describe('no-code-after-done helpers', function () {
+    it('checkNodeForCodeAfterDone() ignores non-function nodes', function () {
+        const reports: string[] = [];
+
+        checkNodeForCodeAfterDone({
+            report() {
+                reports.push('reported');
+            }
+        } as unknown as Rule.RuleContext, { type: 'Identifier' } as Rule.Node);
+
+        assert.deepStrictEqual(reports, []);
+    });
+});

--- a/source/rules/no-code-after-done.test.ts
+++ b/source/rules/no-code-after-done.test.ts
@@ -1,8 +1,10 @@
+import * as typescriptParser from '@typescript-eslint/parser';
 import { RuleTester } from 'eslint';
 import { noCodeAfterDoneRule } from './no-code-after-done.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const message = 'Do not execute code after calling the Mocha callback';
+const typescriptLanguageOptions = { parser: typescriptParser };
 
 ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
     valid: [
@@ -10,11 +12,18 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
         'it("title", function(done) { return done(); });',
         'it("title", function(done) { const foo = done; foo(); });',
         'it("title", function(finish) { finish(); });',
+        'it("title", function([finish]) { finish(); });',
         'it("title", function(done) { handler(function () { done(); return; }); });',
         'it("title", function(done) { const foo = done; setTimeout(foo, 0); });',
+        'it("title", function(done) { getCallbacks().complete = done; done(); });',
         'it("title", async function() { await work(); });',
         'it("title", function() { work(); });',
-        'notMocha("title", function(done) { done(); expect(true).to.be.false; });'
+        'notMocha("title", function(done) { done(); expect(true).to.be.false; });',
+
+        {
+            code: 'it("title", function(this: Mocha.Context, done) { done(); });',
+            languageOptions: typescriptLanguageOptions
+        }
     ],
 
     invalid: [
@@ -31,12 +40,39 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
             errors: [{ message }]
         },
         {
+            code: 'it("title", function(done) { let finish; finish = done; finish(); expect(true).to.be.true; });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var callbacks = {}; callbacks.complete = done; ' +
+                'callbacks.complete(); expect(true).to.be.true; });',
+            errors: [{ message }]
+        },
+        {
             code: 'it("title", function(done) { handler(function () { done(); expect(true).to.be.true; }); });',
             errors: [{ message }]
         },
         {
             code: 'beforeEach(function(done) { done(); setupNextStep(); });',
             errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { let finish = done; done(); finish++; });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var callbacks = { complete: done }; done(); callbacks.complete++; });',
+            errors: [{ message }]
+        },
+        {
+            code:
+                'it("title", function(done) { var callbacks = { complete: done }; done(); delete callbacks.complete; });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(this: Mocha.Context, done) { done(); expect(true).to.be.true; });',
+            errors: [{ message }],
+            languageOptions: typescriptLanguageOptions
         }
     ]
 });

--- a/source/rules/no-code-after-done.ts
+++ b/source/rules/no-code-after-done.ts
@@ -1,0 +1,221 @@
+import { findVariable } from '@eslint-community/eslint-utils';
+import type { Rule, Scope, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import {
+    type AnyFunction,
+    type BlockStatement,
+    isBlockStatement,
+    isFunction,
+    isIdentifier
+} from '../ast/node-types.js';
+import { asRuleNode } from '../done-callback-paths.js';
+
+type TraversableNode = Except<Rule.Node, 'parent'>;
+type Statement = BlockStatement['body'][number];
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
+    return param !== undefined && isIdentifier(param) && param.name === 'this';
+}
+
+function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = node.params;
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
+}
+
+function getDoneCallbackVariable(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<AnyFunction>
+): Readonly<Scope.Variable | null | undefined> {
+    const callbackParameter = getFirstMeaningfulParameter(node);
+
+    if (callbackParameter?.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return findVariable(sourceCode.getScope(asRuleNode(callbackParameter)), callbackParameter.name);
+}
+
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function visitChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (isNode(item)) {
+                    visitor(item);
+                }
+            });
+        } else if (isNode(value)) {
+            visitor(value);
+        }
+    }
+}
+
+function visitWithoutNestedFunctions(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    visitor(node);
+
+    if (isFunction(node)) {
+        return;
+    }
+
+    visitChildNodes(sourceCode, node, (childNode) => {
+        visitWithoutNestedFunctions(sourceCode, childNode, visitor);
+    });
+}
+
+function isDoneCallbackCall(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): boolean {
+    return node.type === 'CallExpression' &&
+        node.callee.type === 'Identifier' &&
+        findVariable(sourceCode.getScope(asRuleNode(node.callee)), node.callee.name) === doneCallbackVariable;
+}
+
+function statementContainsDoneCallbackCall(
+    sourceCode: Readonly<SourceCode>,
+    statement: Readonly<Statement>,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): boolean {
+    let containsDoneCallbackCall = false;
+
+    visitWithoutNestedFunctions(sourceCode, statement, (childNode) => {
+        if (isDoneCallbackCall(sourceCode, childNode, doneCallbackVariable)) {
+            containsDoneCallbackCall = true;
+        }
+    });
+
+    return containsDoneCallbackCall;
+}
+
+function isFlowExitStatement(statement: Readonly<Statement>): boolean {
+    return statement.type === 'ReturnStatement' ||
+        statement.type === 'ThrowStatement' ||
+        statement.type === 'BreakStatement' ||
+        statement.type === 'ContinueStatement';
+}
+
+function isExecutableStatement(statement: Readonly<Statement>): boolean {
+    return statement.type !== 'FunctionDeclaration';
+}
+
+function shouldReportFollowingStatement(statement: Readonly<Statement>): boolean {
+    return !isFlowExitStatement(statement) && isExecutableStatement(statement);
+}
+
+function reportFollowingStatementIfNeeded(
+    context: Readonly<Rule.RuleContext>,
+    statement: Readonly<Statement>,
+    shouldReportNextExecutableStatement: boolean
+): void {
+    if (!shouldReportNextExecutableStatement) {
+        return;
+    }
+
+    if (shouldReportFollowingStatement(statement)) {
+        context.report({
+            node: statement,
+            messageId: 'unexpectedCodeAfterDone'
+        });
+    }
+}
+
+function shouldStartTrackingFollowingStatement(
+    sourceCode: Readonly<SourceCode>,
+    statement: Readonly<Statement>,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): boolean {
+    return statementContainsDoneCallbackCall(
+        sourceCode,
+        statement,
+        doneCallbackVariable
+    ) && !isFlowExitStatement(statement);
+}
+
+function inspectBlockStatements(
+    context: Readonly<Rule.RuleContext>,
+    blockStatement: Readonly<BlockStatement>,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): void {
+    let shouldReportNextExecutableStatement = false;
+
+    for (const statement of blockStatement.body) {
+        reportFollowingStatementIfNeeded(context, statement, shouldReportNextExecutableStatement);
+        if (shouldReportNextExecutableStatement) {
+            shouldReportNextExecutableStatement = false;
+        }
+        shouldReportNextExecutableStatement = shouldStartTrackingFollowingStatement(
+            context.sourceCode,
+            statement,
+            doneCallbackVariable
+        ) || shouldReportNextExecutableStatement;
+    }
+}
+
+function inspectNodeRecursively(
+    context: Readonly<Rule.RuleContext>,
+    node: TraversableNode,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): void {
+    if (isBlockStatement(node)) {
+        inspectBlockStatements(context, node, doneCallbackVariable);
+    }
+
+    visitChildNodes(context.sourceCode, node, (childNode) => {
+        inspectNodeRecursively(context, childNode, doneCallbackVariable);
+    });
+}
+
+export function checkNodeForCodeAfterDone(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
+    if (!isFunction(node)) {
+        return;
+    }
+
+    const doneCallbackVariable = getDoneCallbackVariable(context.sourceCode, node);
+
+    if (doneCallbackVariable === undefined || doneCallbackVariable === null) {
+        return;
+    }
+
+    inspectNodeRecursively(context, node.body, doneCallbackVariable);
+}
+
+export const noCodeAfterDoneRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'problem',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow executing code after calling a Mocha callback',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-code-after-done.md'
+        },
+        messages: {
+            unexpectedCodeAfterDone: 'Do not execute code after calling the Mocha callback'
+        },
+        schema: []
+    },
+    create(context) {
+        return createMochaVisitors(context, {
+            anyTestEntityCallback(visitorContext) {
+                checkNodeForCodeAfterDone(context, visitorContext.node);
+            }
+        });
+    }
+};

--- a/source/rules/no-code-after-done.ts
+++ b/source/rules/no-code-after-done.ts
@@ -1,201 +1,141 @@
-import { findVariable } from '@eslint-community/eslint-utils';
-import type { Rule, Scope, SourceCode } from 'eslint';
-import type { Except } from 'type-fest';
+import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type AnyFunction, isFunction, isIdentifier } from '../ast/node-types.js';
+import { collectCodeAfterCallbackHandlingNodes } from '../callback-handling-paths.js';
+import type { CallbackHandlingOperation } from '../callback-handling-state.js';
 import {
-    type AnyFunction,
-    type BlockStatement,
-    isBlockStatement,
-    isFunction,
-    isIdentifier
-} from '../ast/node-types.js';
-import { asRuleNode } from '../done-callback-paths.js';
+    asRuleNode,
+    asRuleNodeOrNull,
+    getMemberExpressionBindingAndProperty,
+    getTrackedBinding,
+    type TrackedBinding
+} from '../done-callback-paths.js';
 
-type TraversableNode = Except<Rule.Node, 'parent'>;
-type Statement = BlockStatement['body'][number];
+type TrackedFunctionState = {
+    callbackBinding: TrackedBinding;
+    codePath: Readonly<Rule.CodePath>;
+    currentSegments: Set<Rule.CodePathSegment>;
+    operationsBySegmentId: Map<string, CallbackHandlingOperation[]>;
+};
 
-function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
-    return param !== undefined && isIdentifier(param) && param.name === 'this';
+type FunctionState = {
+    tracked: TrackedFunctionState | undefined;
+    upper: FunctionState | null;
+};
+type TrackedFunctionStateContext = {
+    codePath: Readonly<Rule.CodePath>;
+    inheritedCallbackBinding: TrackedBinding | undefined;
+    node: Readonly<Rule.Node>;
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>;
+    trackedCallbackNodes: Readonly<WeakSet<Rule.Node>>;
+};
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number]): boolean {
+    return isIdentifier(param) && param.name === 'this';
 }
 
-function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
-    const [firstParam, secondParam] = node.params;
-    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
-}
+function getDoneCallback(
+    functionExpression: Readonly<AnyFunction>
+): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = functionExpression.params;
 
-function getDoneCallbackVariable(
-    sourceCode: Readonly<SourceCode>,
-    node: Readonly<AnyFunction>
-): Readonly<Scope.Variable | null | undefined> {
-    const callbackParameter = getFirstMeaningfulParameter(node);
-
-    if (callbackParameter?.type !== 'Identifier') {
+    if (firstParam === undefined) {
         return undefined;
     }
 
-    return findVariable(sourceCode.getScope(asRuleNode(callbackParameter)), callbackParameter.name);
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
 }
 
-function getNodeProperty(node: TraversableNode, key: string): unknown {
-    return Reflect.get(node, key);
-}
-
-function isNode(value: unknown): value is TraversableNode {
-    return typeof value === 'object' && value !== null && 'type' in value;
-}
-
-function visitChildNodes(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    visitor: (childNode: TraversableNode) => void
+function pushOperation(
+    operationsBySegmentId: Map<string, CallbackHandlingOperation[]>,
+    segmentId: string,
+    operation: Readonly<CallbackHandlingOperation>
 ): void {
-    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
-        const value = getNodeProperty(node, key);
+    const operations = operationsBySegmentId.get(segmentId);
 
-        if (Array.isArray(value)) {
-            value.forEach((item) => {
-                if (isNode(item)) {
-                    visitor(item);
-                }
-            });
-        } else if (isNode(value)) {
-            visitor(value);
-        }
-    }
-}
-
-function visitWithoutNestedFunctions(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    visitor: (childNode: TraversableNode) => void
-): void {
-    visitor(node);
-
-    if (isFunction(node)) {
+    if (operations === undefined) {
+        operationsBySegmentId.set(segmentId, [operation]);
         return;
     }
 
-    visitChildNodes(sourceCode, node, (childNode) => {
-        visitWithoutNestedFunctions(sourceCode, childNode, visitor);
-    });
+    operations.push(operation);
 }
 
-function isDoneCallbackCall(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): boolean {
-    return node.type === 'CallExpression' &&
-        node.callee.type === 'Identifier' &&
-        findVariable(sourceCode.getScope(asRuleNode(node.callee)), node.callee.name) === doneCallbackVariable;
+function createTrackedState(
+    callbackBinding: TrackedBinding,
+    codePath: Readonly<Rule.CodePath>
+): TrackedFunctionState {
+    return {
+        callbackBinding,
+        codePath,
+        currentSegments: new Set(),
+        operationsBySegmentId: new Map()
+    };
 }
 
-function statementContainsDoneCallbackCall(
-    sourceCode: Readonly<SourceCode>,
-    statement: Readonly<Statement>,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): boolean {
-    let containsDoneCallbackCall = false;
+function getTrackedMochaCallbackBinding(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    trackedCallbackNodes: Readonly<WeakSet<Rule.Node>>,
+    node: Readonly<Rule.Node>
+): TrackedBinding | undefined {
+    if (!trackedCallbackNodes.has(node) || !isFunction(node)) {
+        return undefined;
+    }
 
-    visitWithoutNestedFunctions(sourceCode, statement, (childNode) => {
-        if (isDoneCallbackCall(sourceCode, childNode, doneCallbackVariable)) {
-            containsDoneCallbackCall = true;
-        }
-    });
+    const callback = getDoneCallback(node);
 
-    return containsDoneCallbackCall;
+    if (callback === undefined || callback.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return getTrackedBinding(sourceCode, callback);
 }
 
-function isFlowExitStatement(statement: Readonly<Statement>): boolean {
-    return statement.type === 'ReturnStatement' ||
-        statement.type === 'ThrowStatement' ||
-        statement.type === 'BreakStatement' ||
-        statement.type === 'ContinueStatement';
+function createTrackedFunctionState(
+    trackedFunctionStateContext: Readonly<TrackedFunctionStateContext>
+): TrackedFunctionState | undefined {
+    const {
+        sourceCode,
+        trackedCallbackNodes,
+        inheritedCallbackBinding,
+        codePath,
+        node
+    } = trackedFunctionStateContext;
+
+    if (!isFunction(node)) {
+        return undefined;
+    }
+
+    const trackedMochaCallbackBinding = getTrackedMochaCallbackBinding(sourceCode, trackedCallbackNodes, node);
+
+    if (trackedMochaCallbackBinding !== undefined) {
+        return createTrackedState(trackedMochaCallbackBinding, codePath);
+    }
+
+    if (inheritedCallbackBinding === undefined) {
+        return undefined;
+    }
+
+    return createTrackedState(inheritedCallbackBinding, codePath);
 }
 
-function isExecutableStatement(statement: Readonly<Statement>): boolean {
-    return statement.type !== 'FunctionDeclaration';
-}
-
-function shouldReportFollowingStatement(statement: Readonly<Statement>): boolean {
-    return !isFlowExitStatement(statement) && isExecutableStatement(statement);
-}
-
-function reportFollowingStatementIfNeeded(
+function reportCodeAfterDone(
     context: Readonly<Rule.RuleContext>,
-    statement: Readonly<Statement>,
-    shouldReportNextExecutableStatement: boolean
+    trackedFunction: Readonly<TrackedFunctionState>
 ): void {
-    if (!shouldReportNextExecutableStatement) {
-        return;
-    }
+    const reportedNodes = collectCodeAfterCallbackHandlingNodes({
+        callbackBinding: trackedFunction.callbackBinding,
+        codePath: trackedFunction.codePath,
+        operationsBySegmentId: trackedFunction.operationsBySegmentId,
+        sourceCode: context.sourceCode
+    });
 
-    if (shouldReportFollowingStatement(statement)) {
+    for (const node of reportedNodes) {
         context.report({
-            node: statement,
+            node,
             messageId: 'unexpectedCodeAfterDone'
         });
     }
-}
-
-function shouldStartTrackingFollowingStatement(
-    sourceCode: Readonly<SourceCode>,
-    statement: Readonly<Statement>,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): boolean {
-    return statementContainsDoneCallbackCall(
-        sourceCode,
-        statement,
-        doneCallbackVariable
-    ) && !isFlowExitStatement(statement);
-}
-
-function inspectBlockStatements(
-    context: Readonly<Rule.RuleContext>,
-    blockStatement: Readonly<BlockStatement>,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): void {
-    let shouldReportNextExecutableStatement = false;
-
-    for (const statement of blockStatement.body) {
-        reportFollowingStatementIfNeeded(context, statement, shouldReportNextExecutableStatement);
-        if (shouldReportNextExecutableStatement) {
-            shouldReportNextExecutableStatement = false;
-        }
-        shouldReportNextExecutableStatement = shouldStartTrackingFollowingStatement(
-            context.sourceCode,
-            statement,
-            doneCallbackVariable
-        ) || shouldReportNextExecutableStatement;
-    }
-}
-
-function inspectNodeRecursively(
-    context: Readonly<Rule.RuleContext>,
-    node: TraversableNode,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): void {
-    if (isBlockStatement(node)) {
-        inspectBlockStatements(context, node, doneCallbackVariable);
-    }
-
-    visitChildNodes(context.sourceCode, node, (childNode) => {
-        inspectNodeRecursively(context, childNode, doneCallbackVariable);
-    });
-}
-
-export function checkNodeForCodeAfterDone(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
-    if (!isFunction(node)) {
-        return;
-    }
-
-    const doneCallbackVariable = getDoneCallbackVariable(context.sourceCode, node);
-
-    if (doneCallbackVariable === undefined || doneCallbackVariable === null) {
-        return;
-    }
-
-    inspectNodeRecursively(context, node.body, doneCallbackVariable);
 }
 
 export const noCodeAfterDoneRule: Readonly<Rule.RuleModule> = {
@@ -212,9 +152,146 @@ export const noCodeAfterDoneRule: Readonly<Rule.RuleModule> = {
         schema: []
     },
     create(context) {
+        const trackedCallbackNodes = new WeakSet<Rule.Node>();
+        let currentFunction: FunctionState | null = null;
+
+        function recordOperation(operation: Readonly<CallbackHandlingOperation>): void {
+            const trackedFunction = currentFunction?.tracked;
+
+            if (trackedFunction === undefined) {
+                return;
+            }
+
+            for (const segment of trackedFunction.currentSegments) {
+                pushOperation(trackedFunction.operationsBySegmentId, segment.id, operation);
+            }
+        }
+
+        function trackMochaCallback(node: Readonly<Rule.Node>): void {
+            trackedCallbackNodes.add(node);
+        }
+
         return createMochaVisitors(context, {
-            anyTestEntityCallback(visitorContext) {
-                checkNodeForCodeAfterDone(context, visitorContext.node);
+            testCaseCallback(visitorContext) {
+                trackMochaCallback(visitorContext.node);
+            },
+
+            hookCallback(visitorContext) {
+                trackMochaCallback(visitorContext.node);
+            },
+
+            onCodePathStart(codePath, node) {
+                currentFunction = {
+                    tracked: createTrackedFunctionState({
+                        sourceCode: context.sourceCode,
+                        trackedCallbackNodes,
+                        inheritedCallbackBinding: currentFunction?.tracked?.callbackBinding,
+                        codePath,
+                        node
+                    }),
+                    upper: currentFunction
+                };
+            },
+
+            onCodePathEnd() {
+                const trackedFunction = currentFunction?.tracked;
+
+                if (trackedFunction !== undefined) {
+                    reportCodeAfterDone(context, trackedFunction);
+                }
+
+                currentFunction = currentFunction?.upper ?? null;
+            },
+
+            onCodePathSegmentStart(segment) {
+                currentFunction?.tracked?.currentSegments.add(segment);
+            },
+
+            onCodePathSegmentEnd(segment) {
+                currentFunction?.tracked?.currentSegments.delete(segment);
+            },
+
+            'CallExpression:exit'(node) {
+                recordOperation({ node, type: 'call' });
+            },
+
+            'VariableDeclarator:exit'(node) {
+                if (node.id.type === 'Identifier') {
+                    recordOperation({
+                        node,
+                        source: asRuleNodeOrNull(node.init),
+                        target: getTrackedBinding(context.sourceCode, node.id),
+                        type: 'bindingAssignment'
+                    });
+                }
+            },
+
+            'AssignmentExpression:exit'(node) {
+                if (node.left.type === 'Identifier') {
+                    recordOperation({
+                        node,
+                        source: asRuleNode(node.right),
+                        target: getTrackedBinding(context.sourceCode, node.left),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.left.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.left);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            node,
+                            propertyName: bindingAndProperty.propertyName,
+                            source: asRuleNode(node.right),
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
+            },
+
+            'UpdateExpression:exit'(node) {
+                if (node.argument.type === 'Identifier') {
+                    recordOperation({
+                        node,
+                        source: null,
+                        target: getTrackedBinding(context.sourceCode, node.argument),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.argument.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            node,
+                            propertyName: bindingAndProperty.propertyName,
+                            source: null,
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
+            },
+
+            'UnaryExpression:exit'(node) {
+                if (node.operator === 'delete' && node.argument.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            node,
+                            propertyName: bindingAndProperty.propertyName,
+                            source: null,
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
Add a new mocha/no-code-after-done rule to report executable statements that run after a callback-style test or hook calls done().
Cover nested callback bodies and enable the rule in the recommended config.