### PR TITLE
Add `limit-retries` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
+| [limit-retries](documentation/rules/limit-retries.md)                                         | Enforce limits for Mocha retries                                        |    |    | ✅  |    |    |
 | [limit-timeout](documentation/rules/limit-timeout.md)                                         | Enforce limits for Mocha timeouts                                       |    |    | ✅  |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |

--- a/documentation/rules/limit-retries.md
+++ b/documentation/rules/limit-retries.md
@@ -1,0 +1,70 @@
+# Enforce limits for Mocha retries (`mocha/limit-retries`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Mocha lets suites, tests, and hooks configure retries with `this.retries(...)` or chained calls such as `it(...).retries(...)`. This rule lets you forbid retry configuration entirely or constrain the values that are allowed.
+
+This rule applies to:
+
+- `this.retries(...)` inside suite, test, and hook callbacks
+- `describe(...).retries(...)`, `it(...).retries(...)`, and hook variants
+- TDD interface equivalents such as `suite(...).retries(...)` and `test(...).retries(...)`
+- Equivalent configured custom names
+
+With `mode: "disallow"`, getter-style calls such as `this.retries()` and `it(...).retries()` are also reported. Other modes only check calls with a statically known numeric argument.
+
+## Options
+
+This rule supports the following options:
+
+- `{ "mode": "disallow" }`: Reports every Mocha retry call.
+- `{ "mode": "max", "max": 2 }`: Reports statically known numeric retry values greater than `max`.
+- `{ "mode": "range", "min": 0, "max": 2 }`: Reports statically known numeric retry values outside the inclusive range.
+
+For `max` and `range`, unresolved dynamic values are ignored.
+
+```json
+{
+    "rules": {
+        "mocha/limit-retries": ["error", {
+            "mode": "range",
+            "min": 0,
+            "max": 2
+        }]
+    }
+}
+```
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+it('works', function () {}).retries(3);
+
+describe('suite', function () {
+    this.retries(3);
+});
+```
+
+Examples of correct code for this rule with `{ "mode": "range", "min": 0, "max": 2 }`:
+
+```js
+it('works', function () {});
+
+it('works', function () {}).retries(2);
+
+describe('suite', function () {
+    this.retries(1);
+});
+```
+
+## When Not To Use It
+
+- If your project allows arbitrary Mocha retry configuration.
+
+## Further Reading
+
+- [Mocha Retry Tests](https://mochajs.org/declaring/retrying-tests/)

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -5,6 +5,7 @@ import { consistentInterfaceRule } from './rules/consistent-interface.js';
 import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-between-blocks.js';
 import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
+import { limitRetriesRule } from './rules/limit-retries.js';
 import { limitTimeoutRule } from './rules/limit-timeout.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
 import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
@@ -40,6 +41,7 @@ const allRules: Linter.RulesRecord = {
         { order: 'hooks-tests-suites', disallowDuplicateHooks: true, disallowMixedTestsAndSuites: true }
     ],
     'mocha/handle-done-callback': 'error',
+    'mocha/limit-retries': 'error',
     'mocha/limit-timeout': 'error',
     'mocha/max-top-level-suites': 'error',
     'mocha/no-async-and-done': 'error',
@@ -73,6 +75,7 @@ const allRules: Linter.RulesRecord = {
 const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-structure': ['error', { disallowDuplicateHooks: true }],
     'mocha/handle-done-callback': 'error',
+    'mocha/limit-retries': 'off',
     'mocha/limit-timeout': 'off',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
     'mocha/no-async-and-done': 'error',
@@ -106,6 +109,7 @@ const recommendedRules: Linter.RulesRecord = {
 const rules = {
     'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
+    'limit-retries': limitRetriesRule,
     'limit-timeout': limitTimeoutRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
     'no-async-and-done': noAsyncAndDoneRule,

--- a/source/rules/limit-retries.test.ts
+++ b/source/rules/limit-retries.test.ts
@@ -1,4 +1,5 @@
-import { RuleTester } from 'eslint';
+import { Linter, RuleTester } from 'eslint';
+import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import { limitRetriesRule } from './limit-retries.js';
 
@@ -121,4 +122,26 @@ ruleTester.run('limit-retries', limitRetriesRule, {
             errors: [{ message: unexpectedRetries }]
         }
     ]
+});
+
+describe('limit-retries', function () {
+    it('throws when the configured range is invalid', function () {
+        const linter = new Linter();
+
+        assert.throws(
+            function () {
+                linter.verify('it("works", function () {}).retries(2);', {
+                    plugins: { 'test-plugin': { rules: { 'limit-retries': limitRetriesRule } } },
+                    languageOptions: { sourceType: 'script' },
+                    rules: {
+                        'test-plugin/limit-retries': ['error', { mode: 'range', min: 2, max: 1 }]
+                    }
+                });
+            },
+            function (error: unknown) {
+                return error instanceof Error &&
+                    error.message.includes('`min` must be less than or equal to `max`.');
+            }
+        );
+    });
 });

--- a/source/rules/limit-retries.test.ts
+++ b/source/rules/limit-retries.test.ts
@@ -1,0 +1,124 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { limitRetriesRule } from './limit-retries.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const unexpectedRetries = 'Unexpected use of Mocha retry configuration.';
+
+ruleTester.run('limit-retries', limitRetriesRule, {
+    valid: [
+        'it("works", function () {});',
+        'it("works", function () {}).timeout(5000);',
+        {
+            code: 'it("works", function () {}).retries();',
+            options: [{ mode: 'max', max: 2 }]
+        },
+        {
+            code: 'describe("suite", function () { this.retries(2); });',
+            options: [{ mode: 'max', max: 2 }]
+        },
+        {
+            code: 'it("works", function () { this["retries"](2); });',
+            options: [{ mode: 'range', min: 0, max: 2 }]
+        },
+        {
+            code: 'it("works", function () { (() => this.retries(2))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'range', min: 0, max: 2 }]
+        },
+        {
+            code: 'it("works", function () { function later() { this.retries(3); } });',
+            options: [{ mode: 'max', max: 2 }]
+        },
+        {
+            code: 'const retryLimit = 2; it("works", function () {}).retries(retryLimit);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 2 }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).retries(2);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            options: [{ mode: 'max', max: 2 }],
+            settings: { mocha: { interface: 'require' } }
+        },
+        {
+            code: 'custom("works", function () {}).retries(2);',
+            options: [{ mode: 'max', max: 2 }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            }
+        },
+        withInterface('TDD', {
+            code: 'test("works", function () {}).retries(2);',
+            options: [{ mode: 'range', min: 0, max: 2 }]
+        })
+    ],
+
+    invalid: [
+        {
+            code: 'it("works", function () {}).retries(2);',
+            errors: [{ message: unexpectedRetries }]
+        },
+        {
+            code: 'describe("suite", function () { this.retries(2); });',
+            errors: [{ message: unexpectedRetries }]
+        },
+        {
+            code: 'it("works", function () { (() => this.retries(2))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [{ message: unexpectedRetries }]
+        },
+        {
+            code: 'it("works", function () {}).retries(3);',
+            options: [{ mode: 'max', max: 2 }],
+            errors: [{
+                message: 'Unexpected Mocha retry value 3. Maximum allowed is 2.'
+            }]
+        },
+        {
+            code: 'const retryLimit = 3; it("works", function () {}).retries(retryLimit);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 2 }],
+            errors: [{
+                message: 'Unexpected Mocha retry value 3. Maximum allowed is 2.'
+            }]
+        },
+        {
+            code: 'it("works", function () {}).retries(-1);',
+            options: [{ mode: 'range', min: 0, max: 2 }],
+            errors: [{
+                message: 'Unexpected Mocha retry value -1. Expected a value between 0 and 2.'
+            }]
+        },
+        {
+            code: 'describe("suite", function () { this["retries"](3); });',
+            options: [{ mode: 'range', min: 0, max: 2 }],
+            errors: [{
+                message: 'Unexpected Mocha retry value 3. Expected a value between 0 and 2.'
+            }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).retries(2);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            settings: { mocha: { interface: 'require' } },
+            errors: [{ message: unexpectedRetries }]
+        },
+        {
+            code: 'custom("works", function () {}).retries(2);',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            },
+            errors: [{ message: unexpectedRetries }]
+        }
+    ]
+});

--- a/source/rules/limit-retries.ts
+++ b/source/rules/limit-retries.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { isCallExpression } from '../ast/node-types.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
 import {
     getStaticNumericConfigValue,
     type MochaConfigCallExpression,
@@ -61,6 +61,10 @@ type ReportMessageDetails = {
     readonly messageId: RetryMessageId;
     readonly data?: Record<string, string>;
 };
+
+function hasMemberCallee(node: Readonly<CallExpression>): node is MochaConfigCallExpression {
+    return node.callee.type === 'MemberExpression';
+}
 
 const defaultOption: Option = { mode: 'disallow' };
 
@@ -200,9 +204,9 @@ export const limitRetriesRule: Readonly<Rule.RuleModule> = {
                 if (
                     visitorContext.config === 'retries' &&
                     isCallExpression(node) &&
-                    node.callee.type === 'MemberExpression'
+                    hasMemberCallee(node)
                 ) {
-                    checkRetriesCall(node as MochaConfigCallExpression);
+                    checkRetriesCall(node);
                 }
             },
 

--- a/source/rules/limit-retries.ts
+++ b/source/rules/limit-retries.ts
@@ -1,7 +1,11 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
-import { getStaticNumericConfigValue, visitMochaContextConfigCalls } from '../mocha/config-call.js';
+import { isCallExpression } from '../ast/node-types.js';
+import {
+    getStaticNumericConfigValue,
+    type MochaConfigCallExpression,
+    visitMochaContextConfigCalls
+} from '../mocha/config-call.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 const optionSchema = {
@@ -68,18 +72,18 @@ function validateOption(option: Readonly<Option>): void {
 
 function reportUnexpectedRetries(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     descriptor: Readonly<ReportMessageDetails>
 ): void {
     context.report({
         ...descriptor,
-        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+        node: node.callee.property
     });
 }
 
 function reportRetriesAboveMax(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     retryValue: number
 ): void {
@@ -94,7 +98,7 @@ function reportRetriesAboveMax(
 
 function reportRetriesOutsideRange(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     retryValue: number
 ): void {
@@ -110,14 +114,14 @@ function reportRetriesOutsideRange(
 
 function readStaticRetryValue(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>
+    node: MochaConfigCallExpression
 ): number | null {
     return getStaticNumericConfigValue(node, context.sourceCode);
 }
 
 function checkMaximumRetriesCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     retryValue: number
 ): void {
@@ -128,7 +132,7 @@ function checkMaximumRetriesCall(
 
 function checkRetriesRangeCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     retryValue: number
 ): void {
@@ -139,7 +143,7 @@ function checkRetriesRangeCall(
 
 function checkConfiguredRetriesCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Exclude<Option, { mode: 'disallow'; }>,
     retryValue: number
 ): void {
@@ -172,7 +176,7 @@ export const limitRetriesRule: Readonly<Rule.RuleModule> = {
         const option = getRuleOption<Option>(context);
         validateOption(option);
 
-        function checkRetriesCall(node: Readonly<CallExpression>): void {
+        function checkRetriesCall(node: MochaConfigCallExpression): void {
             if (option.mode === 'disallow') {
                 reportUnexpectedRetries(context, node, {
                     messageId: 'unexpectedRetries'
@@ -191,8 +195,14 @@ export const limitRetriesRule: Readonly<Rule.RuleModule> = {
 
         return createMochaVisitors(context, {
             config(visitorContext) {
-                if (visitorContext.config === 'retries' && isCallExpression(visitorContext.node)) {
-                    checkRetriesCall(visitorContext.node);
+                const { node } = visitorContext;
+
+                if (
+                    visitorContext.config === 'retries' &&
+                    isCallExpression(node) &&
+                    node.callee.type === 'MemberExpression'
+                ) {
+                    checkRetriesCall(node as MochaConfigCallExpression);
                 }
             },
 

--- a/source/rules/limit-retries.ts
+++ b/source/rules/limit-retries.ts
@@ -1,0 +1,204 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import { getStaticNumericConfigValue, visitMochaContextConfigCalls } from '../mocha/config-call.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
+
+const optionSchema = {
+    oneOf: [
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['disallow']
+                }
+            },
+            required: ['mode'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['max']
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'max'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['range']
+                },
+                min: {
+                    type: 'integer'
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'min', 'max'],
+            additionalProperties: false
+        }
+    ]
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+type RetryMessageId =
+    | 'unexpectedRetries'
+    | 'unexpectedRetriesAboveMax'
+    | 'unexpectedRetriesOutsideRange';
+type ReportMessageDetails = {
+    readonly messageId: RetryMessageId;
+    readonly data?: Record<string, string>;
+};
+
+const defaultOption: Option = { mode: 'disallow' };
+
+function validateOption(option: Readonly<Option>): void {
+    if (option.mode === 'range' && option.min > option.max) {
+        throw new TypeError('`min` must be less than or equal to `max`.');
+    }
+}
+
+function reportUnexpectedRetries(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    descriptor: Readonly<ReportMessageDetails>
+): void {
+    context.report({
+        ...descriptor,
+        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+    });
+}
+
+function reportRetriesAboveMax(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    retryValue: number
+): void {
+    reportUnexpectedRetries(context, node, {
+        messageId: 'unexpectedRetriesAboveMax',
+        data: {
+            max: String(maximumValue),
+            value: String(retryValue)
+        }
+    });
+}
+
+function reportRetriesOutsideRange(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    retryValue: number
+): void {
+    reportUnexpectedRetries(context, node, {
+        messageId: 'unexpectedRetriesOutsideRange',
+        data: {
+            max: String(option.max),
+            min: String(option.min),
+            value: String(retryValue)
+        }
+    });
+}
+
+function readStaticRetryValue(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>
+): number | null {
+    return getStaticNumericConfigValue(node, context.sourceCode);
+}
+
+function checkMaximumRetriesCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    retryValue: number
+): void {
+    if (retryValue > maximumValue) {
+        reportRetriesAboveMax(context, node, maximumValue, retryValue);
+    }
+}
+
+function checkRetriesRangeCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    retryValue: number
+): void {
+    if (retryValue < option.min || retryValue > option.max) {
+        reportRetriesOutsideRange(context, node, option, retryValue);
+    }
+}
+
+function checkConfiguredRetriesCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Exclude<Option, { mode: 'disallow'; }>,
+    retryValue: number
+): void {
+    if (option.mode === 'max') {
+        checkMaximumRetriesCall(context, node, option.max, retryValue);
+        return;
+    }
+
+    checkRetriesRangeCall(context, node, option, retryValue);
+}
+
+export const limitRetriesRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'suggestion',
+        languages: ['js/js'],
+        docs: {
+            description: 'Enforce limits for Mocha retries',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/limit-retries.md'
+        },
+        defaultOptions: [defaultOption],
+        messages: {
+            unexpectedRetries: 'Unexpected use of Mocha retry configuration.',
+            unexpectedRetriesAboveMax: 'Unexpected Mocha retry value {{value}}. Maximum allowed is {{max}}.',
+            unexpectedRetriesOutsideRange:
+                'Unexpected Mocha retry value {{value}}. Expected a value between {{min}} and {{max}}.'
+        },
+        schema: [optionSchema]
+    },
+    create(context) {
+        const option = getRuleOption<Option>(context);
+        validateOption(option);
+
+        function checkRetriesCall(node: Readonly<CallExpression>): void {
+            if (option.mode === 'disallow') {
+                reportUnexpectedRetries(context, node, {
+                    messageId: 'unexpectedRetries'
+                });
+                return;
+            }
+
+            const retryValue = readStaticRetryValue(context, node);
+
+            if (retryValue === null) {
+                return;
+            }
+
+            checkConfiguredRetriesCall(context, node, option, retryValue);
+        }
+
+        return createMochaVisitors(context, {
+            config(visitorContext) {
+                if (visitorContext.config === 'retries' && isCallExpression(visitorContext.node)) {
+                    checkRetriesCall(visitorContext.node);
+                }
+            },
+
+            anyTestEntityCallback(visitorContext) {
+                visitMochaContextConfigCalls(context.sourceCode, visitorContext.node.body, 'retries', checkRetriesCall);
+            }
+        });
+    }
+};


### PR DESCRIPTION
Adds `mocha/limit-retries` for `this.retries(...)` and chained retry calls.