### PR TITLE
Extend no-async-in-sync-tests for scheduling APIs

### DIFF
--- a/documentation/rules/no-async-in-sync-tests.md
+++ b/documentation/rules/no-async-in-sync-tests.md
@@ -8,12 +8,29 @@ Mocha only waits for asynchronous work when a test or hook uses one of Mocha's a
 
 This rule catches suspicious async work inside callbacks that Mocha still treats as synchronous.
 
+## Options
+
+This rule supports the following options:
+
+- `allowedAsyncMethods`: Allows specific scheduling APIs that would otherwise be reported, such as `setTimeout` or `process.nextTick`. Defaults to `[]`.
+
+```json
+{
+    "rules": {
+        "mocha/no-async-in-sync-tests": ["error", {
+            "allowedAsyncMethods": ["setTimeout"]
+        }]
+    }
+}
+```
+
 ## Rule Details
 
 The rule checks synchronous Mocha tests and hooks for two patterns:
 
 - Promise-based work that is started without being returned.
 - Callback-based work where an inline callback starts with an `err` or `error` parameter.
+- Scheduled async work started via APIs such as `setTimeout`, `queueMicrotask`, or `process.nextTick`.
 
 When TypeScript parser services with type information are available, promise detection uses the exact `PromiseLike` return type of the expression. Without type information, the rule falls back to `.then()`, `.catch()`, and `.finally()` call chains.
 
@@ -36,6 +53,12 @@ it('loads data', function () {
 before(function () {
     initialize().finally(cleanup);
 });
+
+it('schedules work', function () {
+    process.nextTick(function () {
+        expect(true).to.equal(true);
+    });
+});
 ```
 
 These patterns would not be considered warnings:
@@ -57,6 +80,10 @@ it('loads data', function () {
     return loadData().then(function (result) {
         expect(result).to.deep.equal({ ok: true });
     });
+});
+
+it('schedules work explicitly', function (done) {
+    setTimeout(done, 0);
 });
 ```
 

--- a/source/rules/no-async-in-sync-tests.test.ts
+++ b/source/rules/no-async-in-sync-tests.test.ts
@@ -15,6 +15,7 @@ const slowTypedTestTimeout = 30_000;
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const { pathname: projectRoot } = new URL('../../', import.meta.url);
 const { pathname: typescriptFilename } = new URL('./no-async-in-sync-tests.fixture.ts', import.meta.url);
+const allowSetTimeoutOption = { allowedAsyncMethods: ['setTimeout'] };
 const typescriptLanguageOptions = {
     parser: typescriptParser,
     parserOptions: {
@@ -65,8 +66,13 @@ ruleTester.run('no-async-in-sync-tests', noAsyncInSyncTestsRule, {
         'it("", () => load().then(function () {}));',
         'it("", function () { promise[method](cleanup); });',
         'it("", function () { return 42; });',
+        'it("", function (done) { setTimeout(done, 0); });',
         'before(function () { return task().finally(cleanup); });',
         'describe("", function () { load().then(function () {}); });',
+        {
+            code: 'it("", function () { setTimeout(work, 0); });',
+            options: [allowSetTimeoutOption]
+        },
         {
             code: 'it("", function () { queryBuilder().catch(function (reason) {}); });\n' +
                 'declare function queryBuilder(): { catch(callback: (reason: unknown) => number): number; };',
@@ -106,6 +112,18 @@ ruleTester.run('no-async-in-sync-tests', noAsyncInSyncTestsRule, {
         {
             code: 'it("", function () { promise["then"](cleanup); });',
             errors: [{ messageId: 'unexpectedPromiseAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { setTimeout(work, 0); });',
+            errors: [{ messageId: 'unexpectedScheduledAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { process.nextTick(work); });',
+            errors: [{ messageId: 'unexpectedScheduledAsyncOperation' }]
+        },
+        {
+            code: 'it("", function () { globalThis.queueMicrotask(work); });',
+            errors: [{ messageId: 'unexpectedScheduledAsyncOperation' }]
         },
         {
             code: 'it("", function () { promise?.then(cleanup); });',

--- a/source/rules/no-async-in-sync-tests.ts
+++ b/source/rules/no-async-in-sync-tests.ts
@@ -1,14 +1,20 @@
 import type { Rule, SourceCode } from 'eslint';
 import type { Except } from 'type-fest';
+import { extractMemberExpressionPath, isConstantPath } from '../ast/member-expression.js';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 import { type AnyFunction, isFunction, isIdentifier } from '../ast/node-types.js';
 import { asRuleNode } from '../done-callback-paths.js';
+import { stripCallExpressions } from '../mocha/name-details.js';
 import { isRecord } from '../record.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 type TraversableNode = Except<Rule.Node, 'parent'>;
 type CallExpression = Extract<TraversableNode, { type: 'CallExpression'; }>;
 type UnexpectedAsyncOperation = {
-    messageId: 'unexpectedCallbackAsyncOperation' | 'unexpectedPromiseAsyncOperation';
+    messageId:
+        | 'unexpectedCallbackAsyncOperation'
+        | 'unexpectedPromiseAsyncOperation'
+        | 'unexpectedScheduledAsyncOperation';
     node: TraversableNode;
 };
 
@@ -27,6 +33,39 @@ type ParserServicesWithTypeInformation = {
 
 const errorCallbackNames = new Set(['err', 'error']);
 const promiseMethodNames = new Set(['then', 'catch', 'finally']);
+const knownScheduledAsyncMethods = new Set([
+    'setImmediate',
+    'setInterval',
+    'setTimeout',
+    'queueMicrotask',
+    'process.nextTick',
+    'global.setImmediate',
+    'global.setInterval',
+    'global.setTimeout',
+    'global.queueMicrotask',
+    'globalThis.setImmediate',
+    'globalThis.setInterval',
+    'globalThis.setTimeout',
+    'globalThis.queueMicrotask',
+    'window.setInterval',
+    'window.setTimeout',
+    'window.queueMicrotask'
+]);
+const optionSchema = {
+    type: 'object',
+    properties: {
+        allowedAsyncMethods: {
+            type: 'array',
+            items: {
+                type: 'string'
+            }
+        }
+    },
+    additionalProperties: false
+} as const satisfies RuleSchema;
+type Option = InferSchemaOption<typeof optionSchema>;
+type ResolvedOption = Option & { allowedAsyncMethods: string[]; };
+const defaultOption: ResolvedOption = { allowedAsyncMethods: [] };
 
 function isNode(value: unknown): value is TraversableNode {
     return typeof value === 'object' && value !== null && 'type' in value;
@@ -257,6 +296,36 @@ function findCallbackBasedAsyncCall(
     return collectCallExpressions(sourceCode, expression).find(hasInlineErrorFirstCallback);
 }
 
+function normalizeCalledMethodPath(nodePath: readonly string[]): string {
+    return stripCallExpressions(nodePath).join('.');
+}
+
+function isScheduledAsyncCall(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<CallExpression>,
+    allowedAsyncMethods: ReadonlySet<string>
+): boolean {
+    const path = extractMemberExpressionPath(sourceCode, asRuleNode(node.callee));
+
+    if (!isConstantPath(path)) {
+        return false;
+    }
+
+    const calledMethod = normalizeCalledMethodPath(path);
+
+    return knownScheduledAsyncMethods.has(calledMethod) && !allowedAsyncMethods.has(calledMethod);
+}
+
+function findScheduledAsyncCall(
+    sourceCode: Readonly<SourceCode>,
+    expression: Readonly<TraversableNode>,
+    allowedAsyncMethods: ReadonlySet<string>
+): Readonly<CallExpression | undefined> {
+    return collectCallExpressions(sourceCode, expression).find((callExpression) => {
+        return isScheduledAsyncCall(sourceCode, callExpression, allowedAsyncMethods);
+    });
+}
+
 function returnsPromiseToMocha(
     sourceCode: Readonly<SourceCode>,
     parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
@@ -279,37 +348,74 @@ function isSynchronousMochaCallback(
         !returnsPromiseToMocha(sourceCode, parserServices, node);
 }
 
-function findUnexpectedAsyncOperation(
+function createUnexpectedAsyncOperation(
+    node: Readonly<TraversableNode>,
+    messageId: UnexpectedAsyncOperation['messageId']
+): Readonly<UnexpectedAsyncOperation> {
+    return { node, messageId };
+}
+
+function findUnexpectedPromiseAsyncOperation(
     sourceCode: Readonly<SourceCode>,
     parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
     expression: Readonly<TraversableNode>
-): Readonly<UnexpectedAsyncOperation> | undefined {
+): Readonly<UnexpectedAsyncOperation | undefined> {
     if (parserServices !== undefined && hasPromiseLikeType(parserServices, expression)) {
-        return {
-            node: expression,
-            messageId: 'unexpectedPromiseAsyncOperation'
-        };
+        return createUnexpectedAsyncOperation(expression, 'unexpectedPromiseAsyncOperation');
     }
 
     const promiseMethodCall = parserServices === undefined
         ? findPromiseMethodCall(sourceCode, expression)
         : undefined;
 
-    if (promiseMethodCall !== undefined) {
-        return {
-            node: promiseMethodCall,
-            messageId: 'unexpectedPromiseAsyncOperation'
-        };
+    return promiseMethodCall === undefined
+        ? undefined
+        : createUnexpectedAsyncOperation(promiseMethodCall, 'unexpectedPromiseAsyncOperation');
+}
+
+function findUnexpectedScheduledAsyncOperation(
+    sourceCode: Readonly<SourceCode>,
+    expression: Readonly<TraversableNode>,
+    allowedAsyncMethods: ReadonlySet<string>
+): Readonly<UnexpectedAsyncOperation | undefined> {
+    const scheduledAsyncCall = findScheduledAsyncCall(sourceCode, expression, allowedAsyncMethods);
+
+    return scheduledAsyncCall === undefined
+        ? undefined
+        : createUnexpectedAsyncOperation(scheduledAsyncCall, 'unexpectedScheduledAsyncOperation');
+}
+
+function findUnexpectedAsyncOperation(
+    sourceCode: Readonly<SourceCode>,
+    parserServices: Readonly<ParserServicesWithTypeInformation> | undefined,
+    expression: Readonly<TraversableNode>,
+    allowedAsyncMethods: ReadonlySet<string>
+): Readonly<UnexpectedAsyncOperation> | undefined {
+    const unexpectedPromiseAsyncOperation = findUnexpectedPromiseAsyncOperation(
+        sourceCode,
+        parserServices,
+        expression
+    );
+
+    if (unexpectedPromiseAsyncOperation !== undefined) {
+        return unexpectedPromiseAsyncOperation;
+    }
+
+    const unexpectedScheduledAsyncOperation = findUnexpectedScheduledAsyncOperation(
+        sourceCode,
+        expression,
+        allowedAsyncMethods
+    );
+
+    if (unexpectedScheduledAsyncOperation !== undefined) {
+        return unexpectedScheduledAsyncOperation;
     }
 
     const callbackBasedAsyncCall = findCallbackBasedAsyncCall(sourceCode, expression);
 
     return callbackBasedAsyncCall === undefined
         ? undefined
-        : {
-            node: callbackBasedAsyncCall,
-            messageId: 'unexpectedCallbackAsyncOperation'
-        };
+        : createUnexpectedAsyncOperation(callbackBasedAsyncCall, 'unexpectedCallbackAsyncOperation');
 }
 
 function reportUnexpectedAsyncOperation(
@@ -330,15 +436,19 @@ export const noAsyncInSyncTestsRule: Readonly<Rule.RuleModule> = {
             description: 'Disallow async operations in synchronous tests or hooks',
             url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-in-sync-tests.md'
         },
+        defaultOptions: [defaultOption],
         messages: {
             unexpectedCallbackAsyncOperation:
                 'Unexpected callback-based async operation in a synchronous test or hook.',
-            unexpectedPromiseAsyncOperation: 'Unexpected promise-based async operation in a synchronous test or hook.'
+            unexpectedPromiseAsyncOperation: 'Unexpected promise-based async operation in a synchronous test or hook.',
+            unexpectedScheduledAsyncOperation: 'Unexpected scheduled async operation in a synchronous test or hook.'
         },
-        schema: []
+        schema: [optionSchema]
     },
     create(context) {
         const { sourceCode } = context;
+        const { allowedAsyncMethods } = getRuleOption<ResolvedOption>(context);
+        const allowedAsyncMethodSet = new Set(allowedAsyncMethods);
         const parserServices = getParserServicesWithTypeInformation(sourceCode);
 
         function reportUnexpectedAsyncOperations(node: Readonly<Rule.Node>): void {
@@ -347,7 +457,12 @@ export const noAsyncInSyncTestsRule: Readonly<Rule.RuleModule> = {
             }
 
             for (const expression of collectCandidateExpressions(sourceCode, node.body)) {
-                const unexpectedAsyncOperation = findUnexpectedAsyncOperation(sourceCode, parserServices, expression);
+                const unexpectedAsyncOperation = findUnexpectedAsyncOperation(
+                    sourceCode,
+                    parserServices,
+                    expression,
+                    allowedAsyncMethodSet
+                );
 
                 if (unexpectedAsyncOperation !== undefined) {
                     reportUnexpectedAsyncOperation(context, unexpectedAsyncOperation);


### PR DESCRIPTION
Expand mocha/no-async-in-sync-tests to flag scheduling APIs such as setTimeout, queueMicrotask, and process.nextTick in synchronous Mocha callbacks.
Add an allowedAsyncMethods option for projects that intentionally allow selected APIs.