### PR TITLE
Add rule no-done-twice to reject multiple done() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-code-after-done](documentation/rules/no-code-after-done.md)                               | Disallow executing code after calling a Mocha callback                  | ✅  |    |    |    |    |
+| [no-done-twice](documentation/rules/no-done-twice.md)                                         | Disallow calling a Mocha callback more than once                        | ✅  |    |    |    |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty suite and test descriptions                              | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
 | [no-exports](documentation/rules/no-exports.md)                                               | Disallow exports from test files                                        | ✅  |    |    |    | 💡 |

--- a/documentation/rules/no-done-twice.md
+++ b/documentation/rules/no-done-twice.md
@@ -1,0 +1,40 @@
+# Disallow calling a Mocha callback more than once (`mocha/no-done-twice`)
+
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Calling `done()` more than once is a common callback-style test bug. It can produce confusing pass/fail output and can hide the real source of the failure.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+it("calls done twice", function (done) {
+    done();
+    done();
+});
+
+it("calls done on two paths", function (done) {
+    if (failed) {
+        done(error);
+    }
+
+    done();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it("completes once", function (done) {
+    work(function (error) {
+        done(error);
+    });
+});
+
+it("returns after completion", function (done) {
+    return done();
+});
+```

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -10,6 +10,7 @@ import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
 import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noCodeAfterDoneRule } from './rules/no-code-after-done.js';
+import { noDoneTwiceRule } from './rules/no-done-twice.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
 import { noExportsRule } from './rules/no-exports.js';
@@ -43,6 +44,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
     'mocha/no-code-after-done': 'error',
+    'mocha/no-done-twice': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
@@ -74,6 +76,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-async-in-sync-tests': 'off',
     'mocha/no-async-suite': 'error',
     'mocha/no-code-after-done': 'error',
+    'mocha/no-done-twice': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
     'mocha/no-top-level-tests': 'error',
@@ -105,6 +108,7 @@ const rules = {
     'no-async-in-sync-tests': noAsyncInSyncTestsRule,
     'no-async-suite': noAsyncSuiteRule,
     'no-code-after-done': noCodeAfterDoneRule,
+    'no-done-twice': noDoneTwiceRule,
     'no-exclusive-tests': noExclusiveTestsRule,
     'no-exports': noExportsRule,
     'no-top-level-tests': noTopLevelTestsRule,

--- a/source/repeated-callback-handling-paths.test.ts
+++ b/source/repeated-callback-handling-paths.test.ts
@@ -1,7 +1,7 @@
 import type { Rule, Scope, SourceCode } from 'eslint';
 import assert from 'node:assert';
-import { collectRepeatedCallbackHandlingNodes } from './repeated-callback-handling-paths.js';
 import type { CallbackHandlingOperation } from './callback-handling-state.js';
+import { collectRepeatedCallbackHandlingNodes } from './repeated-callback-handling-paths.js';
 
 type MutableSegment = {
     id: string;

--- a/source/repeated-callback-handling-paths.test.ts
+++ b/source/repeated-callback-handling-paths.test.ts
@@ -1,0 +1,441 @@
+import type { Rule, Scope, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import { collectRepeatedCallbackHandlingNodes } from './repeated-callback-handling-paths.js';
+import type { CallbackHandlingOperation } from './callback-handling-state.js';
+
+type MutableSegment = {
+    id: string;
+    nextSegments: MutableSegment[];
+    prevSegments: MutableSegment[];
+};
+
+type CallExpressionNode = Extract<CallbackHandlingOperation, { type: 'call'; }>['node'];
+type MemberExpressionNode = Parameters<Exclude<Rule.RuleListener['MemberExpression'], undefined>>[0];
+type PropertyNode = Parameters<Exclude<Rule.RuleListener['Property'], undefined>>[0];
+type ObjectExpressionNode = Parameters<Exclude<Rule.RuleListener['ObjectExpression'], undefined>>[0];
+type IdentifierNode = Parameters<Exclude<Rule.RuleListener['Identifier'], undefined>>[0];
+type LiteralNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'Literal'; }> & Rule.Node;
+type SpreadElementNode = Extract<Readonly<CallExpressionNode['arguments'][number]>, { type: 'SpreadElement'; }>;
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+function createSourceCode(): SourceCode {
+    const scope = {
+        childScopes: [],
+        set: new Map(),
+        upper: null
+    } as unknown as Scope.Scope;
+
+    return asSourceCode({
+        getScope() {
+            return scope;
+        }
+    });
+}
+
+function identifier(name: string): IdentifierNode {
+    return { name, type: 'Identifier' } as unknown as IdentifierNode;
+}
+
+function literal(value: number | string | null): LiteralNode {
+    return { type: 'Literal', value } as unknown as LiteralNode;
+}
+
+function setParent(node: Readonly<Rule.Node> | null | undefined, parent: Readonly<Rule.Node>): void {
+    if (node !== null && node !== undefined) {
+        Reflect.set(node, 'parent', parent);
+    }
+}
+
+function memberExpression(
+    object: Readonly<Rule.Node>,
+    propertyNode: Readonly<Rule.Node>,
+    computed = false
+): MemberExpressionNode {
+    const node = {
+        computed,
+        object,
+        property: propertyNode,
+        type: 'MemberExpression'
+    } as unknown as MemberExpressionNode;
+
+    setParent(object, node);
+    setParent(propertyNode, node);
+
+    return node;
+}
+
+function property(
+    key: Readonly<Rule.Node>,
+    value: Readonly<Rule.Node>,
+    computed = false
+): PropertyNode {
+    const node = {
+        computed,
+        key,
+        kind: 'init',
+        type: 'Property',
+        value
+    } as unknown as PropertyNode;
+
+    setParent(key, node);
+    setParent(value, node);
+
+    return node;
+}
+
+function objectExpression(properties: readonly Readonly<PropertyNode>[]): ObjectExpressionNode {
+    const node = { properties, type: 'ObjectExpression' } as unknown as ObjectExpressionNode;
+
+    for (const propertyNode of properties) {
+        setParent(propertyNode as unknown as Rule.Node, node);
+    }
+
+    return node;
+}
+
+function callExpression(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): CallExpressionNode {
+    const node = {
+        arguments: args,
+        callee,
+        type: 'CallExpression'
+    } as unknown as CallExpressionNode;
+
+    setParent(callee, node);
+
+    for (const argument of args) {
+        setParent(argument as unknown as Rule.Node, node);
+    }
+
+    return node;
+}
+
+function spreadElement(argument: Readonly<Rule.Node>): SpreadElementNode {
+    const node = { argument, type: 'SpreadElement' } as unknown as SpreadElementNode;
+
+    setParent(argument, node as unknown as Rule.Node);
+
+    return node;
+}
+
+function createSegment(id: string): MutableSegment {
+    return { id, nextSegments: [], prevSegments: [] };
+}
+
+function linkSegments(previous: MutableSegment, next: MutableSegment): void {
+    previous.nextSegments.push(next);
+    next.prevSegments.push(previous);
+}
+
+function asCodePathSegment(segment: MutableSegment): Rule.CodePathSegment {
+    return segment as unknown as Rule.CodePathSegment;
+}
+
+function createCodePath(initialSegment: MutableSegment, returnedSegments: readonly MutableSegment[]): Rule.CodePath {
+    return {
+        initialSegment: asCodePathSegment(initialSegment),
+        returnedSegments: returnedSegments.map(asCodePathSegment)
+    } as unknown as Rule.CodePath;
+}
+
+function bindingAssignment(target: string, source: Readonly<Rule.Node> | null): CallbackHandlingOperation {
+    return {
+        node: identifier(target),
+        source,
+        target,
+        type: 'bindingAssignment'
+    };
+}
+
+function containerPropertyAssignment(
+    target: string,
+    propertyName: string | undefined,
+    source: Readonly<Rule.Node> | null
+): CallbackHandlingOperation {
+    return {
+        node: identifier(target),
+        propertyName,
+        source,
+        target,
+        type: 'containerPropertyAssignment'
+    };
+}
+
+function callOperation(
+    callee: Readonly<Rule.Node>,
+    args: readonly Readonly<CallExpressionNode['arguments'][number]>[]
+): Extract<CallbackHandlingOperation, { type: 'call'; }> {
+    return {
+        node: callExpression(callee, args),
+        type: 'call'
+    };
+}
+
+function analyzeOperations(
+    operationsBySegmentId: ReadonlyMap<string, readonly CallbackHandlingOperation[]>,
+    codePath: Readonly<Rule.CodePath>
+): readonly Rule.Node[] {
+    return collectRepeatedCallbackHandlingNodes({
+        callbackBinding: 'done',
+        codePath,
+        operationsBySegmentId,
+        sourceCode: createSourceCode()
+    });
+}
+
+describe('repeated callback handling path helpers', function () {
+    it('collectRepeatedCallbackHandlingNodes() reports repeated aliased calls', function () {
+        const start = createSegment('start');
+        const firstCall = callOperation(identifier('finish'), []);
+        const secondCall = callOperation(identifier('finish'), []);
+
+        const result = analyzeOperations(
+            new Map([
+                ['start', [bindingAssignment('finish', identifier('done')), firstCall, secondCall]]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() tracks container aliases copied through identifiers', function () {
+        const start = createSegment('start');
+        const firstCall = callOperation(memberExpression(identifier('callbacks'), identifier('complete')), []);
+        const secondCall = callOperation(memberExpression(identifier('callbacks'), identifier('complete')), []);
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        containerPropertyAssignment('holder', 'complete', identifier('done')),
+                        bindingAssignment('callbacks', identifier('holder')),
+                        firstCall,
+                        secondCall
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() tracks dynamic callback properties', function () {
+        const start = createSegment('start');
+        const firstCall = callOperation(memberExpression(identifier('callbacks'), identifier('name'), true), []);
+        const secondCall = callOperation(memberExpression(identifier('callbacks'), identifier('name'), true), []);
+
+        const result = analyzeOperations(
+            new Map([
+                ['start', [
+                    containerPropertyAssignment('callbacks', undefined, identifier('done')),
+                    firstCall,
+                    secondCall
+                ]]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() tracks object containers with literal keys', function () {
+        const start = createSegment('start');
+        const firstCall = callOperation(memberExpression(identifier('callbacks'), literal('complete'), true), []);
+        const secondCall = callOperation(memberExpression(identifier('callbacks'), literal('complete'), true), []);
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        bindingAssignment(
+                            'callbacks',
+                            objectExpression([
+                                property(literal('complete'), identifier('done'), true),
+                                property(literal('alias'), identifier('done')),
+                                property(identifier('dynamicName'), identifier('done'), true),
+                                property(literal(null), identifier('done'))
+                            ])
+                        ),
+                        firstCall,
+                        secondCall
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() clears callback aliases on reassignment', function () {
+        const start = createSegment('start');
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        bindingAssignment('finish', identifier('done')),
+                        bindingAssignment('finish', null),
+                        callOperation(identifier('finish'), []),
+                        callOperation(identifier('finish'), [])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() ignores non-object container sources', function () {
+        const start = createSegment('start');
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        bindingAssignment('callbacks', literal(0)),
+                        callOperation(memberExpression(identifier('callbacks'), identifier('complete')), []),
+                        callOperation(memberExpression(identifier('callbacks'), identifier('complete')), [])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() reports repeated delegated spread calls', function () {
+        const start = createSegment('start');
+        const firstCall = callOperation(identifier('setTimeout'), [spreadElement(identifier('done')), literal(0)]);
+        const secondCall = callOperation(identifier('setTimeout'), [spreadElement(identifier('done')), literal(0)]);
+
+        const result = analyzeOperations(
+            new Map([
+                ['start', [firstCall, secondCall]]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() ignores dynamic delegate callees', function () {
+        const start = createSegment('start');
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        callOperation(identifier('done'), []),
+                        callOperation(
+                            memberExpression(identifier('globalThis'), identifier('delegateName'), true),
+                            [identifier('done')]
+                        )
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() ignores unsupported member expressions', function () {
+        const start = createSegment('start');
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        containerPropertyAssignment('callbacks', 'complete', identifier('done')),
+                        callOperation(
+                            memberExpression(callExpression(identifier('getCallbacks'), []), identifier('complete')),
+                            []
+                        ),
+                        callOperation(
+                            memberExpression(callExpression(identifier('getCallbacks'), []), identifier('complete')),
+                            []
+                        )
+                    ]
+                ]
+            ]),
+            createCodePath(start, [start])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() seeds segments without predecessors from the callback binding', function () {
+        const start = createSegment('start');
+        const orphan = createSegment('orphan');
+        start.nextSegments.push(orphan);
+
+        const firstCall = callOperation(identifier('done'), []);
+        const secondCall = callOperation(identifier('done'), []);
+
+        const result = analyzeOperations(
+            new Map([
+                ['orphan', [firstCall, secondCall]]
+            ]),
+            createCodePath(start, [orphan])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() revisits segments until their merged state stabilizes', function () {
+        const start = createSegment('start');
+        const left = createSegment('left');
+        const end = createSegment('end');
+        const right = createSegment('right');
+
+        start.nextSegments.push(left, end, right);
+        left.prevSegments.push(start);
+        right.prevSegments.push(start);
+        left.nextSegments.push(end);
+        right.nextSegments.push(end);
+        end.prevSegments.push(left, right);
+
+        const result = analyzeOperations(
+            new Map([
+                ['left', [bindingAssignment('finish', identifier('done'))]],
+                ['right', [bindingAssignment('finish', identifier('done'))]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('collectRepeatedCallbackHandlingNodes() falls back to the callback binding for missing predecessor state', function () {
+        const start = createSegment('start');
+        const missing = createSegment('missing');
+        const end = createSegment('end');
+
+        linkSegments(start, end);
+        end.prevSegments.push(missing);
+
+        const firstCall = callOperation(identifier('done'), []);
+        const secondCall = callOperation(identifier('done'), []);
+
+        const result = analyzeOperations(
+            new Map([
+                ['end', [firstCall, secondCall]]
+            ]),
+            createCodePath(start, [end])
+        );
+
+        assert.deepStrictEqual(result, [secondCall.node]);
+    });
+});

--- a/source/repeated-callback-handling-paths.ts
+++ b/source/repeated-callback-handling-paths.ts
@@ -1,0 +1,122 @@
+import type { Rule } from 'eslint';
+import {
+    arePathStatesSame,
+    type CallbackHandlingContext,
+    clonePathState,
+    createEntryState,
+    getCodeAfterCallbackHandlingNode,
+    updatePathState
+} from './callback-handling-state.js';
+
+type PendingSegmentCollection = {
+    exitStatesBySegmentId: Map<string, ReturnType<typeof clonePathState>>;
+    pendingSegments: Rule.CodePathSegment[];
+    queuedSegmentIds: Set<string>;
+    reportedNodeSet: WeakSet<Rule.Node>;
+    reportedNodes: Rule.Node[];
+};
+
+function collectSegmentRepeatedCallbackHandlingNodes(
+    context: Readonly<CallbackHandlingContext>,
+    entryState: ReturnType<typeof clonePathState>,
+    segment: Readonly<Rule.CodePathSegment>
+): readonly [Rule.Node[], ReturnType<typeof clonePathState>] {
+    const reportedNodes: Rule.Node[] = [];
+    let nextState = clonePathState(entryState);
+
+    for (const operation of context.operationsBySegmentId.get(segment.id) ?? []) {
+        const repeatedCallbackHandlingNode = operation.type === 'call' &&
+                nextState.callbackHandled &&
+                getCodeAfterCallbackHandlingNode(context.sourceCode, nextState, operation) === undefined
+            ? operation.node
+            : undefined;
+
+        if (repeatedCallbackHandlingNode !== undefined) {
+            reportedNodes.push(repeatedCallbackHandlingNode);
+        }
+
+        nextState = updatePathState(context.sourceCode, nextState, operation);
+    }
+
+    return [reportedNodes, nextState];
+}
+
+function enqueueNextSegments(
+    nextSegments: readonly Readonly<Rule.CodePathSegment>[],
+    pendingSegments: Rule.CodePathSegment[],
+    queuedSegmentIds: Set<string>
+): void {
+    for (const nextSegment of nextSegments) {
+        if (!queuedSegmentIds.has(nextSegment.id)) {
+            pendingSegments.push(nextSegment);
+            queuedSegmentIds.add(nextSegment.id);
+        }
+    }
+}
+
+function recordReportedNodes(
+    reportedNodes: Rule.Node[],
+    reportedNodeSet: WeakSet<Rule.Node>,
+    segmentReportedNodes: readonly Rule.Node[]
+): void {
+    for (const reportedNode of segmentReportedNodes) {
+        if (!reportedNodeSet.has(reportedNode)) {
+            reportedNodeSet.add(reportedNode);
+            reportedNodes.push(reportedNode);
+        }
+    }
+}
+
+function shouldRevisitSegment(
+    collection: Readonly<PendingSegmentCollection>,
+    nextState: ReturnType<typeof clonePathState>,
+    segment: Readonly<Rule.CodePathSegment>,
+    segmentReportedNodes: readonly Rule.Node[]
+): boolean {
+    return segmentReportedNodes.length > 0 ||
+        !arePathStatesSame(collection.exitStatesBySegmentId.get(segment.id), nextState);
+}
+
+function processPendingSegment(
+    context: Readonly<CallbackHandlingContext>,
+    collection: PendingSegmentCollection,
+    segment: Readonly<Rule.CodePathSegment>
+): void {
+    collection.queuedSegmentIds.delete(segment.id);
+
+    const entryState = createEntryState(context, segment, collection.exitStatesBySegmentId);
+    const [segmentReportedNodes, nextState] = collectSegmentRepeatedCallbackHandlingNodes(
+        context,
+        entryState,
+        segment
+    );
+
+    recordReportedNodes(collection.reportedNodes, collection.reportedNodeSet, segmentReportedNodes);
+
+    if (shouldRevisitSegment(collection, nextState, segment, segmentReportedNodes)) {
+        collection.exitStatesBySegmentId.set(segment.id, nextState);
+        enqueueNextSegments(segment.nextSegments, collection.pendingSegments, collection.queuedSegmentIds);
+    }
+}
+
+export function collectRepeatedCallbackHandlingNodes(
+    context: Readonly<CallbackHandlingContext>
+): readonly Rule.Node[] {
+    const collection: PendingSegmentCollection = {
+        exitStatesBySegmentId: new Map(),
+        pendingSegments: [context.codePath.initialSegment],
+        queuedSegmentIds: new Set([context.codePath.initialSegment.id]),
+        reportedNodeSet: new WeakSet(),
+        reportedNodes: []
+    };
+
+    while (collection.pendingSegments.length > 0) {
+        const segment = collection.pendingSegments.shift();
+
+        if (segment !== undefined) {
+            processPendingSegment(context, collection, segment);
+        }
+    }
+
+    return collection.reportedNodes;
+}

--- a/source/repeated-callback-handling-paths.ts
+++ b/source/repeated-callback-handling-paths.ts
@@ -2,6 +2,7 @@ import type { Rule } from 'eslint';
 import {
     arePathStatesSame,
     type CallbackHandlingContext,
+    type CallbackHandlingOperation,
     clonePathState,
     createEntryState,
     getCodeAfterCallbackHandlingNode,
@@ -16,6 +17,20 @@ type PendingSegmentCollection = {
     reportedNodes: Rule.Node[];
 };
 
+function getRepeatedCallbackHandlingNode(
+    context: Readonly<CallbackHandlingContext>,
+    pathState: ReturnType<typeof clonePathState>,
+    operation: Readonly<CallbackHandlingOperation>
+): Rule.Node | undefined {
+    if (operation.type !== 'call' || !pathState.callbackHandled) {
+        return undefined;
+    }
+
+    return getCodeAfterCallbackHandlingNode(context.sourceCode, pathState, operation) === undefined
+        ? operation.node
+        : undefined;
+}
+
 function collectSegmentRepeatedCallbackHandlingNodes(
     context: Readonly<CallbackHandlingContext>,
     entryState: ReturnType<typeof clonePathState>,
@@ -25,11 +40,7 @@ function collectSegmentRepeatedCallbackHandlingNodes(
     let nextState = clonePathState(entryState);
 
     for (const operation of context.operationsBySegmentId.get(segment.id) ?? []) {
-        const repeatedCallbackHandlingNode = operation.type === 'call' &&
-                nextState.callbackHandled &&
-                getCodeAfterCallbackHandlingNode(context.sourceCode, nextState, operation) === undefined
-            ? operation.node
-            : undefined;
+        const repeatedCallbackHandlingNode = getRepeatedCallbackHandlingNode(context, nextState, operation);
 
         if (repeatedCallbackHandlingNode !== undefined) {
             reportedNodes.push(repeatedCallbackHandlingNode);

--- a/source/rules/no-done-twice.test.ts
+++ b/source/rules/no-done-twice.test.ts
@@ -11,12 +11,18 @@ ruleTester.run('no-done-twice', noDoneTwiceRule, {
         'it("title", function(done) { done(); });',
         'it("title", function(done) { const foo = done; foo(); });',
         'it("title", function(finish) { finish(); });',
+        'it("title", function() { work(); });',
+        'it("title", function([finish]) { finish(); });',
         'it("title", function(done) { return done(); done(); });',
         'it("title", function(done) { if (failed) { done(error); } else { done(); } });',
         'it("title", function(done) { var finish = done; if (failed) { finish(error); } else { done(); } });',
         'it("title", function(done) { if (failed) { setTimeout(done, 0); } else { done(); } });',
         'it("title", function(done) { var finish = done; if (failed) { setTimeout(finish, 0); } else { done(); } });',
         'it("title", function(done) { var callbacks = { complete: done }; if (failed) { setTimeout(callbacks.complete, 0); } else { callbacks.complete(); } });',
+        'it("title", function(done) { let finish = done; finish++; done(); });',
+        'it("title", function(done) { var callbacks = { complete: done }; callbacks.complete++; done(); });',
+        'it("title", function(done) { var callbacks = { complete: done }; delete callbacks.complete; done(); });',
+        'it("title", function(done) { getCallbacks().complete = done; done(); });',
         'it("title", function(done) { handler(function () { done(); done(); }); });',
         'beforeEach(function(done) { done(); });',
         'notMocha("title", function(done) { done(); done(); });',
@@ -68,6 +74,20 @@ ruleTester.run('no-done-twice', noDoneTwiceRule, {
         {
             code: 'it("title", function(done) { var callbacks = { complete: done }; ' +
                 'setTimeout(callbacks.complete, 0); callbacks.complete(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { let finish; finish = done; finish(); finish(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var callbacks = {}; callbacks.complete = done; ' +
+                'callbacks.complete(); callbacks.complete(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var callbacks = {}; callbacks["complete"] = done; ' +
+                'callbacks.complete(); callbacks.complete(); });',
             errors: [{ message }]
         },
         {

--- a/source/rules/no-done-twice.test.ts
+++ b/source/rules/no-done-twice.test.ts
@@ -1,0 +1,46 @@
+import { type Rule, RuleTester } from 'eslint';
+import assert from 'node:assert';
+import { checkNodeForDoneTwice, noDoneTwiceRule } from './no-done-twice.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const message = 'Do not call the Mocha callback more than once';
+
+ruleTester.run('no-done-twice', noDoneTwiceRule, {
+    valid: [
+        'it("title", function(done) { done(); });',
+        'it("title", function(done) { return done(); done(); });',
+        'it("title", function(done) { handler(function () { return done(); done(); }); });',
+        'it("title", function(done) { function later(done) { done(); done(); } });',
+        'it("title", async function() { await work(); });',
+        'notMocha("title", function(done) { done(); done(); });'
+    ],
+
+    invalid: [
+        {
+            code: 'it("title", function(done) { done(); done(); });',
+            errors: [{ message, column: 38, line: 1 }]
+        },
+        {
+            code: 'it("title", function(done) { if (failed) { done(error); } done(); });',
+            errors: [{ message, column: 59, line: 1 }]
+        },
+        {
+            code: 'it("title", function(done) { handler(function () { done(); done(); }); });',
+            errors: [{ message, column: 60, line: 1 }]
+        }
+    ]
+});
+
+describe('no-done-twice helpers', function () {
+    it('checkNodeForDoneTwice() ignores non-function nodes', function () {
+        const reports: string[] = [];
+
+        checkNodeForDoneTwice({
+            report() {
+                reports.push('reported');
+            }
+        } as unknown as Rule.RuleContext, { type: 'Identifier' } as Rule.Node);
+
+        assert.deepStrictEqual(reports, []);
+    });
+});

--- a/source/rules/no-done-twice.test.ts
+++ b/source/rules/no-done-twice.test.ts
@@ -9,6 +9,7 @@ const typescriptLanguageOptions = { parser: typescriptParser };
 ruleTester.run('no-done-twice', noDoneTwiceRule, {
     valid: [
         'it("title", function(done) { done(); });',
+        'it("title", function(done) { const foo = done; foo(); });',
         'it("title", function(finish) { finish(); });',
         'it("title", function(done) { return done(); done(); });',
         'it("title", function(done) { if (failed) { done(error); } else { done(); } });',
@@ -29,6 +30,10 @@ ruleTester.run('no-done-twice', noDoneTwiceRule, {
     invalid: [
         {
             code: 'it("title", function(done) { done(); done(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { const foo = done; foo(); foo(); });',
             errors: [{ message }]
         },
         {

--- a/source/rules/no-done-twice.test.ts
+++ b/source/rules/no-done-twice.test.ts
@@ -1,46 +1,78 @@
-import { type Rule, RuleTester } from 'eslint';
-import assert from 'node:assert';
-import { checkNodeForDoneTwice, noDoneTwiceRule } from './no-done-twice.js';
+import * as typescriptParser from '@typescript-eslint/parser';
+import { RuleTester } from 'eslint';
+import { noDoneTwiceRule } from './no-done-twice.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const message = 'Do not call the Mocha callback more than once';
+const typescriptLanguageOptions = { parser: typescriptParser };
 
 ruleTester.run('no-done-twice', noDoneTwiceRule, {
     valid: [
         'it("title", function(done) { done(); });',
+        'it("title", function(finish) { finish(); });',
         'it("title", function(done) { return done(); done(); });',
-        'it("title", function(done) { handler(function () { return done(); done(); }); });',
-        'it("title", function(done) { function later(done) { done(); done(); } });',
-        'it("title", async function() { await work(); });',
-        'notMocha("title", function(done) { done(); done(); });'
+        'it("title", function(done) { if (failed) { done(error); } else { done(); } });',
+        'it("title", function(done) { var finish = done; if (failed) { finish(error); } else { done(); } });',
+        'it("title", function(done) { if (failed) { setTimeout(done, 0); } else { done(); } });',
+        'it("title", function(done) { var finish = done; if (failed) { setTimeout(finish, 0); } else { done(); } });',
+        'it("title", function(done) { var callbacks = { complete: done }; if (failed) { setTimeout(callbacks.complete, 0); } else { callbacks.complete(); } });',
+        'it("title", function(done) { handler(function () { done(); done(); }); });',
+        'beforeEach(function(done) { done(); });',
+        'notMocha("title", function(done) { done(); done(); });',
+
+        {
+            code: 'it("title", function(this: Mocha.Context, finish) { finish(); });',
+            languageOptions: typescriptLanguageOptions
+        }
     ],
 
     invalid: [
         {
             code: 'it("title", function(done) { done(); done(); });',
-            errors: [{ message, column: 38, line: 1 }]
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(finish) { finish(); finish(); });',
+            errors: [{ message }]
         },
         {
             code: 'it("title", function(done) { if (failed) { done(error); } done(); });',
-            errors: [{ message, column: 59, line: 1 }]
+            errors: [{ message }]
         },
         {
-            code: 'it("title", function(done) { handler(function () { done(); done(); }); });',
-            errors: [{ message, column: 60, line: 1 }]
+            code: 'it("title", function(done) { var finish = done; finish(); finish(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var finish = done; if (failed) { finish(error); } else { done(); } ' +
+                'finish(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { setTimeout(done, 0); done(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { done(); setTimeout(done, 0); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var finish = done; setTimeout(finish, 0); finish(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(done) { var callbacks = { complete: done }; ' +
+                'setTimeout(callbacks.complete, 0); callbacks.complete(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'beforeEach(function(done) { done(); done(); });',
+            errors: [{ message }]
+        },
+        {
+            code: 'it("title", function(this: Mocha.Context, finish) { finish(); finish(); });',
+            languageOptions: typescriptLanguageOptions,
+            errors: [{ message }]
         }
     ]
-});
-
-describe('no-done-twice helpers', function () {
-    it('checkNodeForDoneTwice() ignores non-function nodes', function () {
-        const reports: string[] = [];
-
-        checkNodeForDoneTwice({
-            report() {
-                reports.push('reported');
-            }
-        } as unknown as Rule.RuleContext, { type: 'Identifier' } as Rule.Node);
-
-        assert.deepStrictEqual(reports, []);
-    });
 });

--- a/source/rules/no-done-twice.ts
+++ b/source/rules/no-done-twice.ts
@@ -168,6 +168,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
             'VariableDeclarator:exit'(node) {
                 if (node.id.type === 'Identifier') {
                     recordOperation({
+                        node,
                         source: asRuleNodeOrNull(node.init),
                         target: getTrackedBinding(context.sourceCode, node.id),
                         type: 'bindingAssignment'
@@ -178,6 +179,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
             'AssignmentExpression:exit'(node) {
                 if (node.left.type === 'Identifier') {
                     recordOperation({
+                        node,
                         source: asRuleNode(node.right),
                         target: getTrackedBinding(context.sourceCode, node.left),
                         type: 'bindingAssignment'
@@ -190,6 +192,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
 
                     if (bindingAndProperty !== undefined) {
                         recordOperation({
+                            node,
                             propertyName: bindingAndProperty.propertyName,
                             source: asRuleNode(node.right),
                             target: bindingAndProperty.binding,
@@ -202,6 +205,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
             'UpdateExpression:exit'(node) {
                 if (node.argument.type === 'Identifier') {
                     recordOperation({
+                        node,
                         source: null,
                         target: getTrackedBinding(context.sourceCode, node.argument),
                         type: 'bindingAssignment'
@@ -214,6 +218,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
 
                     if (bindingAndProperty !== undefined) {
                         recordOperation({
+                            node,
                             propertyName: bindingAndProperty.propertyName,
                             source: null,
                             target: bindingAndProperty.binding,
@@ -229,6 +234,7 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
 
                     if (bindingAndProperty !== undefined) {
                         recordOperation({
+                            node,
                             propertyName: bindingAndProperty.propertyName,
                             source: null,
                             target: bindingAndProperty.binding,

--- a/source/rules/no-done-twice.ts
+++ b/source/rules/no-done-twice.ts
@@ -1,0 +1,224 @@
+import { findVariable } from '@eslint-community/eslint-utils';
+import type { Rule, Scope, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import {
+    type AnyFunction,
+    type BlockStatement,
+    isBlockStatement,
+    isFunction,
+    isIdentifier
+} from '../ast/node-types.js';
+import { asRuleNode } from '../done-callback-paths.js';
+
+type TraversableNode = Except<Rule.Node, 'parent'>;
+type Statement = BlockStatement['body'][number];
+type CallExpression = Extract<TraversableNode, { type: 'CallExpression'; }>;
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
+    return param !== undefined && isIdentifier(param) && param.name === 'this';
+}
+
+function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = node.params;
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
+}
+
+function getDoneCallbackVariable(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<AnyFunction>
+): Readonly<Scope.Variable | null | undefined> {
+    const callbackParameter = getFirstMeaningfulParameter(node);
+
+    if (callbackParameter?.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return findVariable(sourceCode.getScope(asRuleNode(callbackParameter)), callbackParameter.name);
+}
+
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function visitChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (isNode(item)) {
+                    visitor(item);
+                }
+            });
+        } else if (isNode(value)) {
+            visitor(value);
+        }
+    }
+}
+
+function visitWithoutNestedFunctions(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    visitor(node);
+
+    if (isFunction(node)) {
+        return;
+    }
+
+    visitChildNodes(sourceCode, node, (childNode) => {
+        visitWithoutNestedFunctions(sourceCode, childNode, visitor);
+    });
+}
+
+function isDoneCallbackCall(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): node is CallExpression {
+    return node.type === 'CallExpression' &&
+        node.callee.type === 'Identifier' &&
+        findVariable(sourceCode.getScope(asRuleNode(node.callee)), node.callee.name) === doneCallbackVariable;
+}
+
+function collectDoneCallbackCalls(
+    sourceCode: Readonly<SourceCode>,
+    statement: Readonly<Statement>,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): readonly Readonly<CallExpression>[] {
+    const doneCallbackCalls: CallExpression[] = [];
+
+    visitWithoutNestedFunctions(sourceCode, statement, (childNode) => {
+        if (isDoneCallbackCall(sourceCode, childNode, doneCallbackVariable)) {
+            doneCallbackCalls.push(childNode);
+        }
+    });
+
+    return doneCallbackCalls;
+}
+
+function isFlowExitStatement(statement: Readonly<Statement>): boolean {
+    return statement.type === 'ReturnStatement' ||
+        statement.type === 'ThrowStatement' ||
+        statement.type === 'BreakStatement' ||
+        statement.type === 'ContinueStatement';
+}
+
+function reportDoneCallbackCall(context: Readonly<Rule.RuleContext>, callExpression: Readonly<CallExpression>): void {
+    context.report({
+        node: callExpression,
+        messageId: 'unexpectedDoneTwice'
+    });
+}
+
+function findRepeatedDoneCallbackCall(
+    doneCallbackCalls: readonly Readonly<CallExpression>[],
+    seenDoneCallbackCall: boolean
+): Readonly<CallExpression | undefined> {
+    const [firstDoneCallbackCall, secondDoneCallbackCall] = doneCallbackCalls;
+
+    if (secondDoneCallbackCall !== undefined) {
+        return secondDoneCallbackCall;
+    }
+
+    return seenDoneCallbackCall ? firstDoneCallbackCall : undefined;
+}
+
+function shouldRememberDoneCallbackCall(
+    statement: Readonly<Statement>,
+    firstDoneCallbackCall: Readonly<CallExpression | undefined>
+): boolean {
+    return firstDoneCallbackCall !== undefined && !isFlowExitStatement(statement);
+}
+
+function getSeenDoneCallbackCall(
+    statement: Readonly<Statement>,
+    firstDoneCallbackCall: Readonly<CallExpression | undefined>,
+    seenDoneCallbackCall: boolean
+): boolean {
+    if (isFlowExitStatement(statement)) {
+        return false;
+    }
+
+    return shouldRememberDoneCallbackCall(statement, firstDoneCallbackCall) || seenDoneCallbackCall;
+}
+
+function inspectBlockStatements(
+    context: Readonly<Rule.RuleContext>,
+    blockStatement: Readonly<BlockStatement>,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): void {
+    let seenDoneCallbackCall = false;
+
+    for (const statement of blockStatement.body) {
+        const doneCallbackCalls = collectDoneCallbackCalls(context.sourceCode, statement, doneCallbackVariable);
+        const [firstDoneCallbackCall] = doneCallbackCalls;
+        const repeatedDoneCallbackCall = findRepeatedDoneCallbackCall(doneCallbackCalls, seenDoneCallbackCall);
+
+        if (repeatedDoneCallbackCall !== undefined) {
+            reportDoneCallbackCall(context, repeatedDoneCallbackCall);
+        }
+
+        seenDoneCallbackCall = getSeenDoneCallbackCall(statement, firstDoneCallbackCall, seenDoneCallbackCall);
+    }
+}
+
+function inspectNodeRecursively(
+    context: Readonly<Rule.RuleContext>,
+    node: TraversableNode,
+    doneCallbackVariable: Readonly<Scope.Variable>
+): void {
+    if (isBlockStatement(node)) {
+        inspectBlockStatements(context, node, doneCallbackVariable);
+    }
+
+    visitChildNodes(context.sourceCode, node, (childNode) => {
+        inspectNodeRecursively(context, childNode, doneCallbackVariable);
+    });
+}
+
+export function checkNodeForDoneTwice(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
+    if (!isFunction(node)) {
+        return;
+    }
+
+    const doneCallbackVariable = getDoneCallbackVariable(context.sourceCode, node);
+
+    if (doneCallbackVariable === undefined || doneCallbackVariable === null) {
+        return;
+    }
+
+    inspectNodeRecursively(context, node.body, doneCallbackVariable);
+}
+
+export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'problem',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow calling a Mocha callback more than once',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-done-twice.md'
+        },
+        messages: {
+            unexpectedDoneTwice: 'Do not call the Mocha callback more than once'
+        },
+        schema: []
+    },
+    create(context) {
+        return createMochaVisitors(context, {
+            anyTestEntityCallback(visitorContext) {
+                checkNodeForDoneTwice(context, visitorContext.node);
+            }
+        });
+    }
+};

--- a/source/rules/no-done-twice.ts
+++ b/source/rules/no-done-twice.ts
@@ -1,204 +1,97 @@
-import { findVariable } from '@eslint-community/eslint-utils';
-import type { Rule, Scope, SourceCode } from 'eslint';
-import type { Except } from 'type-fest';
+import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type AnyFunction, isFunction, isIdentifier } from '../ast/node-types.js';
+import type { CallbackHandlingOperation } from '../callback-handling-state.js';
 import {
-    type AnyFunction,
-    type BlockStatement,
-    isBlockStatement,
-    isFunction,
-    isIdentifier
-} from '../ast/node-types.js';
-import { asRuleNode } from '../done-callback-paths.js';
+    asRuleNode,
+    asRuleNodeOrNull,
+    getMemberExpressionBindingAndProperty,
+    getTrackedBinding,
+    type TrackedBinding
+} from '../done-callback-paths.js';
+import { collectRepeatedCallbackHandlingNodes } from '../repeated-callback-handling-paths.js';
 
-type TraversableNode = Except<Rule.Node, 'parent'>;
-type Statement = BlockStatement['body'][number];
-type CallExpression = Extract<TraversableNode, { type: 'CallExpression'; }>;
+type TrackedFunctionState = {
+    callbackBinding: TrackedBinding;
+    codePath: Readonly<Rule.CodePath>;
+    currentSegments: Set<Rule.CodePathSegment>;
+    operationsBySegmentId: Map<string, CallbackHandlingOperation[]>;
+};
 
-function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
-    return param !== undefined && isIdentifier(param) && param.name === 'this';
+type FunctionState = {
+    tracked: TrackedFunctionState | undefined;
+    upper: FunctionState | null;
+};
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number]): boolean {
+    return isIdentifier(param) && param.name === 'this';
 }
 
-function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
-    const [firstParam, secondParam] = node.params;
-    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
-}
+function getDoneCallback(
+    functionExpression: Readonly<AnyFunction>
+): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = functionExpression.params;
 
-function getDoneCallbackVariable(
-    sourceCode: Readonly<SourceCode>,
-    node: Readonly<AnyFunction>
-): Readonly<Scope.Variable | null | undefined> {
-    const callbackParameter = getFirstMeaningfulParameter(node);
-
-    if (callbackParameter?.type !== 'Identifier') {
+    if (firstParam === undefined) {
         return undefined;
     }
 
-    return findVariable(sourceCode.getScope(asRuleNode(callbackParameter)), callbackParameter.name);
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
 }
 
-function getNodeProperty(node: TraversableNode, key: string): unknown {
-    return Reflect.get(node, key);
-}
-
-function isNode(value: unknown): value is TraversableNode {
-    return typeof value === 'object' && value !== null && 'type' in value;
-}
-
-function visitChildNodes(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    visitor: (childNode: TraversableNode) => void
+function pushOperation(
+    operationsBySegmentId: Map<string, CallbackHandlingOperation[]>,
+    segmentId: string,
+    operation: Readonly<CallbackHandlingOperation>
 ): void {
-    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
-        const value = getNodeProperty(node, key);
+    const operations = operationsBySegmentId.get(segmentId);
 
-        if (Array.isArray(value)) {
-            value.forEach((item) => {
-                if (isNode(item)) {
-                    visitor(item);
-                }
-            });
-        } else if (isNode(value)) {
-            visitor(value);
-        }
-    }
-}
-
-function visitWithoutNestedFunctions(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    visitor: (childNode: TraversableNode) => void
-): void {
-    visitor(node);
-
-    if (isFunction(node)) {
+    if (operations === undefined) {
+        operationsBySegmentId.set(segmentId, [operation]);
         return;
     }
 
-    visitChildNodes(sourceCode, node, (childNode) => {
-        visitWithoutNestedFunctions(sourceCode, childNode, visitor);
+    operations.push(operation);
+}
+
+function createTrackedFunctionState(
+    sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
+    trackedCallbackNodes: Readonly<WeakSet<Rule.Node>>,
+    codePath: Readonly<Rule.CodePath>,
+    node: Readonly<Rule.Node>
+): TrackedFunctionState | undefined {
+    if (!trackedCallbackNodes.has(node) || !isFunction(node)) {
+        return undefined;
+    }
+
+    const callback = getDoneCallback(node);
+
+    if (callback === undefined || callback.type !== 'Identifier') {
+        return undefined;
+    }
+
+    return {
+        callbackBinding: getTrackedBinding(sourceCode, callback),
+        codePath,
+        currentSegments: new Set(),
+        operationsBySegmentId: new Map()
+    };
+}
+
+function reportDoneTwice(context: Readonly<Rule.RuleContext>, trackedFunction: Readonly<TrackedFunctionState>): void {
+    const reportedNodes = collectRepeatedCallbackHandlingNodes({
+        callbackBinding: trackedFunction.callbackBinding,
+        codePath: trackedFunction.codePath,
+        operationsBySegmentId: trackedFunction.operationsBySegmentId,
+        sourceCode: context.sourceCode
     });
-}
 
-function isDoneCallbackCall(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): node is CallExpression {
-    return node.type === 'CallExpression' &&
-        node.callee.type === 'Identifier' &&
-        findVariable(sourceCode.getScope(asRuleNode(node.callee)), node.callee.name) === doneCallbackVariable;
-}
-
-function collectDoneCallbackCalls(
-    sourceCode: Readonly<SourceCode>,
-    statement: Readonly<Statement>,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): readonly Readonly<CallExpression>[] {
-    const doneCallbackCalls: CallExpression[] = [];
-
-    visitWithoutNestedFunctions(sourceCode, statement, (childNode) => {
-        if (isDoneCallbackCall(sourceCode, childNode, doneCallbackVariable)) {
-            doneCallbackCalls.push(childNode);
-        }
-    });
-
-    return doneCallbackCalls;
-}
-
-function isFlowExitStatement(statement: Readonly<Statement>): boolean {
-    return statement.type === 'ReturnStatement' ||
-        statement.type === 'ThrowStatement' ||
-        statement.type === 'BreakStatement' ||
-        statement.type === 'ContinueStatement';
-}
-
-function reportDoneCallbackCall(context: Readonly<Rule.RuleContext>, callExpression: Readonly<CallExpression>): void {
-    context.report({
-        node: callExpression,
-        messageId: 'unexpectedDoneTwice'
-    });
-}
-
-function findRepeatedDoneCallbackCall(
-    doneCallbackCalls: readonly Readonly<CallExpression>[],
-    seenDoneCallbackCall: boolean
-): Readonly<CallExpression | undefined> {
-    const [firstDoneCallbackCall, secondDoneCallbackCall] = doneCallbackCalls;
-
-    if (secondDoneCallbackCall !== undefined) {
-        return secondDoneCallbackCall;
+    for (const node of reportedNodes) {
+        context.report({
+            node,
+            messageId: 'unexpectedDoneTwice'
+        });
     }
-
-    return seenDoneCallbackCall ? firstDoneCallbackCall : undefined;
-}
-
-function shouldRememberDoneCallbackCall(
-    statement: Readonly<Statement>,
-    firstDoneCallbackCall: Readonly<CallExpression | undefined>
-): boolean {
-    return firstDoneCallbackCall !== undefined && !isFlowExitStatement(statement);
-}
-
-function getSeenDoneCallbackCall(
-    statement: Readonly<Statement>,
-    firstDoneCallbackCall: Readonly<CallExpression | undefined>,
-    seenDoneCallbackCall: boolean
-): boolean {
-    if (isFlowExitStatement(statement)) {
-        return false;
-    }
-
-    return shouldRememberDoneCallbackCall(statement, firstDoneCallbackCall) || seenDoneCallbackCall;
-}
-
-function inspectBlockStatements(
-    context: Readonly<Rule.RuleContext>,
-    blockStatement: Readonly<BlockStatement>,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): void {
-    let seenDoneCallbackCall = false;
-
-    for (const statement of blockStatement.body) {
-        const doneCallbackCalls = collectDoneCallbackCalls(context.sourceCode, statement, doneCallbackVariable);
-        const [firstDoneCallbackCall] = doneCallbackCalls;
-        const repeatedDoneCallbackCall = findRepeatedDoneCallbackCall(doneCallbackCalls, seenDoneCallbackCall);
-
-        if (repeatedDoneCallbackCall !== undefined) {
-            reportDoneCallbackCall(context, repeatedDoneCallbackCall);
-        }
-
-        seenDoneCallbackCall = getSeenDoneCallbackCall(statement, firstDoneCallbackCall, seenDoneCallbackCall);
-    }
-}
-
-function inspectNodeRecursively(
-    context: Readonly<Rule.RuleContext>,
-    node: TraversableNode,
-    doneCallbackVariable: Readonly<Scope.Variable>
-): void {
-    if (isBlockStatement(node)) {
-        inspectBlockStatements(context, node, doneCallbackVariable);
-    }
-
-    visitChildNodes(context.sourceCode, node, (childNode) => {
-        inspectNodeRecursively(context, childNode, doneCallbackVariable);
-    });
-}
-
-export function checkNodeForDoneTwice(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
-    if (!isFunction(node)) {
-        return;
-    }
-
-    const doneCallbackVariable = getDoneCallbackVariable(context.sourceCode, node);
-
-    if (doneCallbackVariable === undefined || doneCallbackVariable === null) {
-        return;
-    }
-
-    inspectNodeRecursively(context, node.body, doneCallbackVariable);
 }
 
 export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
@@ -215,9 +108,134 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
         schema: []
     },
     create(context) {
+        const trackedCallbackNodes = new WeakSet<Rule.Node>();
+        let currentFunction: FunctionState | null = null;
+
+        function recordOperation(operation: Readonly<CallbackHandlingOperation>): void {
+            const trackedFunction = currentFunction?.tracked;
+
+            if (trackedFunction === undefined) {
+                return;
+            }
+
+            for (const segment of trackedFunction.currentSegments) {
+                pushOperation(trackedFunction.operationsBySegmentId, segment.id, operation);
+            }
+        }
+
+        function trackMochaCallback(node: Readonly<Rule.Node>): void {
+            trackedCallbackNodes.add(node);
+        }
+
         return createMochaVisitors(context, {
-            anyTestEntityCallback(visitorContext) {
-                checkNodeForDoneTwice(context, visitorContext.node);
+            testCaseCallback(visitorContext) {
+                trackMochaCallback(visitorContext.node);
+            },
+
+            hookCallback(visitorContext) {
+                trackMochaCallback(visitorContext.node);
+            },
+
+            onCodePathStart(codePath, node) {
+                currentFunction = {
+                    tracked: createTrackedFunctionState(context.sourceCode, trackedCallbackNodes, codePath, node),
+                    upper: currentFunction
+                };
+            },
+
+            onCodePathEnd() {
+                const trackedFunction = currentFunction?.tracked;
+
+                if (trackedFunction !== undefined) {
+                    reportDoneTwice(context, trackedFunction);
+                }
+
+                currentFunction = currentFunction?.upper ?? null;
+            },
+
+            onCodePathSegmentStart(segment) {
+                currentFunction?.tracked?.currentSegments.add(segment);
+            },
+
+            onCodePathSegmentEnd(segment) {
+                currentFunction?.tracked?.currentSegments.delete(segment);
+            },
+
+            'CallExpression:exit'(node) {
+                recordOperation({ node, type: 'call' });
+            },
+
+            'VariableDeclarator:exit'(node) {
+                if (node.id.type === 'Identifier') {
+                    recordOperation({
+                        source: asRuleNodeOrNull(node.init),
+                        target: getTrackedBinding(context.sourceCode, node.id),
+                        type: 'bindingAssignment'
+                    });
+                }
+            },
+
+            'AssignmentExpression:exit'(node) {
+                if (node.left.type === 'Identifier') {
+                    recordOperation({
+                        source: asRuleNode(node.right),
+                        target: getTrackedBinding(context.sourceCode, node.left),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.left.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.left);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            propertyName: bindingAndProperty.propertyName,
+                            source: asRuleNode(node.right),
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
+            },
+
+            'UpdateExpression:exit'(node) {
+                if (node.argument.type === 'Identifier') {
+                    recordOperation({
+                        source: null,
+                        target: getTrackedBinding(context.sourceCode, node.argument),
+                        type: 'bindingAssignment'
+                    });
+                    return;
+                }
+
+                if (node.argument.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            propertyName: bindingAndProperty.propertyName,
+                            source: null,
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
+            },
+
+            'UnaryExpression:exit'(node) {
+                if (node.operator === 'delete' && node.argument.type === 'MemberExpression') {
+                    const bindingAndProperty = getMemberExpressionBindingAndProperty(context.sourceCode, node.argument);
+
+                    if (bindingAndProperty !== undefined) {
+                        recordOperation({
+                            propertyName: bindingAndProperty.propertyName,
+                            source: null,
+                            target: bindingAndProperty.binding,
+                            type: 'containerPropertyAssignment'
+                        });
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
Add a new mocha/no-done-twice rule to report repeated completion of the same Mocha callback.
Enable the rule in the recommended config and document the expected callback style.