### PR TITLE
Add rule no-async-and-done to forbid async callbacks with done

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
+| [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty test descriptions                                        | ✅  |    |    |    |    |

--- a/documentation/rules/no-async-and-done.md
+++ b/documentation/rules/no-async-and-done.md
@@ -1,0 +1,44 @@
+# Disallow async functions that also use a Mocha callback (`mocha/no-async-and-done`)
+
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Mocha supports asynchronous tests and hooks in three distinct ways:
+
+- Provide a callback parameter such as `done`
+- Return a promise
+- Use an `async` function
+
+Mixing an `async` function with a callback parameter does both at once and triggers Mocha's "overspecified resolution method" error.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+it("loads data", async function (done) {
+    done();
+});
+
+beforeEach(async (done) => {
+    await setup();
+    done();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it("loads data", function (done) {
+    loadData(done);
+});
+
+it("loads data", async function () {
+    await loadData();
+});
+```
+
+## Further Reading
+
+- [Asynchronous code](https://mochajs.org/#asynchronous-code)

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -6,6 +6,7 @@ import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-b
 import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
+import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
 import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
@@ -37,6 +38,7 @@ const allRules: Linter.RulesRecord = {
     ],
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': 'error',
+    'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'error',
@@ -66,6 +68,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-structure': ['error', { disallowDuplicateHooks: true }],
     'mocha/handle-done-callback': 'error',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
+    'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'off',
     'mocha/no-async-suite': 'error',
     'mocha/no-exclusive-tests': 'warn',
@@ -95,6 +98,7 @@ const rules = {
     'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
+    'no-async-and-done': noAsyncAndDoneRule,
     'no-async-in-sync-tests': noAsyncInSyncTestsRule,
     'no-async-suite': noAsyncSuiteRule,
     'no-exclusive-tests': noExclusiveTestsRule,

--- a/source/rules/no-async-and-done.test.ts
+++ b/source/rules/no-async-and-done.test.ts
@@ -1,0 +1,92 @@
+import * as typescriptParser from '@typescript-eslint/parser';
+import { type Rule, RuleTester } from 'eslint';
+import assert from 'node:assert';
+import { checkNodeForAsyncAndDone, noAsyncAndDoneRule } from './no-async-and-done.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const message = 'Do not use an async function together with a Mocha callback parameter';
+const es6LanguageOptions = {
+    sourceType: 'module',
+    ecmaVersion: 8
+} as const;
+const typescriptLanguageOptions = { parser: typescriptParser };
+
+ruleTester.run('no-async-and-done', noAsyncAndDoneRule, {
+    valid: [
+        {
+            code: 'it("title", function(done) {});'
+        },
+        {
+            code: 'it("title", async function() {});',
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'it("title", async function() { async function other(done) {} });',
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'it("title", function() { const other = async function(done) {}; });',
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'notMocha("title", async function(done) {});',
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'it("title", async function(this: Context) {});',
+            languageOptions: typescriptLanguageOptions
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'it("title", async function(done) {});',
+            errors: [{ message, column: 13, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'it("title", async (done) => {});',
+            errors: [{ message, column: 13, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'it.only("title", async function(done) {});',
+            errors: [{ message, column: 18, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'before("title", async function(done) {});',
+            errors: [{ message, column: 17, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'beforeEach("title", async function(done) {});',
+            errors: [{ message, column: 21, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'after("title", async function(done) {});',
+            errors: [{ message, column: 16, line: 1 }],
+            languageOptions: es6LanguageOptions
+        },
+        {
+            code: 'afterEach("title", async function(done) {});',
+            errors: [{ message, column: 20, line: 1 }],
+            languageOptions: es6LanguageOptions
+        }
+    ]
+});
+
+describe('no-async-and-done helpers', function () {
+    it('checkNodeForAsyncAndDone() ignores non-function nodes', function () {
+        const reports: string[] = [];
+
+        checkNodeForAsyncAndDone({
+            report() {
+                reports.push('reported');
+            }
+        } as unknown as Rule.RuleContext, { type: 'Identifier' } as Rule.Node);
+
+        assert.deepStrictEqual(reports, []);
+    });
+});

--- a/source/rules/no-async-and-done.ts
+++ b/source/rules/no-async-and-done.ts
@@ -1,0 +1,49 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type AnyFunction, isFunction, isIdentifier } from '../ast/node-types.js';
+
+function isTypeScriptThisParameter(param: AnyFunction['params'][number] | undefined): boolean {
+    return param !== undefined && isIdentifier(param) && param.name === 'this';
+}
+
+function getFirstMeaningfulParameter(node: Readonly<AnyFunction>): AnyFunction['params'][number] | undefined {
+    const [firstParam, secondParam] = node.params;
+    return isTypeScriptThisParameter(firstParam) ? secondParam : firstParam;
+}
+
+function hasDoneCallbackParameter(node: Readonly<AnyFunction>): boolean {
+    return getFirstMeaningfulParameter(node) !== undefined;
+}
+
+export function checkNodeForAsyncAndDone(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
+    if (!isFunction(node) || node.async !== true || !hasDoneCallbackParameter(node)) {
+        return;
+    }
+
+    context.report({
+        node,
+        messageId: 'unexpectedAsyncAndDone'
+    });
+}
+
+export const noAsyncAndDoneRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'problem',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow async functions that also use a Mocha callback',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-async-and-done.md'
+        },
+        messages: {
+            unexpectedAsyncAndDone: 'Do not use an async function together with a Mocha callback parameter'
+        },
+        schema: []
+    },
+    create(context) {
+        return createMochaVisitors(context, {
+            anyTestEntityCallback(visitorContext) {
+                checkNodeForAsyncAndDone(context, visitorContext.node);
+            }
+        });
+    }
+};


### PR DESCRIPTION
Add a new mocha/no-async-and-done rule to catch tests and hooks that mix async functions with callback completion.
Enable the rule in the recommended config and document the new behavior.