### PR TITLE
Extend no-pending-tests to catch this.skip()

### DIFF
--- a/documentation/rules/no-pending-tests.md
+++ b/documentation/rules/no-pending-tests.md
@@ -14,7 +14,7 @@ This rule intentionally does not support the `--fix` CLI option. Many editors ap
 
 This rule supports the following options:
 
-- `allowSkippedWithComment`: Allows explicit skip forms when they have an immediately preceding comment with no blank line. This applies to `.skip`, `xdescribe()`, `xit()`, and equivalent configured custom names. It does not allow bare pending tests such as `it('name');`. Defaults to `false`.
+- `allowSkippedWithComment`: Allows explicit skip forms when they have an immediately preceding comment with no blank line. This applies to `.skip`, `xdescribe()`, `xit()`, `this.skip()`, and equivalent configured custom names. It does not allow bare pending tests such as `it('name');`. Defaults to `false`.
 
 ```json
 {
@@ -43,11 +43,13 @@ describe['skip']('bar', function () {});
 it['skip']('bar', function () {});
 xdescribe('baz', function () {});
 xit('baz', function () {});
+it('qux', function () { this.skip(); });
 
 suite.skip('foo', function () {});
 test.skip('foo', function () {});
 suite['skip']('bar', function () {});
 test['skip']('bar', function () {});
+beforeEach(function () { this.skip(); });
 ```
 
 These patterns are not considered warnings:
@@ -76,6 +78,9 @@ it.skip('foo', function () {});
 
 /* SKIP pending #202 */
 xdescribe('bar', function () {});
+
+// SKIP pending #203
+before(function () { this.skip(); });
 ```
 
 ## When Not To Use It

--- a/source/ast/function-expression-arguments.ts
+++ b/source/ast/function-expression-arguments.ts
@@ -1,0 +1,22 @@
+import type { Rule } from 'eslint';
+
+type CallExpressionNode = Parameters<Exclude<Rule.RuleListener['CallExpression'], undefined>>[0];
+type FunctionExpressionNode = Parameters<Exclude<Rule.RuleListener['FunctionExpression'], undefined>>[0];
+type ArrowFunctionExpressionNode = Parameters<Exclude<Rule.RuleListener['ArrowFunctionExpression'], undefined>>[0];
+
+export type AnyFunctionExpressionNode = ArrowFunctionExpressionNode | FunctionExpressionNode;
+
+function isAnyFunctionExpression(
+    node: Readonly<CallExpressionNode['arguments'][number]>
+): node is AnyFunctionExpressionNode {
+    return node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
+}
+
+export function getFunctionExpressionLastArgument(
+    node: Readonly<CallExpressionNode>
+): Readonly<AnyFunctionExpressionNode | undefined> {
+    const lastArgument = node.arguments.at(-1);
+    return lastArgument !== undefined && isAnyFunctionExpression(lastArgument)
+        ? lastArgument
+        : undefined;
+}

--- a/source/ast/mocha-visitors.ts
+++ b/source/ast/mocha-visitors.ts
@@ -1,38 +1,41 @@
 import type { Rule, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
 import { getAllCustomNameDetails, getCustomNameDetailsForInterface } from '../mocha/all-name-details.js';
 import type { MochaEntityType, MochaInterface, MochaModifier } from '../mocha/descriptors.js';
 import { getAdditionalNames, getInterface } from '../settings.js';
 import { findMochaVariableCalls, type ResolvedReferenceWithNameDetails } from './find-mocha-variable-calls.js';
+import {
+    type AnyFunctionExpressionNode,
+    getFunctionExpressionLastArgument
+} from './function-expression-arguments.js';
 import { isCallExpression } from './node-types.js';
 
 type MochaVisitor = (context: Readonly<VisitorContext>) => void;
 type ExpressionListener<Name extends keyof Rule.RuleListener> = Exclude<Rule.RuleListener[Name], undefined>;
 type CallExpressionNode = Parameters<ExpressionListener<'CallExpression'>>[0];
-type MemberExpressionNode = Parameters<ExpressionListener<'MemberExpression'>>[0];
 type FunctionExpressionNode = Parameters<ExpressionListener<'FunctionExpression'>>[0];
-type ArrowFunctionExpressionNode = Parameters<ExpressionListener<'ArrowFunctionExpression'>>[0];
-type AnyFunctionExpressionNode = ArrowFunctionExpressionNode | FunctionExpressionNode;
+type MemberExpressionNode = Parameters<ExpressionListener<'MemberExpression'>>[0];
 type CallExpressionNodeVisitor = (node: CallExpressionNode) => void;
-
+type MochaCallbackVisitor = (context: Readonly<CallbackVisitorContext>) => void;
 type TestEntityVisitors = {
     testCase?: MochaVisitor | undefined;
     'testCase:exit'?: MochaVisitor | undefined;
-    testCaseCallback?: MochaVisitor | undefined;
-    'testCaseCallback:exit'?: MochaVisitor | undefined;
+    testCaseCallback?: MochaCallbackVisitor | undefined;
+    'testCaseCallback:exit'?: MochaCallbackVisitor | undefined;
     suite?: MochaVisitor | undefined;
     'suite:exit'?: MochaVisitor | undefined;
-    suiteCallback?: MochaVisitor | undefined;
-    'suiteCallback:exit'?: MochaVisitor | undefined;
+    suiteCallback?: MochaCallbackVisitor | undefined;
+    'suiteCallback:exit'?: MochaCallbackVisitor | undefined;
     hook?: MochaVisitor | undefined;
     'hook:exit'?: MochaVisitor | undefined;
-    hookCallback?: MochaVisitor | undefined;
-    'hookCallback:exit'?: MochaVisitor | undefined;
+    hookCallback?: MochaCallbackVisitor | undefined;
+    'hookCallback:exit'?: MochaCallbackVisitor | undefined;
     suiteOrTestCase?: MochaVisitor | undefined;
     'suiteOrTestCase:exit'?: MochaVisitor | undefined;
     anyTestEntity?: MochaVisitor | undefined;
     'anyTestEntity:exit'?: MochaVisitor | undefined;
-    anyTestEntityCallback?: MochaVisitor | undefined;
-    'anyTestEntityCallback:exit'?: MochaVisitor | undefined;
+    anyTestEntityCallback?: MochaCallbackVisitor | undefined;
+    'anyTestEntityCallback:exit'?: MochaCallbackVisitor | undefined;
 };
 
 type MochaSpecificVisitors = TestEntityVisitors & {
@@ -69,21 +72,6 @@ const enum MochaEntityKind {
     Hook
 }
 
-function isAnyFunctionExpression(
-    node: Readonly<CallExpressionNode['arguments'][number]>
-): node is AnyFunctionExpressionNode {
-    return node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
-}
-
-function getFunctionExpressionLastArgument(
-    node: Readonly<CallExpressionNode>
-): Readonly<AnyFunctionExpressionNode | undefined> {
-    const lastArgument = node.arguments.at(-1);
-    return lastArgument !== undefined && isAnyFunctionExpression(lastArgument)
-        ? lastArgument
-        : undefined;
-}
-
 export type VisitorContext = {
     name: string;
     node: Rule.Node;
@@ -91,7 +79,7 @@ export type VisitorContext = {
     modifier: MochaModifier | null;
     interface: MochaInterface;
 };
-
+type CallbackVisitorContext = Except<VisitorContext, 'node'> & { node: AnyFunctionExpressionNode; };
 type CachedMochaCall = {
     readonly kind: MochaEntityKind;
     readonly reference: Readonly<ResolvedReferenceWithNameDetails>;
@@ -99,20 +87,20 @@ type CachedMochaCall = {
 
 type CallExpressionDispatchers = {
     readonly testCase?: MochaVisitor | undefined;
-    readonly testCaseCallback?: MochaVisitor | undefined;
+    readonly testCaseCallback?: MochaCallbackVisitor | undefined;
     readonly suite?: MochaVisitor | undefined;
-    readonly suiteCallback?: MochaVisitor | undefined;
+    readonly suiteCallback?: MochaCallbackVisitor | undefined;
     readonly hook?: MochaVisitor | undefined;
-    readonly hookCallback?: MochaVisitor | undefined;
+    readonly hookCallback?: MochaCallbackVisitor | undefined;
     readonly suiteOrTestCase?: MochaVisitor | undefined;
     readonly anyTestEntity?: MochaVisitor | undefined;
-    readonly anyTestEntityCallback?: MochaVisitor | undefined;
+    readonly anyTestEntityCallback?: MochaCallbackVisitor | undefined;
 };
 
 type CallExpressionDispatcher = (cachedMochaCall: Readonly<CachedMochaCall>) => void;
 type CallExpressionDispatchGroup = {
     readonly visitor?: MochaVisitor | undefined;
-    readonly callbackVisitor?: MochaVisitor | undefined;
+    readonly callbackVisitor?: MochaCallbackVisitor | undefined;
     readonly includeSuiteOrTestCase: boolean;
 };
 type SplitMochaVisitors = {
@@ -187,7 +175,7 @@ function createMochaCallCache(
 
 function createCallExpressionDispatchGroup(
     visitor: MochaVisitor | undefined,
-    callbackVisitor: MochaVisitor | undefined,
+    callbackVisitor: MochaCallbackVisitor | undefined,
     includeSuiteOrTestCase = false
 ): Readonly<CallExpressionDispatchGroup> | undefined {
     if (visitor === undefined && callbackVisitor === undefined && !includeSuiteOrTestCase) {
@@ -202,7 +190,7 @@ function createCallExpressionDispatchGroup(
 }
 
 export function dispatchCallback(
-    visitor: MochaVisitor | undefined,
+    visitor: MochaCallbackVisitor | undefined,
     context: Readonly<VisitorContext>
 ): void {
     const callbackNode = isCallExpression(context.node)

--- a/source/ast/visit-child-nodes.test.ts
+++ b/source/ast/visit-child-nodes.test.ts
@@ -1,0 +1,54 @@
+import type { Rule, SourceCode } from 'eslint';
+import assert from 'node:assert';
+import { visitChildNodes } from './visit-child-nodes.js';
+
+function asRuleNode(node: Record<string, unknown>): Rule.Node {
+    return node as unknown as Rule.Node;
+}
+
+function asSourceCode(sourceCode: Record<string, unknown>): SourceCode {
+    return sourceCode as unknown as SourceCode;
+}
+
+describe('visit child nodes', function () {
+    it('visitChildNodes() visits array and direct child nodes', function () {
+        const visitedTypes: string[] = [];
+
+        visitChildNodes(
+            asSourceCode({
+                visitorKeys: {
+                    ParentNode: ['children', 'child']
+                }
+            }),
+            asRuleNode({
+                child: { type: 'Identifier' },
+                children: [{ type: 'Literal' }, 'ignore me'],
+                type: 'ParentNode'
+            }),
+            (node) => {
+                visitedTypes.push(node.type);
+            }
+        );
+
+        assert.deepStrictEqual(visitedTypes, ['Literal', 'Identifier']);
+    });
+
+    it('visitChildNodes() ignores nodes without registered visitor keys', function () {
+        const visitedTypes: string[] = [];
+
+        visitChildNodes(
+            asSourceCode({
+                visitorKeys: {}
+            }),
+            asRuleNode({
+                child: { type: 'Identifier' },
+                type: 'UnknownNode'
+            }),
+            (node) => {
+                visitedTypes.push(node.type);
+            }
+        );
+
+        assert.deepStrictEqual(visitedTypes, []);
+    });
+});

--- a/source/ast/visit-child-nodes.ts
+++ b/source/ast/visit-child-nodes.ts
@@ -1,0 +1,38 @@
+import type { Rule, SourceCode } from 'eslint';
+import type { Except } from 'type-fest';
+
+export type TraversableNode = Except<Rule.Node, 'parent'>;
+
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+export function visitChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    const visitorKeys = sourceCode.visitorKeys[node.type];
+
+    if (visitorKeys === undefined) {
+        return;
+    }
+
+    for (const key of visitorKeys) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (isNode(item)) {
+                    visitor(item);
+                }
+            });
+        } else if (isNode(value)) {
+            visitor(value);
+        }
+    }
+}

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -2,7 +2,6 @@ import { type Rule, RuleTester, type SourceCode } from 'eslint';
 import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import {
-    checkPendingCallback,
     checkPendingSuite,
     checkPendingTestCase,
     fixPendingMemberExpression,
@@ -439,26 +438,6 @@ describe('no-pending-tests helpers', function () {
             }),
             {
                 modifier: 'pending',
-                node: asRuleNode({ type: 'Identifier' })
-            },
-            { allowSkippedWithComment: false }
-        );
-
-        assert.deepStrictEqual(reports, []);
-    });
-
-    it('checkPendingCallback() ignores non-function nodes', function () {
-        const reports: string[] = [];
-
-        checkPendingCallback(
-            asRuleContext({
-                report() {
-                    reports.push('reported');
-                },
-                sourceCode: asSourceCode({ visitorKeys: {} })
-            }),
-            {
-                modifier: null,
                 node: asRuleNode({ type: 'Identifier' })
             },
             { allowSkippedWithComment: false }

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -2,6 +2,7 @@ import { type Rule, RuleTester, type SourceCode } from 'eslint';
 import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import {
+    checkPendingCallback,
     checkPendingSuite,
     checkPendingTestCase,
     fixPendingMemberExpression,
@@ -67,6 +68,15 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
             code: '// SKIP pending #201\ntest.skip("works", function() {})',
             options: [allowSkippedWithCommentOption]
         }),
+        {
+            code: '// SKIP pending #201\nit("works", function() { this.skip(); })',
+            options: [allowSkippedWithCommentOption]
+        },
+        {
+            code: '// SKIP pending #201\nbefore(function() { this.skip(); })',
+            options: [allowSkippedWithCommentOption]
+        },
+        'it("works", function() { function later() { this.skip(); } later.call(this); })',
         {
             code: 'xcustom()',
             settings: {
@@ -374,6 +384,23 @@ ruleTester.run('no-pending-tests', noPendingTestsRule, {
                 suggestions: [{ messageId: 'removePendingModifier', output: 'custom()' }]
             }]
         },
+        {
+            code: 'it("works", function() { this.skip(); })',
+            errors: [{ message: expectedErrorMessage, column: 31, line: 1 }]
+        },
+        {
+            code: 'before(function() { this.skip(); })',
+            errors: [{ message: expectedErrorMessage, column: 26, line: 1 }]
+        },
+        {
+            code: 'it("works", function() { (() => this.skip())(); })',
+            errors: [{ message: expectedErrorMessage, column: 38, line: 1 }]
+        },
+        {
+            code: 'it("works", function() { this.skip(); })',
+            options: [allowSkippedWithCommentOption],
+            errors: [{ message: expectedMissingCommentMessage, column: 31, line: 1 }]
+        },
         withInterface('TDD', {
             code: 'var dynamicOnly = "skip"; suite[dynamicOnly]()',
             errors: [{ message: expectedErrorMessage, column: 33, line: 1 }]
@@ -412,6 +439,26 @@ describe('no-pending-tests helpers', function () {
             }),
             {
                 modifier: 'pending',
+                node: asRuleNode({ type: 'Identifier' })
+            },
+            { allowSkippedWithComment: false }
+        );
+
+        assert.deepStrictEqual(reports, []);
+    });
+
+    it('checkPendingCallback() ignores non-function nodes', function () {
+        const reports: string[] = [];
+
+        checkPendingCallback(
+            asRuleContext({
+                report() {
+                    reports.push('reported');
+                },
+                sourceCode: asSourceCode({ visitorKeys: {} })
+            }),
+            {
+                modifier: null,
                 node: asRuleNode({ type: 'Identifier' })
             },
             { allowSkippedWithComment: false }

--- a/source/rules/no-pending-tests.test.ts
+++ b/source/rules/no-pending-tests.test.ts
@@ -446,6 +446,39 @@ describe('no-pending-tests helpers', function () {
         assert.deepStrictEqual(reports, []);
     });
 
+    it('checkPendingSuite() handles this.skip() calls when skipped comments are allowed', function () {
+        const reports: string[] = [];
+
+        checkPendingSuite(
+            asRuleContext({
+                report() {
+                    reports.push('reported');
+                },
+                sourceCode: asSourceCode({
+                    getCommentsBefore() {
+                        return [];
+                    }
+                })
+            }),
+            {
+                modifier: 'pending',
+                node: asRuleNode({
+                    arguments: [],
+                    callee: {
+                        computed: false,
+                        object: { type: 'ThisExpression' },
+                        property: { name: 'skip', type: 'Identifier' },
+                        type: 'MemberExpression'
+                    },
+                    type: 'CallExpression'
+                })
+            },
+            { allowSkippedWithComment: true }
+        );
+
+        assert.deepStrictEqual(reports, ['reported']);
+    });
+
     it('isPendingMemberExpression() returns false for non-member-expression callees', function () {
         const result = isPendingMemberExpression({ type: 'Identifier', name: 'xdescribe' } as never);
 

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -1,9 +1,12 @@
 import type { Rule, SourceCode } from 'eslint';
 import type { Comment as EstreeComment } from 'estree';
+import type { Except } from 'type-fest';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 import {
     type CallExpression,
+    getParentNode,
     isCallExpression,
+    isFunction,
     isIdentifier,
     isLiteral,
     isMemberExpression,
@@ -48,6 +51,7 @@ type KnownLocation = Locatable & {
     readonly loc: NonNullable<Locatable['loc']>;
 };
 type KnownLocationComment = EstreeComment & KnownLocation;
+type TraversableNode = Except<Rule.Node, 'parent'>;
 
 export function isCallbackMissing(node: CallExpression): boolean {
     const [firstArgument] = node.arguments;
@@ -86,6 +90,16 @@ export function isPendingMemberExpression(
         (callee.computed && isLiteralSkipProperty(property));
 }
 
+function isThisSkipMemberExpression(
+    callee: Readonly<CallExpression['callee']>
+): callee is Extract<CallExpression['callee'], { type: 'MemberExpression'; }> {
+    return isPendingMemberExpression(callee) && callee.object.type === 'ThisExpression';
+}
+
+function isThisSkipCall(node: Readonly<CallExpression>): boolean {
+    return isThisSkipMemberExpression(node.callee);
+}
+
 export function fixPendingMemberExpression(
     fixer: Rule.RuleFixer,
     sourceCode: Readonly<SourceCode>,
@@ -109,7 +123,12 @@ function fixPendingTest(
 }
 
 function canSuggestPendingTest(node: Readonly<CallExpression>): boolean {
-    return (isIdentifier(node.callee) && node.callee.name.startsWith('x')) || isPendingMemberExpression(node.callee);
+    return (isIdentifier(node.callee) && node.callee.name.startsWith('x')) ||
+        (isPendingMemberExpression(node.callee) && !isThisSkipMemberExpression(node.callee));
+}
+
+function isSkippedCall(node: Readonly<CallExpression>): boolean {
+    return canSuggestPendingTest(node) || isThisSkipCall(node);
 }
 
 function hasKnownLocation(
@@ -150,8 +169,54 @@ function shouldAllowSkippedWithComment(
     configuration: Readonly<PendingRuleConfiguration>
 ): boolean {
     return configuration.allowSkippedWithComment &&
-        canSuggestPendingTest(node) &&
+        isSkippedCall(node) &&
         hasAdjacentLeadingComment(context.sourceCode, node);
+}
+
+function getNodeProperty(node: TraversableNode, key: string): unknown {
+    return Reflect.get(node, key);
+}
+
+function isNode(value: unknown): value is TraversableNode {
+    return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function visitChildNodes(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (childNode: TraversableNode) => void
+): void {
+    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
+        const value = getNodeProperty(node, key);
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (isNode(item)) {
+                    visitor(item);
+                }
+            });
+        } else if (isNode(value)) {
+            visitor(value);
+        }
+    }
+}
+
+function visitThisSkipCalls(
+    sourceCode: Readonly<SourceCode>,
+    node: TraversableNode,
+    visitor: (callExpression: Readonly<CallExpression>) => void
+): void {
+    if (isCallExpression(node) && isThisSkipCall(node)) {
+        visitor(node);
+    }
+
+    if (isFunction(node) && node.type !== 'ArrowFunctionExpression') {
+        return;
+    }
+
+    visitChildNodes(sourceCode, node, (childNode) => {
+        visitThisSkipCalls(sourceCode, childNode, visitor);
+    });
 }
 
 export function reportSkipped(
@@ -226,6 +291,34 @@ export function checkPendingSuite(
     }
 }
 
+export function checkPendingCallback(
+    context: Readonly<Rule.RuleContext>,
+    visitorContext: PendingVisitorContext,
+    configuration: Readonly<PendingRuleConfiguration>
+): void {
+    if (!isFunction(visitorContext.node)) {
+        return;
+    }
+
+    const callbackParent = getParentNode(visitorContext.node);
+
+    visitThisSkipCalls(context.sourceCode, visitorContext.node.body, (thisSkipCall) => {
+        if (
+            configuration.allowSkippedWithComment &&
+            (hasAdjacentLeadingComment(context.sourceCode, thisSkipCall) ||
+                hasAdjacentLeadingComment(context.sourceCode, callbackParent))
+        ) {
+            return;
+        }
+
+        reportSkipped(
+            context,
+            thisSkipCall,
+            configuration.allowSkippedWithComment ? 'unexpectedSkippedTestWithoutComment' : 'unexpectedPendingTest'
+        );
+    });
+}
+
 export const noPendingTestsRule: Rule.RuleModule = {
     meta: {
         type: 'suggestion',
@@ -253,6 +346,10 @@ export const noPendingTestsRule: Rule.RuleModule = {
 
             suite(visitorContext) {
                 checkPendingSuite(context, visitorContext, configuration);
+            },
+
+            anyTestEntityCallback(visitorContext) {
+                checkPendingCallback(context, visitorContext, configuration);
             }
         });
     }

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -291,7 +291,7 @@ export function checkPendingSuite(
     }
 }
 
-export function checkPendingCallback(
+function checkPendingCallback(
     context: Readonly<Rule.RuleContext>,
     visitorContext: PendingVisitorContext,
     configuration: Readonly<PendingRuleConfiguration>

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -1,8 +1,8 @@
 import type { Rule, SourceCode } from 'eslint';
 import type { Comment as EstreeComment } from 'estree';
-import type { Except } from 'type-fest';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
 import {
+    type AnyFunction,
     type CallExpression,
     getParentNode,
     isCallExpression,
@@ -12,6 +12,7 @@ import {
     isMemberExpression,
     type MemberExpression
 } from '../ast/node-types.js';
+import { type TraversableNode, visitChildNodes } from '../ast/visit-child-nodes.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 const optionSchema = {
@@ -51,7 +52,6 @@ type KnownLocation = Locatable & {
     readonly loc: NonNullable<Locatable['loc']>;
 };
 type KnownLocationComment = EstreeComment & KnownLocation;
-type TraversableNode = Except<Rule.Node, 'parent'>;
 
 export function isCallbackMissing(node: CallExpression): boolean {
     const [firstArgument] = node.arguments;
@@ -173,34 +173,6 @@ function shouldAllowSkippedWithComment(
         hasAdjacentLeadingComment(context.sourceCode, node);
 }
 
-function getNodeProperty(node: TraversableNode, key: string): unknown {
-    return Reflect.get(node, key);
-}
-
-function isNode(value: unknown): value is TraversableNode {
-    return typeof value === 'object' && value !== null && 'type' in value;
-}
-
-function visitChildNodes(
-    sourceCode: Readonly<SourceCode>,
-    node: TraversableNode,
-    visitor: (childNode: TraversableNode) => void
-): void {
-    for (const key of sourceCode.visitorKeys[node.type] ?? []) {
-        const value = getNodeProperty(node, key);
-
-        if (Array.isArray(value)) {
-            value.forEach((item) => {
-                if (isNode(item)) {
-                    visitor(item);
-                }
-            });
-        } else if (isNode(value)) {
-            visitor(value);
-        }
-    }
-}
-
 function visitThisSkipCalls(
     sourceCode: Readonly<SourceCode>,
     node: TraversableNode,
@@ -293,16 +265,12 @@ export function checkPendingSuite(
 
 function checkPendingCallback(
     context: Readonly<Rule.RuleContext>,
-    visitorContext: PendingVisitorContext,
+    callbackNode: Readonly<AnyFunction>,
     configuration: Readonly<PendingRuleConfiguration>
 ): void {
-    if (!isFunction(visitorContext.node)) {
-        return;
-    }
+    const callbackParent = getParentNode(callbackNode);
 
-    const callbackParent = getParentNode(visitorContext.node);
-
-    visitThisSkipCalls(context.sourceCode, visitorContext.node.body, (thisSkipCall) => {
+    visitThisSkipCalls(context.sourceCode, callbackNode.body, (thisSkipCall) => {
         if (
             configuration.allowSkippedWithComment &&
             (hasAdjacentLeadingComment(context.sourceCode, thisSkipCall) ||
@@ -349,7 +317,7 @@ export const noPendingTestsRule: Rule.RuleModule = {
             },
 
             anyTestEntityCallback(visitorContext) {
-                checkPendingCallback(context, visitorContext, configuration);
+                checkPendingCallback(context, visitorContext.node, configuration);
             }
         });
     }


### PR DESCRIPTION
Teach mocha/no-pending-tests to report runtime skips triggered with this.skip() inside test and hook callbacks.
Reuse the existing commented-skip option for documented this.skip() cases.