### PR TITLE
Add `limit-slow` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
 | [limit-retries](documentation/rules/limit-retries.md)                                         | Enforce limits for Mocha retries                                        |    |    | ✅  |    |    |
+| [limit-slow](documentation/rules/limit-slow.md)                                               | Enforce limits for Mocha slow thresholds                                |    |    | ✅  |    |    |
 | [limit-timeout](documentation/rules/limit-timeout.md)                                         | Enforce limits for Mocha timeouts                                       |    |    | ✅  |    |    |
 | [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
 | [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |

--- a/documentation/rules/limit-slow.md
+++ b/documentation/rules/limit-slow.md
@@ -1,0 +1,71 @@
+# Enforce limits for Mocha slow thresholds (`mocha/limit-slow`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Mocha lets suites, tests, and hooks configure the slow threshold with `this.slow(...)` or chained calls such as `it(...).slow(...)`. This rule lets you forbid slow-threshold configuration entirely or constrain the values that are allowed.
+
+This rule applies to:
+
+- `this.slow(...)` inside suite, test, and hook callbacks
+- `describe(...).slow(...)`, `it(...).slow(...)`, and hook variants
+- TDD interface equivalents such as `suite(...).slow(...)` and `test(...).slow(...)`
+- Equivalent configured custom names
+
+With `mode: "disallow"`, getter-style calls such as `this.slow()` and `it(...).slow()` are also reported. Other modes only check calls with a statically known numeric argument.
+
+## Options
+
+This rule supports the following options:
+
+- `{ "mode": "disallow" }`: Reports every Mocha slow-threshold call.
+- `{ "mode": "max", "max": 200 }`: Reports statically known numeric slow values greater than `max`.
+- `{ "mode": "range", "min": 50, "max": 200 }`: Reports statically known numeric slow values outside the inclusive range.
+
+For `max` and `range`, unresolved dynamic values and string shorthands such as `"2s"` are ignored.
+
+```json
+{
+    "rules": {
+        "mocha/limit-slow": ["error", {
+            "mode": "range",
+            "min": 50,
+            "max": 200
+        }]
+    }
+}
+```
+
+## Rule Details
+
+Examples of incorrect code for this rule:
+
+```js
+it('works', function () {}).slow(300);
+
+describe('suite', function () {
+    this.slow(300);
+});
+```
+
+Examples of correct code for this rule with `{ "mode": "range", "min": 50, "max": 200 }`:
+
+```js
+it('works', function () {});
+
+it('works', function () {}).slow(200);
+
+describe('suite', function () {
+    this.slow(100);
+});
+```
+
+## When Not To Use It
+
+- If your project allows arbitrary Mocha slow-threshold configuration.
+- If your project relies heavily on string-based slow values and you need exhaustive checking for those forms.
+
+## Further Reading
+
+- [Mocha Timeouts](https://mochajs.org/features/timeouts/)

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -6,6 +6,7 @@ import { consistentSpacingBetweenBlocksRule } from './rules/consistent-spacing-b
 import { consistentStructureRule } from './rules/consistent-structure.js';
 import { handleDoneCallbackRule } from './rules/handle-done-callback.js';
 import { limitRetriesRule } from './rules/limit-retries.js';
+import { limitSlowRule } from './rules/limit-slow.js';
 import { limitTimeoutRule } from './rules/limit-timeout.js';
 import { maxTopLevelSuitesRule } from './rules/max-top-level-suites.js';
 import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
@@ -42,6 +43,7 @@ const allRules: Linter.RulesRecord = {
     ],
     'mocha/handle-done-callback': 'error',
     'mocha/limit-retries': 'error',
+    'mocha/limit-slow': 'error',
     'mocha/limit-timeout': 'error',
     'mocha/max-top-level-suites': 'error',
     'mocha/no-async-and-done': 'error',
@@ -76,6 +78,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/consistent-structure': ['error', { disallowDuplicateHooks: true }],
     'mocha/handle-done-callback': 'error',
     'mocha/limit-retries': 'off',
+    'mocha/limit-slow': 'off',
     'mocha/limit-timeout': 'off',
     'mocha/max-top-level-suites': ['error', { limit: 1 }],
     'mocha/no-async-and-done': 'error',
@@ -110,6 +113,7 @@ const rules = {
     'consistent-structure': consistentStructureRule,
     'handle-done-callback': handleDoneCallbackRule,
     'limit-retries': limitRetriesRule,
+    'limit-slow': limitSlowRule,
     'limit-timeout': limitTimeoutRule,
     'max-top-level-suites': maxTopLevelSuitesRule,
     'no-async-and-done': noAsyncAndDoneRule,

--- a/source/rules/limit-slow.test.ts
+++ b/source/rules/limit-slow.test.ts
@@ -1,4 +1,5 @@
-import { RuleTester } from 'eslint';
+import { Linter, RuleTester } from 'eslint';
+import assert from 'node:assert';
 import { withInterface } from '../mocha-interface-test-cases.js';
 import { limitSlowRule } from './limit-slow.js';
 
@@ -121,4 +122,26 @@ ruleTester.run('limit-slow', limitSlowRule, {
             errors: [{ message: unexpectedSlow }]
         }
     ]
+});
+
+describe('limit-slow', function () {
+    it('throws when the configured range is invalid', function () {
+        const linter = new Linter();
+
+        assert.throws(
+            function () {
+                linter.verify('it("works", function () {}).slow(200);', {
+                    plugins: { 'test-plugin': { rules: { 'limit-slow': limitSlowRule } } },
+                    languageOptions: { sourceType: 'script' },
+                    rules: {
+                        'test-plugin/limit-slow': ['error', { mode: 'range', min: 200, max: 50 }]
+                    }
+                });
+            },
+            function (error: unknown) {
+                return error instanceof Error &&
+                    error.message.includes('`min` must be less than or equal to `max`.');
+            }
+        );
+    });
 });

--- a/source/rules/limit-slow.test.ts
+++ b/source/rules/limit-slow.test.ts
@@ -1,0 +1,124 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { limitSlowRule } from './limit-slow.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+const unexpectedSlow = 'Unexpected use of Mocha slow threshold configuration.';
+
+ruleTester.run('limit-slow', limitSlowRule, {
+    valid: [
+        'it("works", function () {});',
+        'it("works", function () {}).timeout(5000);',
+        {
+            code: 'it("works", function () {}).slow();',
+            options: [{ mode: 'max', max: 200 }]
+        },
+        {
+            code: 'describe("suite", function () { this.slow(200); });',
+            options: [{ mode: 'max', max: 200 }]
+        },
+        {
+            code: 'it("works", function () { this["slow"](200); });',
+            options: [{ mode: 'range', min: 50, max: 200 }]
+        },
+        {
+            code: 'it("works", function () { (() => this.slow(200))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'range', min: 50, max: 200 }]
+        },
+        {
+            code: 'it("works", function () { function later() { this.slow(300); } });',
+            options: [{ mode: 'max', max: 200 }]
+        },
+        {
+            code: 'const slowThreshold = 200; it("works", function () {}).slow(slowThreshold);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 200 }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).slow(200);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            options: [{ mode: 'max', max: 200 }],
+            settings: { mocha: { interface: 'require' } }
+        },
+        {
+            code: 'custom("works", function () {}).slow(200);',
+            options: [{ mode: 'max', max: 200 }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            }
+        },
+        withInterface('TDD', {
+            code: 'test("works", function () {}).slow(200);',
+            options: [{ mode: 'range', min: 50, max: 200 }]
+        })
+    ],
+
+    invalid: [
+        {
+            code: 'it("works", function () {}).slow(200);',
+            errors: [{ message: unexpectedSlow }]
+        },
+        {
+            code: 'describe("suite", function () { this.slow(200); });',
+            errors: [{ message: unexpectedSlow }]
+        },
+        {
+            code: 'it("works", function () { (() => this.slow(200))(); });',
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [{ message: unexpectedSlow }]
+        },
+        {
+            code: 'it("works", function () {}).slow(300);',
+            options: [{ mode: 'max', max: 200 }],
+            errors: [{
+                message: 'Unexpected Mocha slow value 300. Maximum allowed is 200.'
+            }]
+        },
+        {
+            code: 'const slowThreshold = 300; it("works", function () {}).slow(slowThreshold);',
+            languageOptions: { ecmaVersion: 2015 },
+            options: [{ mode: 'max', max: 200 }],
+            errors: [{
+                message: 'Unexpected Mocha slow value 300. Maximum allowed is 200.'
+            }]
+        },
+        {
+            code: 'it("works", function () {}).slow(25);',
+            options: [{ mode: 'range', min: 50, max: 200 }],
+            errors: [{
+                message: 'Unexpected Mocha slow value 25. Expected a value between 50 and 200.'
+            }]
+        },
+        {
+            code: 'describe("suite", function () { this["slow"](250); });',
+            options: [{ mode: 'range', min: 50, max: 200 }],
+            errors: [{
+                message: 'Unexpected Mocha slow value 250. Expected a value between 50 and 200.'
+            }]
+        },
+        {
+            code: 'import { it } from "mocha"; it("works", function () {}).slow(200);',
+            languageOptions: {
+                ecmaVersion: 2018,
+                sourceType: 'module'
+            },
+            settings: { mocha: { interface: 'require' } },
+            errors: [{ message: unexpectedSlow }]
+        },
+        {
+            code: 'custom("works", function () {}).slow(200);',
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'custom', type: 'testCase', interface: 'BDD' }]
+                }
+            },
+            errors: [{ message: unexpectedSlow }]
+        }
+    ]
+});

--- a/source/rules/limit-slow.ts
+++ b/source/rules/limit-slow.ts
@@ -1,0 +1,204 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
+import { getStaticNumericConfigValue, visitMochaContextConfigCalls } from '../mocha/config-call.js';
+import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
+
+const optionSchema = {
+    oneOf: [
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['disallow']
+                }
+            },
+            required: ['mode'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['max']
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'max'],
+            additionalProperties: false
+        },
+        {
+            type: 'object',
+            properties: {
+                mode: {
+                    enum: ['range']
+                },
+                min: {
+                    type: 'integer'
+                },
+                max: {
+                    type: 'integer'
+                }
+            },
+            required: ['mode', 'min', 'max'],
+            additionalProperties: false
+        }
+    ]
+} as const satisfies RuleSchema;
+
+type Option = InferSchemaOption<typeof optionSchema>;
+type SlowMessageId =
+    | 'unexpectedSlow'
+    | 'unexpectedSlowAboveMax'
+    | 'unexpectedSlowOutsideRange';
+type ReportMessageDetails = {
+    readonly messageId: SlowMessageId;
+    readonly data?: Record<string, string>;
+};
+
+const defaultOption: Option = { mode: 'disallow' };
+
+function validateOption(option: Readonly<Option>): void {
+    if (option.mode === 'range' && option.min > option.max) {
+        throw new TypeError('`min` must be less than or equal to `max`.');
+    }
+}
+
+function reportUnexpectedSlow(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    descriptor: Readonly<ReportMessageDetails>
+): void {
+    context.report({
+        ...descriptor,
+        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+    });
+}
+
+function reportSlowAboveMax(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    slowValue: number
+): void {
+    reportUnexpectedSlow(context, node, {
+        messageId: 'unexpectedSlowAboveMax',
+        data: {
+            max: String(maximumValue),
+            value: String(slowValue)
+        }
+    });
+}
+
+function reportSlowOutsideRange(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    slowValue: number
+): void {
+    reportUnexpectedSlow(context, node, {
+        messageId: 'unexpectedSlowOutsideRange',
+        data: {
+            max: String(option.max),
+            min: String(option.min),
+            value: String(slowValue)
+        }
+    });
+}
+
+function readStaticSlowValue(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>
+): number | null {
+    return getStaticNumericConfigValue(node, context.sourceCode);
+}
+
+function checkMaximumSlowCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    maximumValue: number,
+    slowValue: number
+): void {
+    if (slowValue > maximumValue) {
+        reportSlowAboveMax(context, node, maximumValue, slowValue);
+    }
+}
+
+function checkSlowRangeCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Readonly<Extract<Option, { mode: 'range'; }>>,
+    slowValue: number
+): void {
+    if (slowValue < option.min || slowValue > option.max) {
+        reportSlowOutsideRange(context, node, option, slowValue);
+    }
+}
+
+function checkConfiguredSlowCall(
+    context: Readonly<Rule.RuleContext>,
+    node: Readonly<CallExpression>,
+    option: Exclude<Option, { mode: 'disallow'; }>,
+    slowValue: number
+): void {
+    if (option.mode === 'max') {
+        checkMaximumSlowCall(context, node, option.max, slowValue);
+        return;
+    }
+
+    checkSlowRangeCall(context, node, option, slowValue);
+}
+
+export const limitSlowRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'suggestion',
+        languages: ['js/js'],
+        docs: {
+            description: 'Enforce limits for Mocha slow thresholds',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/limit-slow.md'
+        },
+        defaultOptions: [defaultOption],
+        messages: {
+            unexpectedSlow: 'Unexpected use of Mocha slow threshold configuration.',
+            unexpectedSlowAboveMax: 'Unexpected Mocha slow value {{value}}. Maximum allowed is {{max}}.',
+            unexpectedSlowOutsideRange:
+                'Unexpected Mocha slow value {{value}}. Expected a value between {{min}} and {{max}}.'
+        },
+        schema: [optionSchema]
+    },
+    create(context) {
+        const option = getRuleOption<Option>(context);
+        validateOption(option);
+
+        function checkSlowCall(node: Readonly<CallExpression>): void {
+            if (option.mode === 'disallow') {
+                reportUnexpectedSlow(context, node, {
+                    messageId: 'unexpectedSlow'
+                });
+                return;
+            }
+
+            const slowValue = readStaticSlowValue(context, node);
+
+            if (slowValue === null) {
+                return;
+            }
+
+            checkConfiguredSlowCall(context, node, option, slowValue);
+        }
+
+        return createMochaVisitors(context, {
+            config(visitorContext) {
+                if (visitorContext.config === 'slow' && isCallExpression(visitorContext.node)) {
+                    checkSlowCall(visitorContext.node);
+                }
+            },
+
+            anyTestEntityCallback(visitorContext) {
+                visitMochaContextConfigCalls(context.sourceCode, visitorContext.node.body, 'slow', checkSlowCall);
+            }
+        });
+    }
+};

--- a/source/rules/limit-slow.ts
+++ b/source/rules/limit-slow.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { isCallExpression } from '../ast/node-types.js';
+import { type CallExpression, isCallExpression } from '../ast/node-types.js';
 import {
     getStaticNumericConfigValue,
     type MochaConfigCallExpression,
@@ -61,6 +61,10 @@ type ReportMessageDetails = {
     readonly messageId: SlowMessageId;
     readonly data?: Record<string, string>;
 };
+
+function hasMemberCallee(node: Readonly<CallExpression>): node is MochaConfigCallExpression {
+    return node.callee.type === 'MemberExpression';
+}
 
 const defaultOption: Option = { mode: 'disallow' };
 
@@ -200,9 +204,9 @@ export const limitSlowRule: Readonly<Rule.RuleModule> = {
                 if (
                     visitorContext.config === 'slow' &&
                     isCallExpression(node) &&
-                    node.callee.type === 'MemberExpression'
+                    hasMemberCallee(node)
                 ) {
-                    checkSlowCall(node as MochaConfigCallExpression);
+                    checkSlowCall(node);
                 }
             },
 

--- a/source/rules/limit-slow.ts
+++ b/source/rules/limit-slow.ts
@@ -1,7 +1,11 @@
 import type { Rule } from 'eslint';
 import { createMochaVisitors } from '../ast/mocha-visitors.js';
-import { type CallExpression, isCallExpression } from '../ast/node-types.js';
-import { getStaticNumericConfigValue, visitMochaContextConfigCalls } from '../mocha/config-call.js';
+import { isCallExpression } from '../ast/node-types.js';
+import {
+    getStaticNumericConfigValue,
+    type MochaConfigCallExpression,
+    visitMochaContextConfigCalls
+} from '../mocha/config-call.js';
 import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-options.js';
 
 const optionSchema = {
@@ -68,18 +72,18 @@ function validateOption(option: Readonly<Option>): void {
 
 function reportUnexpectedSlow(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     descriptor: Readonly<ReportMessageDetails>
 ): void {
     context.report({
         ...descriptor,
-        node: node.callee.type === 'MemberExpression' ? node.callee.property : node.callee
+        node: node.callee.property
     });
 }
 
 function reportSlowAboveMax(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     slowValue: number
 ): void {
@@ -94,7 +98,7 @@ function reportSlowAboveMax(
 
 function reportSlowOutsideRange(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     slowValue: number
 ): void {
@@ -110,14 +114,14 @@ function reportSlowOutsideRange(
 
 function readStaticSlowValue(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>
+    node: MochaConfigCallExpression
 ): number | null {
     return getStaticNumericConfigValue(node, context.sourceCode);
 }
 
 function checkMaximumSlowCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     maximumValue: number,
     slowValue: number
 ): void {
@@ -128,7 +132,7 @@ function checkMaximumSlowCall(
 
 function checkSlowRangeCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Readonly<Extract<Option, { mode: 'range'; }>>,
     slowValue: number
 ): void {
@@ -139,7 +143,7 @@ function checkSlowRangeCall(
 
 function checkConfiguredSlowCall(
     context: Readonly<Rule.RuleContext>,
-    node: Readonly<CallExpression>,
+    node: MochaConfigCallExpression,
     option: Exclude<Option, { mode: 'disallow'; }>,
     slowValue: number
 ): void {
@@ -172,7 +176,7 @@ export const limitSlowRule: Readonly<Rule.RuleModule> = {
         const option = getRuleOption<Option>(context);
         validateOption(option);
 
-        function checkSlowCall(node: Readonly<CallExpression>): void {
+        function checkSlowCall(node: MochaConfigCallExpression): void {
             if (option.mode === 'disallow') {
                 reportUnexpectedSlow(context, node, {
                     messageId: 'unexpectedSlow'
@@ -191,8 +195,14 @@ export const limitSlowRule: Readonly<Rule.RuleModule> = {
 
         return createMochaVisitors(context, {
             config(visitorContext) {
-                if (visitorContext.config === 'slow' && isCallExpression(visitorContext.node)) {
-                    checkSlowCall(visitorContext.node);
+                const { node } = visitorContext;
+
+                if (
+                    visitorContext.config === 'slow' &&
+                    isCallExpression(node) &&
+                    node.callee.type === 'MemberExpression'
+                ) {
+                    checkSlowCall(node as MochaConfigCallExpression);
                 }
             },
 


### PR DESCRIPTION
Adds `mocha/limit-slow` for `this.slow(...)` and chained slow-threshold calls.