### PR TITLE
Add `limit-timeout` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
+| [limit-timeout](documentation/rules/limit-timeout.md)                                         | Enforce limits for Mocha timeouts                                       |    |    | ✅  |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |

--- a/benchmarks/runtime.bench.ts
+++ b/benchmarks/runtime.bench.ts
@@ -81,7 +81,7 @@ const iterations = 50;
 
 describe('runtime', function () {
     it('should not take longer as the defined budget to lint many files with the recommended config', function () {
-        const cpuAgnosticBudget = 2_300_000;
+        const cpuAgnosticBudget = 2_325_000;
         const budget = cpuAgnosticBudget / cpuSpeed;
 
         const { medianDuration } = runSyncBenchmark(() => {

--- a/documentation/rules/limit-timeout.md
+++ b/documentation/rules/limit-timeout.md
@@ -1,0 +1,84 @@
+# Enforce limits for Mocha timeouts (`mocha/limit-timeout`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Mocha lets suites, tests, and hooks override their timeout with `this.timeout(...)` or chained calls such as `it(...).timeout(...)`. This rule lets you forbid timeout configuration entirely or constrain the values that are allowed.
+
+This rule applies to:
+
+- `this.timeout(...)` inside suite, test, and hook callbacks
+- `describe(...).timeout(...)`, `it(...).timeout(...)`, and hook variants
+- TDD interface equivalents such as `suite(...).timeout(...)` and `test(...).timeout(...)`
+- Equivalent configured custom names
+
+With `mode: "disallow"`, getter-style calls such as `this.timeout()` and `it(...).timeout()` are also reported. Other modes only check calls with a statically known numeric argument.
+
+## Options
+
+This rule supports the following options:
+
+- `{ "mode": "disallow" }`: Reports every Mocha timeout call.
+- `{ "mode": "disallowDisabled" }`: Reports timeout values that disable timeouts. In current Mocha behavior, that includes values less than or equal to `0` and values greater than or equal to `2^31 - 1`.
+- `{ "mode": "max", "max": 5000 }`: Reports statically known numeric timeout values greater than `max`.
+- `{ "mode": "range", "min": 1, "max": 5000 }`: Reports statically known numeric timeout values outside the inclusive range.
+
+For `max` and `range`, unresolved dynamic values and string shorthands such as `"2s"` are ignored.
+
+```json
+{
+    "rules": {
+        "mocha/limit-timeout": ["error", {
+            "mode": "range",
+            "min": 1,
+            "max": 5000
+        }]
+    }
+}
+```
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+it('works', function () {}).timeout(5000);
+
+describe('suite', function () {
+    this.timeout(0);
+});
+
+beforeEach(function () {}).timeout(10_000);
+```
+
+Examples of correct code for this rule with `{ "mode": "range", "min": 1, "max": 5000 }`:
+
+```js
+it('works', function () {});
+
+it('works', function () {}).timeout(5000);
+
+describe('suite', function () {
+    this.timeout(2500);
+});
+```
+
+Examples of correct code for this rule with `{ "mode": "disallowDisabled" }`:
+
+```js
+it('works', function () {}).timeout(5000);
+
+describe('suite', function () {
+    this.timeout(2500);
+});
+```
+
+## When Not To Use It
+
+- If your project allows arbitrary Mocha timeout configuration.
+- If your project relies heavily on dynamic or string-based timeout values and you need exhaustive checking for those forms.
+
+## Further Reading
+
+- [Mocha Timeouts](https://mochajs.org/features/timeouts/)

--- a/source/ast/listener-record.ts
+++ b/source/ast/listener-record.ts
@@ -1,0 +1,14 @@
+import type { Rule } from 'eslint';
+
+export function createListenerRecord<Name extends keyof Rule.RuleListener>(
+    name: Name,
+    listener: Rule.RuleListener[Name]
+): Partial<Rule.RuleListener> {
+    const listeners: Partial<Rule.RuleListener> = {};
+
+    if (listener !== undefined) {
+        listeners[name] = listener;
+    }
+
+    return listeners;
+}

--- a/source/ast/mocha-visitors.test.ts
+++ b/source/ast/mocha-visitors.test.ts
@@ -34,6 +34,37 @@ ruleTester.run('mocha-visitors', programOnlyRule, {
     invalid: []
 });
 
+const configDispatchRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        schema: []
+    },
+    create(ruleContext) {
+        return createMochaVisitors(ruleContext, {
+            config(visitorContext) {
+                if (visitorContext.config === 'timeout') {
+                    ruleContext.report({
+                        node: visitorContext.node,
+                        message: `timeout:${visitorContext.name}`
+                    });
+                }
+            }
+        });
+    }
+};
+
+ruleTester.run('mocha-visitors config dispatch', configDispatchRule, {
+    valid: [
+        'it("name", function () {});',
+        'beforeEach(function () { this.timeout(1000); });'
+    ],
+    invalid: [
+        {
+            code: 'it("name", function () {}).timeout(1000);',
+            errors: [{ message: 'timeout:it().timeout()' }]
+        }
+    ]
+});
+
 describe('mocha visitor helpers', function () {
     it('dispatchCallback() ignores non-call-expression nodes', function () {
         let called = false;
@@ -41,6 +72,7 @@ describe('mocha visitor helpers', function () {
         dispatchCallback(function () {
             called = true;
         }, {
+            config: null,
             interface: 'BDD',
             modifier: null,
             name: 'it()',

--- a/source/ast/mocha-visitors.ts
+++ b/source/ast/mocha-visitors.ts
@@ -1,13 +1,14 @@
 import type { Rule, SourceCode } from 'eslint';
 import type { Except } from 'type-fest';
 import { getAllCustomNameDetails, getCustomNameDetailsForInterface } from '../mocha/all-name-details.js';
-import type { MochaEntityType, MochaInterface, MochaModifier } from '../mocha/descriptors.js';
+import type { MochaConfigCall, MochaEntityType, MochaInterface, MochaModifier } from '../mocha/descriptors.js';
 import { getAdditionalNames, getInterface } from '../settings.js';
 import { findMochaVariableCalls, type ResolvedReferenceWithNameDetails } from './find-mocha-variable-calls.js';
 import {
     type AnyFunctionExpressionNode,
     getFunctionExpressionLastArgument
 } from './function-expression-arguments.js';
+import { createListenerRecord } from './listener-record.js';
 import { isCallExpression } from './node-types.js';
 
 type MochaVisitor = (context: Readonly<VisitorContext>) => void;
@@ -18,6 +19,8 @@ type MemberExpressionNode = Parameters<ExpressionListener<'MemberExpression'>>[0
 type CallExpressionNodeVisitor = (node: CallExpressionNode) => void;
 type MochaCallbackVisitor = (context: Readonly<CallbackVisitorContext>) => void;
 type TestEntityVisitors = {
+    config?: MochaVisitor | undefined;
+    'config:exit'?: MochaVisitor | undefined;
     testCase?: MochaVisitor | undefined;
     'testCase:exit'?: MochaVisitor | undefined;
     testCaseCallback?: MochaCallbackVisitor | undefined;
@@ -76,6 +79,7 @@ export type VisitorContext = {
     name: string;
     node: Rule.Node;
     type: MochaEntityType;
+    config: MochaConfigCall | null;
     modifier: MochaModifier | null;
     interface: MochaInterface;
 };
@@ -86,6 +90,7 @@ type CachedMochaCall = {
 };
 
 type CallExpressionDispatchers = {
+    readonly config?: MochaVisitor | undefined;
     readonly testCase?: MochaVisitor | undefined;
     readonly testCaseCallback?: MochaCallbackVisitor | undefined;
     readonly suite?: MochaVisitor | undefined;
@@ -147,6 +152,7 @@ function createContext(reference: Readonly<ResolvedReferenceWithNameDetails>): R
         name: reference.name,
         node: reference.node,
         type: reference.nameDetails.type,
+        config: reference.nameDetails.config,
         modifier: reference.nameDetails.modifier,
         interface: reference.nameDetails.interface
     };
@@ -225,11 +231,12 @@ function dispatchCallExpressionContext(
     dispatchers: Readonly<CallExpressionDispatchers>,
     cachedMochaCall: Readonly<CachedMochaCall>
 ): void {
+    const context = createContext(cachedMochaCall.reference);
+
     if (kind === MochaEntityKind.Config) {
+        group?.visitor?.(context);
         return;
     }
-
-    const context = createContext(cachedMochaCall.reference);
 
     dispatchSpecificCallExpressionContext(group, dispatchers, context);
     dispatchers.anyTestEntity?.(context);
@@ -240,7 +247,7 @@ function createCallExpressionDispatcher(
     dispatchers: Readonly<CallExpressionDispatchers>
 ): CallExpressionDispatcher | undefined {
     const groups = {
-        [MochaEntityKind.Config]: undefined,
+        [MochaEntityKind.Config]: createCallExpressionDispatchGroup(dispatchers.config, undefined),
         [MochaEntityKind.TestCase]: createCallExpressionDispatchGroup(
             dispatchers.testCase,
             dispatchers.testCaseCallback,
@@ -256,14 +263,19 @@ function createCallExpressionDispatcher(
             dispatchers.hookCallback
         )
     } as const satisfies Readonly<Record<MochaEntityKind, Readonly<CallExpressionDispatchGroup> | undefined>>;
+    const hasDispatcher = [
+        groups[MochaEntityKind.Config],
+        groups[MochaEntityKind.TestCase],
+        groups[MochaEntityKind.Suite],
+        groups[MochaEntityKind.Hook],
+        dispatchers.anyTestEntity,
+        dispatchers.anyTestEntityCallback
+    ]
+        .some((dispatcher) => {
+            return dispatcher !== undefined;
+        });
 
-    if (
-        groups[MochaEntityKind.TestCase] === undefined &&
-        groups[MochaEntityKind.Suite] === undefined &&
-        groups[MochaEntityKind.Hook] === undefined &&
-        dispatchers.anyTestEntity === undefined &&
-        dispatchers.anyTestEntityCallback === undefined
-    ) {
+    if (!hasDispatcher) {
         return undefined;
     }
 
@@ -365,6 +377,8 @@ function splitMochaVisitors(visitors: Readonly<MochaVisitors>): Readonly<SplitMo
         nonMochaFunctionExpression,
         'mochaFunctionExpression:exit': mochaFunctionExpressionExit,
         'nonMochaFunctionExpression:exit': nonMochaFunctionExpressionExit,
+        config,
+        'config:exit': configExit,
         testCase,
         'testCase:exit': testCaseExit,
         testCaseCallback,
@@ -422,6 +436,7 @@ function splitMochaVisitors(visitors: Readonly<MochaVisitors>): Readonly<SplitMo
             }
         },
         enterDispatchers: {
+            config,
             testCase,
             testCaseCallback,
             suite,
@@ -433,6 +448,7 @@ function splitMochaVisitors(visitors: Readonly<MochaVisitors>): Readonly<SplitMo
             anyTestEntityCallback
         },
         exitDispatchers: {
+            config: configExit,
             testCase: testCaseExit,
             testCaseCallback: testCaseCallbackExit,
             suite: suiteExit,
@@ -471,18 +487,6 @@ function createExpressionRuleListener<Node extends FunctionExpressionNode | Memb
     return function (node): void {
         expressionVisitor(cachedMochaCallsByNode, node, listenerSet);
     };
-}
-
-function createListenerRecord<Name extends keyof Rule.RuleListener>(
-    name: Name,
-    listener: Rule.RuleListener[Name]
-): Partial<Rule.RuleListener> {
-    const listeners: Partial<Rule.RuleListener> = {};
-    if (listener !== undefined) {
-        listeners[name] = listener;
-    }
-
-    return listeners;
 }
 
 function createSpecificVisitors(

--- a/source/mocha/config-call.test.ts
+++ b/source/mocha/config-call.test.ts
@@ -1,0 +1,123 @@
+import { Linter, type Rule, type SourceCode } from 'eslint';
+import assert from 'node:assert';
+import type { TraversableNode } from '../ast/visit-child-nodes.js';
+import {
+    getConfigPropertyName,
+    getStaticNumericConfigValue,
+    isMochaContextConfigCall,
+    isSuiteConfigCall,
+    visitMochaContextConfigCalls
+} from './config-call.js';
+
+function readExpression(code: string): { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; } {
+    const linter = new Linter();
+    let result: { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; } | null = null;
+
+    const testRule: Rule.RuleModule = {
+        create(ruleContext) {
+            return {
+                Program() {
+                    const expressionStatement = ruleContext.sourceCode.ast.body.at(-1);
+                    assert.notStrictEqual(expressionStatement, undefined);
+                    assert.strictEqual(expressionStatement?.type, 'ExpressionStatement');
+
+                    result = {
+                        sourceCode: ruleContext.sourceCode,
+                        expression: expressionStatement.expression as unknown as Readonly<Rule.Node>
+                    };
+                }
+            };
+        }
+    };
+
+    const messages = linter.verify(code, {
+        plugins: { 'test-plugin': { rules: { 'test-rule': testRule } } },
+        languageOptions: { ecmaVersion: 2020, sourceType: 'script' },
+        rules: { 'test-plugin/test-rule': 'error' }
+    });
+    assert.deepStrictEqual(messages, []);
+    assert.notStrictEqual(result, null);
+
+    return result as unknown as { sourceCode: Readonly<SourceCode>; expression: Readonly<Rule.Node>; };
+}
+
+function asTraversableNode(node: Readonly<Rule.Node>): Readonly<TraversableNode> {
+    return node as unknown as Readonly<TraversableNode>;
+}
+
+describe('config call helpers', function () {
+    it('getConfigPropertyName() returns config names for direct and computed members', function () {
+        const timeoutExpression = readExpression('it("works", function () {}).timeout(5000);').expression;
+        const slowExpression = readExpression('it("works", function () {})["slow"](5000);').expression;
+        const otherExpression = readExpression('it("works", function () {})["only"]();').expression;
+
+        assert.strictEqual(timeoutExpression.type, 'CallExpression');
+        assert.strictEqual(slowExpression.type, 'CallExpression');
+        assert.strictEqual(otherExpression.type, 'CallExpression');
+
+        assert.strictEqual(getConfigPropertyName(timeoutExpression), 'timeout');
+        assert.strictEqual(getConfigPropertyName(slowExpression), 'slow');
+        assert.strictEqual(getConfigPropertyName(otherExpression), null);
+    });
+
+    it('isMochaContextConfigCall() and isSuiteConfigCall() detect this-bound config calls', function () {
+        const timeoutExpression = readExpression('this.timeout(5000);').expression;
+        const chainedExpression = readExpression('it("works", function () {}).timeout(5000);').expression;
+
+        assert.strictEqual(isMochaContextConfigCall(asTraversableNode(timeoutExpression), 'timeout'), true);
+        assert.strictEqual(isMochaContextConfigCall(asTraversableNode(timeoutExpression), 'slow'), false);
+        assert.strictEqual(isSuiteConfigCall(asTraversableNode(timeoutExpression)), true);
+        assert.strictEqual(isSuiteConfigCall(asTraversableNode(chainedExpression)), false);
+    });
+
+    it('getStaticNumericConfigValue() resolves static numeric arguments', function () {
+        const literalExpression = readExpression('it("works", function () {}).retries(2);');
+        const constantExpression = readExpression(
+            'const retryCount = 2; it("works", function () {}).retries(retryCount);'
+        );
+
+        assert.strictEqual(literalExpression.expression.type, 'CallExpression');
+        assert.strictEqual(constantExpression.expression.type, 'CallExpression');
+
+        assert.strictEqual(getStaticNumericConfigValue(literalExpression.expression, literalExpression.sourceCode), 2);
+        assert.strictEqual(
+            getStaticNumericConfigValue(constantExpression.expression, constantExpression.sourceCode),
+            2
+        );
+    });
+
+    it('getStaticNumericConfigValue() returns null for spread and non-numeric values', function () {
+        const spreadExpression = readExpression('it("works", function () {}).timeout(...values);');
+        const stringExpression = readExpression('it("works", function () {}).timeout("2s");');
+
+        assert.strictEqual(spreadExpression.expression.type, 'CallExpression');
+        assert.strictEqual(stringExpression.expression.type, 'CallExpression');
+
+        assert.strictEqual(getStaticNumericConfigValue(spreadExpression.expression, spreadExpression.sourceCode), null);
+        assert.strictEqual(getStaticNumericConfigValue(stringExpression.expression, stringExpression.sourceCode), null);
+    });
+
+    it('visitMochaContextConfigCalls() skips nested non-arrow functions', function () {
+        const { sourceCode, expression } = readExpression(
+            'it("works", function () { this.timeout(1000); (() => this.timeout(2000))(); function later() { this.timeout(3000); } });'
+        );
+        const visitedTimeouts: number[] = [];
+
+        assert.strictEqual(expression.type, 'CallExpression');
+        const callbackBody = expression.arguments[1];
+        assert.notStrictEqual(callbackBody, undefined);
+        assert.notStrictEqual(callbackBody?.type, 'SpreadElement');
+        assert.strictEqual(callbackBody?.type, 'FunctionExpression');
+
+        visitMochaContextConfigCalls(sourceCode, callbackBody.body, 'timeout', (callExpression) => {
+            const timeoutValue = getStaticNumericConfigValue(callExpression, sourceCode);
+            if (timeoutValue === null) {
+                throw new Error('Expected static timeout value');
+            }
+
+            visitedTimeouts.push(timeoutValue);
+        });
+
+        assert.deepStrictEqual(visitedTimeouts, [1000, 2000]);
+    });
+});

--- a/source/mocha/config-call.ts
+++ b/source/mocha/config-call.ts
@@ -1,33 +1,128 @@
-import type { Rule } from 'eslint';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import { getStaticValue } from '@eslint-community/eslint-utils';
+import type { SourceCode } from 'eslint';
+import {
+    type CallExpression,
+    isCallExpression,
+    isFunction,
+    isIdentifier,
+    isLiteral,
+    isMemberExpression
+} from '../ast/node-types.js';
+import { type TraversableNode, visitChildNodes } from '../ast/visit-child-nodes.js';
+import { configCallNames, type MochaConfigCall } from './descriptors.js';
 
-const suiteConfig = new Set(['timeout', 'slow', 'retries']);
+const suiteConfig = new Set<string>(configCallNames);
+const maximumTimeout = Number.parseInt('2147483647', 10);
 
-function getPropertyName(
-    property: { name: undefined; value: string; } | { readonly name: string; readonly value: undefined; }
-): string {
-    return property.name ?? property.value;
+function isMochaConfigCallName(value: string): value is MochaConfigCall {
+    return suiteConfig.has(value);
 }
 
-function isSuiteConfigExpression(node: Readonly<CallExpression['callee']>): boolean {
-    if (node.type !== 'MemberExpression') {
+function getNamedConfigPropertyName(property: Readonly<CallExpression['callee']>): MochaConfigCall | null {
+    if (!isMemberExpression(property) || !isIdentifier(property.property) || property.computed) {
+        return null;
+    }
+
+    return isMochaConfigCallName(property.property.name)
+        ? property.property.name
+        : null;
+}
+
+function getComputedConfigPropertyName(property: Readonly<CallExpression['callee']>): MochaConfigCall | null {
+    if (!isMemberExpression(property) || !property.computed || !isLiteral(property.property)) {
+        return null;
+    }
+
+    return typeof property.property.value === 'string' && isMochaConfigCallName(property.property.value)
+        ? property.property.value
+        : null;
+}
+
+function getPropertyName(
+    property: Readonly<CallExpression['callee']>
+): MochaConfigCall | null {
+    return getNamedConfigPropertyName(property) ?? getComputedConfigPropertyName(property);
+}
+
+function getMochaContextConfigExpression(
+    callee: Readonly<CallExpression['callee']>
+): Readonly<Extract<CallExpression['callee'], { type: 'MemberExpression'; }>> | null {
+    if (!isMemberExpression(callee) || callee.object.type !== 'ThisExpression') {
+        return null;
+    }
+
+    return getPropertyName(callee) === null
+        ? null
+        : callee;
+}
+
+function getFirstArgument(
+    node: Readonly<CallExpression>
+): Readonly<CallExpression['arguments'][number]> | undefined {
+    const [firstArgument] = node.arguments;
+
+    return firstArgument?.type === 'SpreadElement' ? undefined : firstArgument;
+}
+
+export function getConfigPropertyName(node: Readonly<CallExpression>): MochaConfigCall | null {
+    return getPropertyName(node.callee);
+}
+
+export function isMochaContextConfigCall(
+    node: Readonly<TraversableNode>,
+    configName?: MochaConfigCall
+): node is CallExpression {
+    if (!isCallExpression(node)) {
         return false;
     }
 
-    const usingThis = node.object.type === 'ThisExpression';
+    const propertyName = getPropertyName(node.callee);
+    const matchingContextExpression = getMochaContextConfigExpression(node.callee);
 
-    if (usingThis) {
-        return suiteConfig.has(
-            getPropertyName(
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ok
-                node.property as unknown as { name: string; value: undefined; } | { name: undefined; value: string; }
-            )
-        );
-    }
-
-    return false;
+    return matchingContextExpression !== null &&
+        (configName === undefined || propertyName === configName);
 }
 
-export function isSuiteConfigCall(node: Readonly<Rule.Node>): boolean {
-    return isCallExpression(node) && isSuiteConfigExpression(node.callee);
+export function isSuiteConfigCall(node: Readonly<TraversableNode>): boolean {
+    return isMochaContextConfigCall(node);
+}
+
+export function getStaticNumericConfigValue(
+    node: Readonly<CallExpression>,
+    sourceCode: Readonly<SourceCode>
+): number | null {
+    const firstArgument = getFirstArgument(node);
+
+    if (firstArgument === undefined) {
+        return null;
+    }
+
+    const staticValue = getStaticValue(firstArgument, sourceCode.getScope(firstArgument));
+
+    return staticValue !== null && typeof staticValue.value === 'number' && Number.isFinite(staticValue.value)
+        ? staticValue.value
+        : null;
+}
+
+export function isDisabledTimeoutValue(value: number): boolean {
+    return value <= 0 || value >= maximumTimeout;
+}
+
+export function visitMochaContextConfigCalls(
+    sourceCode: Readonly<SourceCode>,
+    node: Readonly<TraversableNode>,
+    configName: MochaConfigCall,
+    visitor: (callExpression: Readonly<CallExpression>) => void
+): void {
+    if (isMochaContextConfigCall(node, configName)) {
+        visitor(node);
+    }
+
+    if (isFunction(node) && node.type !== 'ArrowFunctionExpression') {
+        return;
+    }
+
+    visitChildNodes(sourceCode, node, (childNode) => {
+        visitMochaContextConfigCalls(sourceCode, childNode, configName, visitor);
+    });
 }

--- a/source/mocha/config-call.ts
+++ b/source/mocha/config-call.ts
@@ -6,13 +6,16 @@ import {
     isFunction,
     isIdentifier,
     isLiteral,
-    isMemberExpression
+    isMemberExpression,
+    type MemberExpression
 } from '../ast/node-types.js';
 import { type TraversableNode, visitChildNodes } from '../ast/visit-child-nodes.js';
 import { configCallNames, type MochaConfigCall } from './descriptors.js';
 
 const suiteConfig = new Set<string>(configCallNames);
 const maximumTimeout = Number.parseInt('2147483647', 10);
+
+export type MochaConfigCallExpression = Readonly<CallExpression> & { readonly callee: MemberExpression; };
 
 function isMochaConfigCallName(value: string): value is MochaConfigCall {
     return suiteConfig.has(value);
@@ -71,7 +74,7 @@ export function getConfigPropertyName(node: Readonly<CallExpression>): MochaConf
 export function isMochaContextConfigCall(
     node: Readonly<TraversableNode>,
     configName?: MochaConfigCall
-): node is CallExpression {
+): node is MochaConfigCallExpression {
     if (!isCallExpression(node)) {
         return false;
     }
@@ -112,7 +115,7 @@ export function visitMochaContextConfigCalls(
     sourceCode: Readonly<SourceCode>,
     node: Readonly<TraversableNode>,
     configName: MochaConfigCall,
-    visitor: (callExpression: Readonly<CallExpression>) => void
+    visitor: (callExpression: MochaConfigCallExpression) => void
 ): void {
     if (isMochaContextConfigCall(node, configName)) {
         visitor(node);

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -5,6 +5,7 @@ import { consistentInterfaceRule } from './rules/consistent-interface.js';
 import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-between-blocks.js';
 import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
+import { limitTimeoutRule } from './rules/limit-timeout.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
 import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
 import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
@@ -39,6 +40,7 @@ const allRules: Linter.RulesRecord = {
         { order: 'hooks-tests-suites', disallowDuplicateHooks: true, disallowMixedTestsAndSuites: true }
     ],
     'mocha/handle-done-callback': 'error',
+    'mocha/limit-timeout': 'error',
     'mocha/max-top-level-suites': 'error',
     'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'error',
@@ -71,6 +73,7 @@ const allRules: Linter.RulesRecord = {
 const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-structure': ['error', { disallowDuplicateHooks: true }],
     'mocha/handle-done-callback': 'error',
+    'mocha/limit-timeout': 'off',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
     'mocha/no-async-and-done': 'error',
     'mocha/no-async-in-sync-tests': 'off',
@@ -103,6 +106,7 @@ const recommendedRules: Linter.RulesRecord = {
 const rules = {
     'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
+    'limit-timeout': limitTimeoutRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
     'no-async-and-done': noAsyncAndDoneRule,
     'no-async-in-sync-tests': noAsyncInSyncTestsRule,

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -237,6 +237,7 @@ describe('consistent-structure helpers', function () {
         assert.throws(
             function () {
                 getStructureEntityKind({
+                    config: 'timeout',
                     interface: 'BDD',
                     modifier: null,
                     name: 'timeout',
@@ -251,6 +252,7 @@ describe('consistent-structure helpers', function () {
     it('getDirectStructureContext() returns null when no structure layer exists', function () {
         const { expression: node } = readExpression('foo;');
         const result = getDirectStructureContext([], {
+            config: null,
             interface: 'BDD',
             modifier: null,
             name: 'describe',
@@ -279,6 +281,7 @@ describe('consistent-structure helpers', function () {
                 usedHookNames: new Set()
             }],
             {
+                config: null,
                 interface: 'BDD',
                 modifier: null,
                 name: 'it',

--- a/source/rules/limit-timeout.test.ts
+++ b/source/rules/limit-timeout.test.ts
@@ -1,4 +1,5 @@
-import { RuleTester } from 'eslint';
+import { Linter, RuleTester } from 'eslint';
+import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import { limitTimeoutRule } from './limit-timeout.js';
 
@@ -142,4 +143,26 @@ ruleTester.run('limit-timeout', limitTimeoutRule, {
             errors: [{ message: unexpectedTimeout }]
         }
     ]
+});
+
+describe('limit-timeout', function () {
+    it('throws when the configured range is invalid', function () {
+        const linter = new Linter();
+
+        assert.throws(
+            function () {
+                linter.verify('it("works", function () {}).timeout(5000);', {
+                    plugins: { 'test-plugin': { rules: { 'limit-timeout': limitTimeoutRule } } },
+                    languageOptions: { sourceType: 'script' },
+                    rules: {
+                        'test-plugin/limit-timeout': ['error', { mode: 'range', min: 10, max: 1 }]
+                    }
+                });
+            },
+            function (error: unknown) {
+                return error instanceof Error &&
+                    error.message.includes('`min` must be less than or equal to `max`.');
+            }
+        );
+    });
 });

--- a/source/rules/limit-timeout.test.ts
+++ b/source/rules/limit-timeout.test.ts
@@ -1,0 +1,145 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { limitTimeoutRule } from './limit-timeout.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const unexpectedTimeout = 'Unexpected use of Mocha timeout configuration.';
+const unexpectedDisabledTimeout = 'Unexpected disabled Mocha timeout.';
+
+ruleTester.run('limit-timeout', limitTimeoutRule, {
+    valid: [
+        'it("works", function () {});',
+        'it("works", function () {}).slow(5000);',
+        {
+            code: 'it("works", function () {}).timeout();',
+            options: [{ mode: 'max', max: 5000 }]
+        },
+        {
+            code: 'it("works", function () {}).timeout(5000);',
+            options: [{ mode: 'max', max: 5000 }]
+        },
+        {
+            code: 'describe("suite", function () { this.timeout(5000); });',
+            options: [{ mode: 'max', max: 5000 }]
+        },
+        {
+            code: 'it("works", function () { this["timeout"](5000); });',
+            options: [{ mode: 'range', min: 1, max: 5000 }]
+        },
+        {
+            code: 'it("works", function () { (() => this.timeout(5000))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'range', min: 1, max: 5000 }]
+        },
+        {
+            code: 'it("works", function () { function later() { this.timeout(0); } });',
+            options: [{ mode: 'disallowDisabled' }]
+        },
+        {
+            code: 'const configuredTimeout = 5000; it("works", function () {}).timeout(configuredTimeout);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 5000 }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).timeout(5000);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            options: [{ mode: 'max', max: 5000 }],
+            settings: { mocha: { interface: 'require' } }
+        },
+        {
+            code: 'custom("works", function () {}).timeout(5000);',
+            options: [{ mode: 'max', max: 5000 }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            }
+        },
+        withInterface('TDD', {
+            code: 'test("works", function () {}).timeout(5000);',
+            options: [{ mode: 'range', min: 1, max: 5000 }]
+        })
+    ],
+
+    invalid: [
+        {
+            code: 'it("works", function () {}).timeout(5000);',
+            errors: [{ message: unexpectedTimeout }]
+        },
+        {
+            code: 'describe("suite", function () { this.timeout(5000); });',
+            errors: [{ message: unexpectedTimeout }]
+        },
+        {
+            code: 'it("works", function () { (() => this.timeout(5000))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [{ message: unexpectedTimeout }]
+        },
+        {
+            code: 'it("works", function () {}).timeout(0);',
+            options: [{ mode: 'disallowDisabled' }],
+            errors: [{ message: unexpectedDisabledTimeout }]
+        },
+        {
+            code: 'it("works", function () { this.timeout(-1); });',
+            options: [{ mode: 'disallowDisabled' }],
+            errors: [{ message: unexpectedDisabledTimeout }]
+        },
+        {
+            code: 'const disabledTimeout = 2147483647; it("works", function () {}).timeout(disabledTimeout);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'disallowDisabled' }],
+            errors: [{ message: unexpectedDisabledTimeout }]
+        },
+        {
+            code: 'it("works", function () {}).timeout(5001);',
+            options: [{ mode: 'max', max: 5000 }],
+            errors: [{
+                message: 'Unexpected Mocha timeout value 5001. Maximum allowed is 5000.'
+            }]
+        },
+        {
+            code: 'const configuredTimeout = 5001; it("works", function () {}).timeout(configuredTimeout);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 5000 }],
+            errors: [{
+                message: 'Unexpected Mocha timeout value 5001. Maximum allowed is 5000.'
+            }]
+        },
+        {
+            code: 'it("works", function () {}).timeout(0);',
+            options: [{ mode: 'range', min: 1, max: 5000 }],
+            errors: [{
+                message: 'Unexpected Mocha timeout value 0. Expected a value between 1 and 5000.'
+            }]
+        },
+        {
+            code: 'describe("suite", function () { this["timeout"](6000); });',
+            options: [{ mode: 'range', min: 1, max: 5000 }],
+            errors: [{
+                message: 'Unexpected Mocha timeout value 6000. Expected a value between 1 and 5000.'
+            }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).timeout(5000);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            settings: { mocha: { interface: 'require' } },
+            errors: [{ message: unexpectedTimeout }]
+        },
+        {
+            code: 'custom("works", function () {}).timeout(5000);',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            },
+            errors: [{ message: unexpectedTimeout }]
+        }
+    ]
+});

--- a/source/rules/limit-timeout.ts
+++ b/source/rules/limit-timeout.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { isCallExpression } from '../ast/node-types.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
 import {
     getStaticNumericConfigValue,
     isDisabledTimeoutValue,
@@ -74,6 +74,10 @@ type ReportMessageDetails = {
     readonly messageId: TimeoutMessageId;
     readonly data?: Record<string, string>;
 };
+
+function hasMemberCallee(node: Readonly<CallExpression>): node is MochaConfigCallExpression {
+    return node.callee.type === 'MemberExpression';
+}
 
 function validateOption(option: Readonly<Option>): void {
     if (option.mode === 'range' && option.min > option.max) {
@@ -233,9 +237,9 @@ export const limitTimeoutRule: Readonly<Rule.RuleModule> = {
                 if (
                     visitorContext.config === 'timeout' &&
                     isCallExpression(node) &&
-                    node.callee.type === 'MemberExpression'
+                    hasMemberCallee(node)
                 ) {
-                    checkTimeoutCall(node as MochaConfigCallExpression);
+                    checkTimeoutCall(node);
                 }
             },
 

--- a/source/rules/limit-timeout.ts
+++ b/source/rules/limit-timeout.ts
@@ -1,0 +1,240 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import {
+    getStaticNumericConfigValue,
+    isDisabledTimeoutValue,
+    visitMochaContextConfigCalls
+} from '../mocha/config-call.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
+
+const optionSchema = {
+    oneOf: [
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['disallow']
+                }
+            },
+            required: ['mode'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['disallowDisabled']
+                }
+            },
+            required: ['mode'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['max']
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'max'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['range']
+                },
+                min: {
+                    type: 'integer'
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'min', 'max'],
+            additionalProperties: false
+        }
+    ]
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+const defaultOption: Option = { mode: 'disallow' };
+type TimeoutMessageId =
+    | 'unexpectedDisabledTimeout'
+    | 'unexpectedTimeout'
+    | 'unexpectedTimeoutAboveMax'
+    | 'unexpectedTimeoutOutsideRange';
+type ReportMessageDetails = {
+    readonly messageId: TimeoutMessageId;
+    readonly data?: Record<string, string>;
+};
+
+function validateOption(option: Readonly<Option>): void {
+    if (option.mode === 'range' && option.min > option.max) {
+        throw new TypeError('`min` must be less than or equal to `max`.');
+    }
+}
+
+function reportUnexpectedTimeout(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    descriptor: Readonly<ReportMessageDetails>
+): void {
+    context.report({
+        ...descriptor,
+        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+    });
+}
+
+function reportDisabledTimeout(context: Readonly<Rule.RuleContext>, node: Readonly<CallExpression>): void {
+    reportUnexpectedTimeout(context, node, {
+        messageId: 'unexpectedDisabledTimeout'
+    });
+}
+
+function reportTimeoutAboveMax(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    timeoutValue: number
+): void {
+    reportUnexpectedTimeout(context, node, {
+        messageId: 'unexpectedTimeoutAboveMax',
+        data: {
+            max: String(maximumValue),
+            value: String(timeoutValue)
+        }
+    });
+}
+
+function reportTimeoutOutsideRange(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    timeoutValue: number
+): void {
+    reportUnexpectedTimeout(context, node, {
+        messageId: 'unexpectedTimeoutOutsideRange',
+        data: {
+            max: String(option.max),
+            min: String(option.min),
+            value: String(timeoutValue)
+        }
+    });
+}
+
+function readStaticTimeoutValue(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>
+): number | null {
+    return getStaticNumericConfigValue(node, context.sourceCode);
+}
+
+function checkDisabledTimeoutCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    timeoutValue: number
+): void {
+    if (isDisabledTimeoutValue(timeoutValue)) {
+        reportDisabledTimeout(context, node);
+    }
+}
+
+function checkMaximumTimeoutCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    timeoutValue: number
+): void {
+    if (timeoutValue > maximumValue) {
+        reportTimeoutAboveMax(context, node, maximumValue, timeoutValue);
+    }
+}
+
+function checkTimeoutRangeCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    timeoutValue: number
+): void {
+    if (timeoutValue < option.min || timeoutValue > option.max) {
+        reportTimeoutOutsideRange(context, node, option, timeoutValue);
+    }
+}
+
+function checkConfiguredTimeoutCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Exclude<Option, { mode: 'disallow'; }>,
+    timeoutValue: number
+): void {
+    if (option.mode === 'disallowDisabled') {
+        checkDisabledTimeoutCall(context, node, timeoutValue);
+        return;
+    }
+
+    if (option.mode === 'max') {
+        checkMaximumTimeoutCall(context, node, option.max, timeoutValue);
+        return;
+    }
+
+    checkTimeoutRangeCall(context, node, option, timeoutValue);
+}
+
+export const limitTimeoutRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'suggestion',
+        languages: ['js/js'],
+        docs: {
+            description: 'Enforce limits for Mocha timeouts',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/limit-timeout.md'
+        },
+        defaultOptions: [defaultOption],
+        messages: {
+            unexpectedTimeout: 'Unexpected use of Mocha timeout configuration.',
+            unexpectedDisabledTimeout: 'Unexpected disabled Mocha timeout.',
+            unexpectedTimeoutAboveMax: 'Unexpected Mocha timeout value {{value}}. Maximum allowed is {{max}}.',
+            unexpectedTimeoutOutsideRange:
+                'Unexpected Mocha timeout value {{value}}. Expected a value between {{min}} and {{max}}.'
+        },
+        schema: [optionSchema]
+    },
+    create(context) {
+        const option = getRuleOption<Option>(context);
+        validateOption(option);
+
+        function checkTimeoutCall(node: Readonly<CallExpression>): void {
+            if (option.mode === 'disallow') {
+                reportUnexpectedTimeout(context, node, {
+                    messageId: 'unexpectedTimeout'
+                });
+                return;
+            }
+
+            const timeoutValue = readStaticTimeoutValue(context, node);
+
+            if (timeoutValue === null) {
+                return;
+            }
+
+            checkConfiguredTimeoutCall(context, node, option, timeoutValue);
+        }
+
+        return createMochaVisitors(context, {
+            config(visitorContext) {
+                if (visitorContext.config === 'timeout' && isCallExpression(visitorContext.node)) {
+                    checkTimeoutCall(visitorContext.node);
+                }
+            },
+
+            anyTestEntityCallback(visitorContext) {
+                visitMochaContextConfigCalls(context.sourceCode, visitorContext.node.body, 'timeout', checkTimeoutCall);
+            }
+        });
+    }
+};

--- a/source/rules/limit-timeout.ts
+++ b/source/rules/limit-timeout.ts
@@ -1,9 +1,10 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import { isCallExpression } from '../ast/node-types.js';
 import {
     getStaticNumericConfigValue,
     isDisabledTimeoutValue,
+    type MochaConfigCallExpression,
     visitMochaContextConfigCalls
 } from '../mocha/config-call.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
@@ -82,16 +83,16 @@ function validateOption(option: Readonly<Option>): void {
 
 function reportUnexpectedTimeout(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     descriptor: Readonly<ReportMessageDetails>
 ): void {
     context.report({
         ...descriptor,
-        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+        node: node.callee.property
     });
 }
 
-function reportDisabledTimeout(context: Readonly<Rule.RuleContext>, node: Readonly<CallExpression>): void {
+function reportDisabledTimeout(context: Readonly<Rule.RuleContext>, node: MochaConfigCallExpression): void {
     reportUnexpectedTimeout(context, node, {
         messageId: 'unexpectedDisabledTimeout'
     });
@@ -99,7 +100,7 @@ function reportDisabledTimeout(context: Readonly<Rule.RuleContext>, node: Readon
 
 function reportTimeoutAboveMax(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     timeoutValue: number
 ): void {
@@ -114,7 +115,7 @@ function reportTimeoutAboveMax(
 
 function reportTimeoutOutsideRange(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     timeoutValue: number
 ): void {
@@ -130,14 +131,14 @@ function reportTimeoutOutsideRange(
 
 function readStaticTimeoutValue(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>
+    node: MochaConfigCallExpression
 ): number | null {
     return getStaticNumericConfigValue(node, context.sourceCode);
 }
 
 function checkDisabledTimeoutCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     timeoutValue: number
 ): void {
     if (isDisabledTimeoutValue(timeoutValue)) {
@@ -147,7 +148,7 @@ function checkDisabledTimeoutCall(
 
 function checkMaximumTimeoutCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     timeoutValue: number
 ): void {
@@ -158,7 +159,7 @@ function checkMaximumTimeoutCall(
 
 function checkTimeoutRangeCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     timeoutValue: number
 ): void {
@@ -169,7 +170,7 @@ function checkTimeoutRangeCall(
 
 function checkConfiguredTimeoutCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Exclude<Option, { mode: 'disallow'; }>,
     timeoutValue: number
 ): void {
@@ -208,7 +209,7 @@ export const limitTimeoutRule: Readonly<Rule.RuleModule> = {
         const option = getRuleOption<Option>(context);
         validateOption(option);
 
-        function checkTimeoutCall(node: Readonly<CallExpression>): void {
+        function checkTimeoutCall(node: MochaConfigCallExpression): void {
             if (option.mode === 'disallow') {
                 reportUnexpectedTimeout(context, node, {
                     messageId: 'unexpectedTimeout'
@@ -227,8 +228,14 @@ export const limitTimeoutRule: Readonly<Rule.RuleModule> = {
 
         return createMochaVisitors(context, {
             config(visitorContext) {
-                if (visitorContext.config === 'timeout' && isCallExpression(visitorContext.node)) {
-                    checkTimeoutCall(visitorContext.node);
+                const { node } = visitorContext;
+
+                if (
+                    visitorContext.config === 'timeout' &&
+                    isCallExpression(node) &&
+                    node.callee.type === 'MemberExpression'
+                ) {
+                    checkTimeoutCall(node as MochaConfigCallExpression);
                 }
             },
 

--- a/source/third-party-type-definitions.d.ts
+++ b/source/third-party-type-definitions.d.ts
@@ -13,4 +13,9 @@ declare module '@eslint-community/eslint-utils' {
         node: Node,
         initialScope?: Scope.Scope | null
     ): string | null;
+
+    export function getStaticValue(
+        node: Node,
+        initialScope?: Scope.Scope | null
+    ): { value: unknown; optional?: true; } | null;
 }


### PR DESCRIPTION
Adds `mocha/limit-timeout` for `this.timeout(...)` and chained timeout calls.

It also teaches the Mocha visitor layer to surface config calls so timeout-style rules can share the same call detection path.