### PR TITLE
Add `no-conditional-tests` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-code-after-done](documentation/rules/no-code-after-done.md)                               | Disallow executing code after calling a Mocha callback                  | ✅  |    |    |    |    |
+| [no-conditional-tests](documentation/rules/no-conditional-tests.md)                           | Disallow conditional suite and test declarations                        |    |    | ✅  |    |    |
 | [no-done-twice](documentation/rules/no-done-twice.md)                                         | Disallow calling a Mocha callback more than once                        | ✅  |    |    |    |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty suite and test descriptions                              | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |

--- a/documentation/rules/no-conditional-tests.md
+++ b/documentation/rules/no-conditional-tests.md
@@ -1,0 +1,49 @@
+# Disallow conditional suite and test declarations (`mocha/no-conditional-tests`)
+
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+
+<!-- end auto-generated rule header -->
+
+Conditionally declaring suites or test cases makes the executed test structure depend on runtime state. That makes the suite harder to understand and easier to accidentally change.
+
+## Rule Details
+
+This rule reports Mocha suite and test declarations inside:
+
+- `if` statements
+- logical short-circuit expressions such as `condition && it(...)`
+- conditional expressions such as `condition ? it(...) : test(...)`
+
+The following patterns are considered problems:
+
+```js
+if (condition) {
+    it('works', function () {});
+}
+
+condition && describe('suite', function () {});
+
+condition ? it('left', function () {}) : it('right', function () {});
+```
+
+These patterns would not be considered problems:
+
+```js
+describe('suite', function () {
+    it('works', function () {});
+});
+
+it('works', function () {
+    if (condition) {
+        doWork();
+    }
+});
+
+if (condition) {
+    beforeEach(function () {});
+}
+```
+
+## When Not To Use It
+
+If your project intentionally declares suites or test cases conditionally.

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -13,6 +13,7 @@ import { noAsyncAndDoneRule } from './rules/no-async-and-done.js';
 import { noAsyncInSyncTestsRule } from './rules/no-async-in-sync-tests.js';
 import { noAsyncSuiteRule } from './rules/no-async-suite.js';
 import { noCodeAfterDoneRule } from './rules/no-code-after-done.js';
+import { noConditionalTestsRule } from './rules/no-conditional-tests.js';
 import { noDoneTwiceRule } from './rules/no-done-twice.js';
 import { noEmptyTitleRule } from './rules/no-empty-title.js';
 import { noExclusiveTestsRule } from './rules/no-exclusive-tests.js';
@@ -50,6 +51,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
     'mocha/no-code-after-done': 'error',
+    'mocha/no-conditional-tests': 'error',
     'mocha/no-done-twice': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-exports': 'error',
@@ -85,6 +87,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-async-in-sync-tests': 'off',
     'mocha/no-async-suite': 'error',
     'mocha/no-code-after-done': 'error',
+    'mocha/no-conditional-tests': 'off',
     'mocha/no-done-twice': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
@@ -120,6 +123,7 @@ const rules = {
     'no-async-in-sync-tests': noAsyncInSyncTestsRule,
     'no-async-suite': noAsyncSuiteRule,
     'no-code-after-done': noCodeAfterDoneRule,
+    'no-conditional-tests': noConditionalTestsRule,
     'no-done-twice': noDoneTwiceRule,
     'no-exclusive-tests': noExclusiveTestsRule,
     'no-exports': noExportsRule,

--- a/source/rules/no-conditional-tests.test.ts
+++ b/source/rules/no-conditional-tests.test.ts
@@ -13,11 +13,7 @@ ruleTester.run('no-conditional-tests', noConditionalTestsRule, {
         'condition ? afterEach(function () {}) : after(function () {});',
         withInterface('TDD', 'suite("suite", function () { test("works", function () {}); });'),
         {
-            code: [
-                'foo("suite", function () {',
-                '    bar("works", function () {});',
-                '});'
-            ].join('\n'),
+            code: 'foo("suite", function () { bar("works", function () {}); });',
             settings: {
                 mocha: {
                     additionalCustomNames: [
@@ -50,9 +46,7 @@ ruleTester.run('no-conditional-tests', noConditionalTestsRule, {
             errors: [{ message: 'Unexpected conditional Mocha suite or test declaration.', column: 14, line: 1 }]
         }),
         {
-            code: [
-                'foo && bar("works", function () {});'
-            ].join('\n'),
+            code: 'foo && bar("works", function () {});',
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'bar', type: 'testCase', interface: 'BDD' }]

--- a/source/rules/no-conditional-tests.test.ts
+++ b/source/rules/no-conditional-tests.test.ts
@@ -1,0 +1,64 @@
+import { RuleTester } from 'eslint';
+import { withInterface } from '../mocha-interface-test-cases.js';
+import { noConditionalTestsRule } from './no-conditional-tests.js';
+
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
+
+ruleTester.run('no-conditional-tests', noConditionalTestsRule, {
+    valid: [
+        'describe("suite", function () { it("works", function () {}); });',
+        'it("works", function () { if (condition) { doWork(); } });',
+        'if (condition) { before(function () {}); }',
+        'condition && beforeEach(function () {});',
+        'condition ? afterEach(function () {}) : after(function () {});',
+        withInterface('TDD', 'suite("suite", function () { test("works", function () {}); });'),
+        {
+            code: [
+                'foo("suite", function () {',
+                '    bar("works", function () {});',
+                '});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'foo', type: 'suite', interface: 'BDD' },
+                        { name: 'bar', type: 'testCase', interface: 'BDD' }
+                    ]
+                }
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: 'if (condition) { it("works", function () {}); }',
+            errors: [{ message: 'Unexpected conditional Mocha suite or test declaration.', column: 18, line: 1 }]
+        },
+        {
+            code: 'condition && describe("suite", function () {});',
+            errors: [{ message: 'Unexpected conditional Mocha suite or test declaration.', column: 14, line: 1 }]
+        },
+        {
+            code: 'condition ? it("left", function () {}) : it("right", function () {});',
+            errors: [
+                { message: 'Unexpected conditional Mocha suite or test declaration.', column: 13, line: 1 },
+                { message: 'Unexpected conditional Mocha suite or test declaration.', column: 42, line: 1 }
+            ]
+        },
+        withInterface('TDD', {
+            code: 'condition && test("works", function () {});',
+            errors: [{ message: 'Unexpected conditional Mocha suite or test declaration.', column: 14, line: 1 }]
+        }),
+        {
+            code: [
+                'foo && bar("works", function () {});'
+            ].join('\n'),
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'bar', type: 'testCase', interface: 'BDD' }]
+                }
+            },
+            errors: [{ message: 'Unexpected conditional Mocha suite or test declaration.', column: 8, line: 1 }]
+        }
+    ]
+});

--- a/source/rules/no-conditional-tests.ts
+++ b/source/rules/no-conditional-tests.ts
@@ -1,0 +1,54 @@
+import type { Rule } from 'eslint';
+import { createMochaVisitors } from '../ast/mocha-visitors.js';
+import { getParentNode, isFunction, isProgram } from '../ast/node-types.js';
+
+function isConditionalNode(node: Readonly<Rule.Node>): boolean {
+    return node.type === 'IfStatement' ||
+        node.type === 'ConditionalExpression' ||
+        node.type === 'LogicalExpression';
+}
+
+function isInsideConditional(node: Readonly<Rule.Node>): boolean {
+    let current = node;
+
+    while (true) {
+        const parent = getParentNode(current);
+
+        if (isFunction(parent) || isProgram(parent)) {
+            return false;
+        }
+
+        if (isConditionalNode(parent)) {
+            return true;
+        }
+
+        current = parent;
+    }
+}
+
+export const noConditionalTestsRule: Readonly<Rule.RuleModule> = {
+    meta: {
+        type: 'problem',
+        languages: ['js/js'],
+        docs: {
+            description: 'Disallow conditional suite and test declarations',
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-conditional-tests.md'
+        },
+        messages: {
+            unexpectedConditionalTest: 'Unexpected conditional Mocha suite or test declaration.'
+        },
+        schema: []
+    },
+    create(context) {
+        return createMochaVisitors(context, {
+            suiteOrTestCase(visitorContext) {
+                if (isInsideConditional(visitorContext.node)) {
+                    context.report({
+                        node: visitorContext.node,
+                        messageId: 'unexpectedConditionalTest'
+                    });
+                }
+            }
+        });
+    }
+};


### PR DESCRIPTION
Disallow conditional suite and test declarations.

This wires the rule into the plugin and refreshes the generated docs.