### PR TITLE
Add hook-order support to `consistent-structure`

### DIFF
--- a/documentation/rules/consistent-structure.md
+++ b/documentation/rules/consistent-structure.md
@@ -11,6 +11,7 @@ This rule enforces a consistent arrangement of direct Mocha children within a su
 This rule can enforce:
 
 - a specific order for hooks, test cases, and child suites
+- a specific order for recognized hook phases
 - that duplicate hook names are not used at the same direct level
 - that direct test cases and direct child suites are not mixed in the same suite
 
@@ -36,6 +37,11 @@ describe('root', function () {
     beforeEach(function () {});
     beforeEach(function () {});
 });
+
+describe('root', function () {
+    afterEach(function () {});
+    beforeEach(function () {});
+});
 ```
 
 These patterns would not be considered warnings:
@@ -45,6 +51,13 @@ describe('root', function () {
     beforeEach(function () {});
     it('works', function () {});
     it('works again', function () {});
+});
+
+describe('root', function () {
+    before(function () {});
+    beforeEach(function () {});
+    afterEach(function () {});
+    after(function () {});
 });
 
 describe('root', function () {
@@ -62,6 +75,7 @@ beforeEach(function () {});
 This rule supports the following options:
 
 - `order`: Controls the required order of direct Mocha children. Use `"hooks-tests-suites"` to require hooks before test cases and test cases before child suites. Defaults to `"off"`.
+- `hookOrder`: Controls the required order of recognized hook phases. Use `"setup-teardown"` to require `before` or `suiteSetup` hooks before `beforeEach` or `setup`, then `afterEach` or `teardown`, then `after` or `suiteTeardown`. This check uses the terminal hook name, so custom hooks with other names are ignored. Defaults to `"off"`.
 - `disallowDuplicateHooks`: Reports duplicate hook names at the same direct level. This also applies to top-level hooks. Defaults to `false`.
 - `disallowMixedTestsAndSuites`: Reports suites that contain both direct test cases and direct child suites. Hooks do not count towards this mix. Defaults to `false`.
 
@@ -71,6 +85,7 @@ This rule supports the following options:
         "mocha/consistent-structure": ["error", {
             "disallowDuplicateHooks": true,
             "order": "hooks-tests-suites",
+            "hookOrder": "setup-teardown",
             "disallowMixedTestsAndSuites": true
         }]
     }
@@ -79,4 +94,4 @@ This rule supports the following options:
 
 ## When Not To Use It
 
-If your project intentionally mixes direct tests and direct child suites, if duplicate sibling hooks are acceptable, or if you do not care about a consistent sibling order inside suites.
+If your project intentionally mixes direct tests and direct child suites, if duplicate sibling hooks are acceptable, or if you do not care about consistent direct-child or hook ordering inside suites.

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -39,7 +39,12 @@ const pluginMeta = await readClosestPackageMetadata(import.meta.url);
 const allRules: Linter.RulesRecord = {
     'mocha/consistent-structure': [
         'error',
-        { order: 'hooks-tests-suites', disallowDuplicateHooks: true, disallowMixedTestsAndSuites: true }
+        {
+            order: 'hooks-tests-suites',
+            hookOrder: 'setup-teardown',
+            disallowDuplicateHooks: true,
+            disallowMixedTestsAndSuites: true
+        }
     ],
     'mocha/handle-done-callback': 'error',
     'mocha/limit-retries': 'error',

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -41,7 +41,6 @@ const allRules: Linter.RulesRecord = {
         'error',
         {
             order: 'hooks-tests-suites',
-            hookOrder: 'setup-teardown',
             disallowDuplicateHooks: true,
             disallowMixedTestsAndSuites: true
         }

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -104,7 +104,8 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
         'describe(function() { describe(function() {}); describe(function() {}); });',
         'describe(function() { it(function() {}); it(function() {}); });',
         {
-            code: 'describe(function() { before(function() {}); beforeEach(function() {}); afterEach(function() {}); after(function() {}); });',
+            code:
+                'describe(function() { before(function() {}); beforeEach(function() {}); afterEach(function() {}); after(function() {}); });',
             options: [{ hookOrder: 'setup-teardown' }]
         },
         {
@@ -135,7 +136,8 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
                 '    teardown(function() {});',
                 '    suiteTeardown(function() {});',
                 '});'
-            ].join('\n'),
+            ]
+                .join('\n'),
             options: [{ hookOrder: 'setup-teardown' }]
         }),
         {
@@ -161,7 +163,8 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
                 '    forEach([ 1 ]).afterEach(function() {});',
                 '    forEach([ 1 ]).after(function() {});',
                 '});'
-            ].join('\n'),
+            ]
+                .join('\n'),
             options: [{ hookOrder: 'setup-teardown' }],
             settings: {
                 mocha: {
@@ -278,7 +281,8 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
                 '    forEach([ 1 ]).afterEach(function() {});',
                 '    forEach([ 1 ]).beforeEach(function() {});',
                 '});'
-            ].join('\n'),
+            ]
+                .join('\n'),
             options: [{ hookOrder: 'setup-teardown' }],
             settings: {
                 mocha: {

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -104,6 +104,14 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
         'describe(function() { describe(function() {}); describe(function() {}); });',
         'describe(function() { it(function() {}); it(function() {}); });',
         {
+            code: 'describe(function() { before(function() {}); beforeEach(function() {}); afterEach(function() {}); after(function() {}); });',
+            options: [{ hookOrder: 'setup-teardown' }]
+        },
+        {
+            code: 'before(function() {}); beforeEach(function() {}); afterEach(function() {}); after(function() {});',
+            options: [{ hookOrder: 'setup-teardown' }]
+        },
+        {
             code: 'describe(function() { it(function() {}); describe(function() {}); });',
             options: [{ order: 'hooks-tests-suites' }]
         },
@@ -119,6 +127,17 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             code: 'suite(function() { setup(function() {}); suite(function() {}); suite(function() {}); });',
             options: [{ order: 'hooks-tests-suites', disallowMixedTestsAndSuites: true }]
         }),
+        withInterface('TDD', {
+            code: [
+                'suite(function() {',
+                '    suiteSetup(function() {});',
+                '    setup(function() {});',
+                '    teardown(function() {});',
+                '    suiteTeardown(function() {});',
+                '});'
+            ].join('\n'),
+            options: [{ hookOrder: 'setup-teardown' }]
+        }),
         {
             code: [
                 'foo(function() {',
@@ -131,6 +150,27 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             settings: {
                 mocha: {
                     additionalCustomNames: [{ name: 'foo', type: 'suite', interface: 'BDD' }]
+                }
+            }
+        },
+        {
+            code: [
+                'describe(function() {',
+                '    forEach([ 1 ]).before(function() {});',
+                '    forEach([ 1 ]).beforeEach(function() {});',
+                '    forEach([ 1 ]).afterEach(function() {});',
+                '    forEach([ 1 ]).after(function() {});',
+                '});'
+            ].join('\n'),
+            options: [{ hookOrder: 'setup-teardown' }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'forEach().before', type: 'hook', interface: 'BDD' },
+                        { name: 'forEach().beforeEach', type: 'hook', interface: 'BDD' },
+                        { name: 'forEach().afterEach', type: 'hook', interface: 'BDD' },
+                        { name: 'forEach().after', type: 'hook', interface: 'BDD' }
+                    ]
                 }
             }
         }
@@ -146,6 +186,15 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             code: 'describe(function() { describe(function() {}); before(function() {}); });',
             options: [{ order: 'hooks-tests-suites' }],
             errors: [{ message: 'Unexpected hook after a child suite.', column: 48, line: 1 }]
+        },
+        {
+            code: 'describe(function() { beforeEach(function() {}); before(function() {}); });',
+            options: [{ hookOrder: 'setup-teardown' }],
+            errors: [{
+                message: 'Unexpected Mocha `before()` hook after `beforeEach()` hook.',
+                column: 50,
+                line: 1
+            }]
         },
         {
             code: 'describe(function() { describe(function() {}); it(function() {}); });',
@@ -194,6 +243,15 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
                 { message: 'Unexpected mix of test cases and child suites at the same level.', column: 42, line: 1 }
             ]
         }),
+        withInterface('TDD', {
+            code: 'suite(function() { teardown(function() {}); setup(function() {}); });',
+            options: [{ hookOrder: 'setup-teardown' }],
+            errors: [{
+                message: 'Unexpected Mocha `setup()` hook after `teardown()` hook.',
+                column: 45,
+                line: 1
+            }]
+        }),
         {
             code: [
                 'foo(function() {',
@@ -210,6 +268,28 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             },
             errors: [{
                 message: 'Unexpected mix of test cases and child suites at the same level.',
+                column: 5,
+                line: 3
+            }]
+        },
+        {
+            code: [
+                'describe(function() {',
+                '    forEach([ 1 ]).afterEach(function() {});',
+                '    forEach([ 1 ]).beforeEach(function() {});',
+                '});'
+            ].join('\n'),
+            options: [{ hookOrder: 'setup-teardown' }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [
+                        { name: 'forEach().beforeEach', type: 'hook', interface: 'BDD' },
+                        { name: 'forEach().afterEach', type: 'hook', interface: 'BDD' }
+                    ]
+                }
+            },
+            errors: [{
+                message: 'Unexpected Mocha `forEach().beforeEach()` hook after `forEach().afterEach()` hook.',
                 column: 5,
                 line: 3
             }]
@@ -276,6 +356,8 @@ describe('consistent-structure helpers', function () {
                 hasReportedMixedStructure: false,
                 hasSeenSuite: false,
                 hasSeenTestCase: false,
+                highestSeenHookOrderName: null,
+                highestSeenHookOrderRank: null,
                 highestSeenKind: null,
                 scopeNode: suiteBody as never,
                 usedHookNames: new Set()

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -113,6 +113,15 @@ ruleTester.run('consistent-structure', consistentStructureRule, {
             options: [{ hookOrder: 'setup-teardown' }]
         },
         {
+            code: 'describe(function() { around(function() {}); before(function() {}); });',
+            options: [{ hookOrder: 'setup-teardown' }],
+            settings: {
+                mocha: {
+                    additionalCustomNames: [{ name: 'around', type: 'hook', interface: 'BDD' }]
+                }
+            }
+        },
+        {
             code: 'describe(function() { it(function() {}); describe(function() {}); });',
             options: [{ order: 'hooks-tests-suites' }]
         },

--- a/source/rules/consistent-structure.ts
+++ b/source/rules/consistent-structure.ts
@@ -15,6 +15,10 @@ import { getRuleOption, type InferSchemaOption, type RuleSchema } from '../rule-
 const optionSchema = {
     type: 'object',
     properties: {
+        hookOrder: {
+            type: 'string',
+            enum: ['setup-teardown', 'off']
+        },
         order: {
             type: 'string',
             enum: ['hooks-tests-suites', 'off']
@@ -32,6 +36,7 @@ const optionSchema = {
 type Option = InferSchemaOption<typeof optionSchema>;
 type ResolvedOption = Option & {
     disallowDuplicateHooks: boolean;
+    hookOrder: 'setup-teardown' | 'off';
     order: 'hooks-tests-suites' | 'off';
     disallowMixedTestsAndSuites: boolean;
 };
@@ -40,6 +45,8 @@ type StructureLayer = {
     hasReportedMixedStructure: boolean;
     hasSeenSuite: boolean;
     hasSeenTestCase: boolean;
+    highestSeenHookOrderName: string | null;
+    highestSeenHookOrderRank: number | null;
     highestSeenKind: StructureEntityKind | null;
     scopeNode: AnyFunction['body'] | Program;
     usedHookNames: Set<string>;
@@ -51,10 +58,14 @@ type DirectStructureContext = {
 type TrackedStructureContext = DirectStructureContext & {
     visitorContext: Readonly<VisitorContext>;
 };
-type StructureTrackingOptions = Pick<ResolvedOption, 'disallowDuplicateHooks' | 'disallowMixedTestsAndSuites'>;
+type StructureTrackingOptions = Pick<
+    ResolvedOption,
+    'disallowDuplicateHooks' | 'disallowMixedTestsAndSuites' | 'hookOrder'
+>;
 
 const defaultOption: ResolvedOption = {
     disallowDuplicateHooks: false,
+    hookOrder: 'off',
     order: 'off',
     disallowMixedTestsAndSuites: false
 };
@@ -63,12 +74,24 @@ const entityRank: Readonly<Record<StructureEntityKind, number>> = {
     testCase: 1,
     suite: 2
 };
+const hookOrderRank: Readonly<Record<string, number>> = {
+    'before()': 0,
+    'suiteSetup()': 0,
+    'beforeEach()': 1,
+    'setup()': 1,
+    'afterEach()': 2,
+    'teardown()': 2,
+    'after()': 3,
+    'suiteTeardown()': 3
+};
 
 function createStructureLayer(scopeNode: StructureLayer['scopeNode']): Readonly<StructureLayer> {
     return {
         hasReportedMixedStructure: false,
         hasSeenSuite: false,
         hasSeenTestCase: false,
+        highestSeenHookOrderName: null,
+        highestSeenHookOrderRank: null,
         highestSeenKind: null,
         scopeNode,
         usedHookNames: new Set()
@@ -175,6 +198,59 @@ function shouldReportDuplicateHook(
     return currentKind === 'hook' && layer.usedHookNames.has(visitorContext.name);
 }
 
+type OrderedHook = {
+    name: string;
+    rank: number;
+};
+
+function getTerminalName(name: string): string {
+    return name.split('.').at(-1) ?? name;
+}
+
+function getOrderedHook(name: string): Readonly<OrderedHook> | null {
+    const rank = hookOrderRank[getTerminalName(name)];
+
+    if (rank === undefined) {
+        return null;
+    }
+
+    return { name, rank };
+}
+
+function reportUnexpectedHookOrder(
+    context: Readonly<Rule.RuleContext>,
+    visitorContext: Readonly<VisitorContext>,
+    previousHook: string
+): void {
+    context.report({
+        node: visitorContext.node,
+        messageId: 'unexpectedHookOrder',
+        data: { currentHook: visitorContext.name, previousHook }
+    });
+}
+
+function getTrackedOrderedHook(
+    currentKind: StructureEntityKind,
+    visitorContext: Readonly<VisitorContext>
+): Readonly<OrderedHook> | null {
+    if (currentKind !== 'hook') {
+        return null;
+    }
+
+    return getOrderedHook(visitorContext.name);
+}
+
+function shouldReportHookOrder(
+    layer: Readonly<StructureLayer>,
+    hookOrder: ResolvedOption['hookOrder'],
+    orderedHook: Readonly<OrderedHook> | null
+): orderedHook is OrderedHook {
+    return hookOrder === 'setup-teardown' &&
+        orderedHook !== null &&
+        layer.highestSeenHookOrderRank !== null &&
+        orderedHook.rank < layer.highestSeenHookOrderRank;
+}
+
 function isSuiteBodyLayer(layer: Readonly<StructureLayer>): boolean {
     return !isProgram(layer.scopeNode);
 }
@@ -186,6 +262,15 @@ function createTrackedLayer(
     hasReportedMixedStructure: boolean
 ): Readonly<StructureLayer> {
     const usedHookNames = new Set(layer.usedHookNames);
+    const trackedOrderedHook = getTrackedOrderedHook(currentKind, visitorContext);
+    const highestSeenHookOrderRank = trackedOrderedHook !== null &&
+        (layer.highestSeenHookOrderRank === null || trackedOrderedHook.rank > layer.highestSeenHookOrderRank)
+        ? trackedOrderedHook.rank
+        : layer.highestSeenHookOrderRank;
+    const highestSeenHookOrderName = trackedOrderedHook !== null &&
+        (layer.highestSeenHookOrderRank === null || trackedOrderedHook.rank > layer.highestSeenHookOrderRank)
+        ? trackedOrderedHook.name
+        : layer.highestSeenHookOrderName;
 
     if (currentKind === 'hook') {
         usedHookNames.add(visitorContext.name);
@@ -195,6 +280,8 @@ function createTrackedLayer(
         hasReportedMixedStructure: layer.hasReportedMixedStructure || hasReportedMixedStructure,
         hasSeenSuite: layer.hasSeenSuite || currentKind === 'suite',
         hasSeenTestCase: layer.hasSeenTestCase || currentKind === 'testCase',
+        highestSeenHookOrderName,
+        highestSeenHookOrderRank,
         highestSeenKind: getHighestSeenKind(layer.highestSeenKind, currentKind),
         scopeNode: layer.scopeNode,
         usedHookNames
@@ -247,12 +334,14 @@ function trackStructureLayer(
     options: Readonly<StructureTrackingOptions>
 ): void {
     const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
-    const { disallowDuplicateHooks, disallowMixedTestsAndSuites } = options;
+    const { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = options;
     const reportsMixedStructure = isSuiteBodyLayer(currentLayer) &&
         disallowMixedTestsAndSuites &&
         shouldReportMixedStructure(currentLayer, currentKind);
     const reportsDuplicateHook = disallowDuplicateHooks &&
         shouldReportDuplicateHook(currentLayer, currentKind, visitorContext);
+    const orderedHook = getTrackedOrderedHook(currentKind, visitorContext);
+    const reportsHookOrder = shouldReportHookOrder(currentLayer, hookOrder, orderedHook);
 
     if (reportsMixedStructure) {
         reportMixedStructure(context, visitorContext);
@@ -260,6 +349,10 @@ function trackStructureLayer(
 
     if (reportsDuplicateHook) {
         reportDuplicateHook(context, visitorContext);
+    }
+
+    if (reportsHookOrder && currentLayer.highestSeenHookOrderName !== null) {
+        reportUnexpectedHookOrder(context, visitorContext, currentLayer.highestSeenHookOrderName);
     }
 
     replaceCurrentLayer(layers, createTrackedLayer(currentLayer, currentKind, visitorContext, reportsMixedStructure));
@@ -278,13 +371,16 @@ export const consistentStructureRule: Readonly<Rule.RuleModule> = {
             unexpectedHookAfterSuite: 'Unexpected hook after a child suite.',
             unexpectedHookAfterTest: 'Unexpected hook after a test case.',
             unexpectedDuplicateHook: 'Unexpected use of duplicate Mocha `{{name}}` hook',
+            unexpectedHookOrder: 'Unexpected Mocha `{{currentHook}}` hook after `{{previousHook}}` hook.',
             unexpectedMixedTestsAndSuites: 'Unexpected mix of test cases and child suites at the same level.',
             unexpectedTestAfterSuite: 'Unexpected test case after a child suite.'
         },
         schema: [optionSchema]
     },
     create(context) {
-        const { order, disallowDuplicateHooks, disallowMixedTestsAndSuites } = getRuleOption<ResolvedOption>(context);
+        const { order, disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = getRuleOption<
+            ResolvedOption
+        >(context);
         const layers: StructureLayer[] = [];
 
         function registerStructure(visitorContext: Readonly<VisitorContext>): void {
@@ -305,7 +401,7 @@ export const consistentStructureRule: Readonly<Rule.RuleModule> = {
                 context,
                 layers,
                 { ...directStructureContext, visitorContext },
-                { disallowDuplicateHooks, disallowMixedTestsAndSuites }
+                { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder }
             );
         }
 

--- a/source/rules/consistent-structure.ts
+++ b/source/rules/consistent-structure.ts
@@ -58,12 +58,6 @@ type DirectStructureContext = {
 type TrackedStructureContext = DirectStructureContext & {
     visitorContext: Readonly<VisitorContext>;
 };
-type HookOrderTracking = Pick<StructureLayer, 'highestSeenHookOrderName' | 'highestSeenHookOrderRank'>;
-type StructureReports = {
-    reportsDuplicateHook: boolean;
-    reportsMixedStructure: boolean;
-    previousHookName: string | null;
-};
 type StructureTrackingOptions = Pick<
     ResolvedOption,
     'disallowDuplicateHooks' | 'disallowMixedTestsAndSuites' | 'hookOrder'
@@ -210,7 +204,9 @@ type OrderedHook = {
 };
 
 function getTerminalName(name: string): string {
-    return name.split('.').at(-1) ?? name;
+    const lastSeparatorIndex = name.lastIndexOf('.');
+
+    return lastSeparatorIndex === -1 ? name : name.slice(lastSeparatorIndex + 1);
 }
 
 function getOrderedHook(name: string): Readonly<OrderedHook> | null {
@@ -257,28 +253,16 @@ function shouldReportHookOrder(
         orderedHook.rank < layer.highestSeenHookOrderRank;
 }
 
-function shouldReplaceHighestSeenHookOrder(
-    layer: Readonly<StructureLayer>,
-    orderedHook: Readonly<OrderedHook>
-): boolean {
-    return layer.highestSeenHookOrderRank === null || orderedHook.rank > layer.highestSeenHookOrderRank;
+function isSuiteBodyLayer(layer: Readonly<StructureLayer>): boolean {
+    return !isProgram(layer.scopeNode);
 }
 
-function getNextHookOrderTracking(
+function shouldRememberHighestSeenHookOrder(
     layer: Readonly<StructureLayer>,
     orderedHook: Readonly<OrderedHook> | null
-): Readonly<HookOrderTracking> {
-    if (orderedHook === null || !shouldReplaceHighestSeenHookOrder(layer, orderedHook)) {
-        return {
-            highestSeenHookOrderName: layer.highestSeenHookOrderName,
-            highestSeenHookOrderRank: layer.highestSeenHookOrderRank
-        };
-    }
-
-    return {
-        highestSeenHookOrderName: orderedHook.name,
-        highestSeenHookOrderRank: orderedHook.rank
-    };
+): orderedHook is OrderedHook {
+    return orderedHook !== null &&
+        (layer.highestSeenHookOrderRank === null || orderedHook.rank > layer.highestSeenHookOrderRank);
 }
 
 function getUsedHookNames(
@@ -295,25 +279,35 @@ function getUsedHookNames(
     return usedHookNames;
 }
 
-function isSuiteBodyLayer(layer: Readonly<StructureLayer>): boolean {
-    return !isProgram(layer.scopeNode);
+function getTrackedOrderedHookForLayer(
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    hookOrder: ResolvedOption['hookOrder']
+): Readonly<OrderedHook> | null {
+    return hookOrder === 'setup-teardown'
+        ? getTrackedOrderedHook(trackedStructureContext.currentKind, trackedStructureContext.visitorContext)
+        : null;
 }
 
 function createTrackedLayer(
     layer: Readonly<StructureLayer>,
-    currentKind: StructureEntityKind,
-    visitorContext: Readonly<VisitorContext>,
-    hasReportedMixedStructure: boolean
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    hasReportedMixedStructure: boolean,
+    hookOrder: ResolvedOption['hookOrder']
 ): Readonly<StructureLayer> {
-    const trackedOrderedHook = getTrackedOrderedHook(currentKind, visitorContext);
-    const { highestSeenHookOrderName, highestSeenHookOrderRank } = getNextHookOrderTracking(layer, trackedOrderedHook);
+    const { currentKind, visitorContext } = trackedStructureContext;
+    const trackedOrderedHook = getTrackedOrderedHookForLayer(trackedStructureContext, hookOrder);
+    const remembersHighestSeenHookOrder = shouldRememberHighestSeenHookOrder(layer, trackedOrderedHook);
 
     return {
         hasReportedMixedStructure: layer.hasReportedMixedStructure || hasReportedMixedStructure,
         hasSeenSuite: layer.hasSeenSuite || currentKind === 'suite',
         hasSeenTestCase: layer.hasSeenTestCase || currentKind === 'testCase',
-        highestSeenHookOrderName,
-        highestSeenHookOrderRank,
+        highestSeenHookOrderName: remembersHighestSeenHookOrder
+            ? trackedOrderedHook.name
+            : layer.highestSeenHookOrderName,
+        highestSeenHookOrderRank: remembersHighestSeenHookOrder
+            ? trackedOrderedHook.rank
+            : layer.highestSeenHookOrderRank,
         highestSeenKind: getHighestSeenKind(layer.highestSeenKind, currentKind),
         scopeNode: layer.scopeNode,
         usedHookNames: getUsedHookNames(layer, currentKind, visitorContext)
@@ -359,41 +353,54 @@ function reportDuplicateHook(context: Readonly<Rule.RuleContext>, visitorContext
     });
 }
 
-function getStructureReports(
-    trackedStructureContext: Readonly<TrackedStructureContext>,
-    options: Readonly<StructureTrackingOptions>
-): Readonly<StructureReports> {
-    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
-    const { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = options;
-    const orderedHook = getTrackedOrderedHook(currentKind, visitorContext);
-
-    return {
-        reportsMixedStructure: isSuiteBodyLayer(currentLayer) &&
-            disallowMixedTestsAndSuites &&
-            shouldReportMixedStructure(currentLayer, currentKind),
-        reportsDuplicateHook: disallowDuplicateHooks &&
-            shouldReportDuplicateHook(currentLayer, currentKind, visitorContext),
-        previousHookName: shouldReportHookOrder(currentLayer, hookOrder, orderedHook)
-            ? currentLayer.highestSeenHookOrderName
-            : null
-    };
-}
-
-function reportStructureReports(
+function reportMixedStructureIfNeeded(
     context: Readonly<Rule.RuleContext>,
-    visitorContext: Readonly<VisitorContext>,
-    reports: Readonly<StructureReports>
-): void {
-    if (reports.reportsMixedStructure) {
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    disallowMixedTestsAndSuites: boolean
+): boolean {
+    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
+    const shouldReport = isSuiteBodyLayer(currentLayer) &&
+        disallowMixedTestsAndSuites &&
+        shouldReportMixedStructure(currentLayer, currentKind);
+
+    if (shouldReport) {
         reportMixedStructure(context, visitorContext);
     }
 
-    if (reports.reportsDuplicateHook) {
+    return shouldReport;
+}
+
+function reportDuplicateHookIfNeeded(
+    context: Readonly<Rule.RuleContext>,
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    disallowDuplicateHooks: boolean
+): void {
+    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
+
+    if (disallowDuplicateHooks && shouldReportDuplicateHook(currentLayer, currentKind, visitorContext)) {
         reportDuplicateHook(context, visitorContext);
     }
+}
 
-    if (reports.previousHookName !== null) {
-        reportUnexpectedHookOrder(context, visitorContext, reports.previousHookName);
+function reportUnexpectedHookOrderIfNeeded(
+    context: Readonly<Rule.RuleContext>,
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    hookOrder: ResolvedOption['hookOrder']
+): void {
+    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
+
+    if (
+        hookOrder === 'off' ||
+        currentLayer.highestSeenHookOrderName === null ||
+        currentLayer.highestSeenHookOrderRank === null
+    ) {
+        return;
+    }
+
+    const orderedHook = getTrackedOrderedHook(currentKind, visitorContext);
+
+    if (shouldReportHookOrder(currentLayer, hookOrder, orderedHook)) {
+        reportUnexpectedHookOrder(context, visitorContext, currentLayer.highestSeenHookOrderName);
     }
 }
 
@@ -403,13 +410,19 @@ function trackStructureLayer(
     trackedStructureContext: Readonly<TrackedStructureContext>,
     options: Readonly<StructureTrackingOptions>
 ): void {
-    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
-    const reports = getStructureReports(trackedStructureContext, options);
+    const { currentLayer } = trackedStructureContext;
+    const { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = options;
+    const reportsMixedStructure = reportMixedStructureIfNeeded(
+        context,
+        trackedStructureContext,
+        disallowMixedTestsAndSuites
+    );
 
-    reportStructureReports(context, visitorContext, reports);
+    reportDuplicateHookIfNeeded(context, trackedStructureContext, disallowDuplicateHooks);
+    reportUnexpectedHookOrderIfNeeded(context, trackedStructureContext, hookOrder);
     replaceCurrentLayer(
         layers,
-        createTrackedLayer(currentLayer, currentKind, visitorContext, reports.reportsMixedStructure)
+        createTrackedLayer(currentLayer, trackedStructureContext, reportsMixedStructure, hookOrder)
     );
 }
 

--- a/source/rules/consistent-structure.ts
+++ b/source/rules/consistent-structure.ts
@@ -36,7 +36,7 @@ const optionSchema = {
 type Option = InferSchemaOption<typeof optionSchema>;
 type ResolvedOption = Option & {
     disallowDuplicateHooks: boolean;
-    hookOrder: 'setup-teardown' | 'off';
+    hookOrder: 'off' | 'setup-teardown';
     order: 'hooks-tests-suites' | 'off';
     disallowMixedTestsAndSuites: boolean;
 };
@@ -57,6 +57,12 @@ type DirectStructureContext = {
 };
 type TrackedStructureContext = DirectStructureContext & {
     visitorContext: Readonly<VisitorContext>;
+};
+type HookOrderTracking = Pick<StructureLayer, 'highestSeenHookOrderName' | 'highestSeenHookOrderRank'>;
+type StructureReports = {
+    reportsDuplicateHook: boolean;
+    reportsMixedStructure: boolean;
+    previousHookName: string | null;
 };
 type StructureTrackingOptions = Pick<
     ResolvedOption,
@@ -251,6 +257,44 @@ function shouldReportHookOrder(
         orderedHook.rank < layer.highestSeenHookOrderRank;
 }
 
+function shouldReplaceHighestSeenHookOrder(
+    layer: Readonly<StructureLayer>,
+    orderedHook: Readonly<OrderedHook>
+): boolean {
+    return layer.highestSeenHookOrderRank === null || orderedHook.rank > layer.highestSeenHookOrderRank;
+}
+
+function getNextHookOrderTracking(
+    layer: Readonly<StructureLayer>,
+    orderedHook: Readonly<OrderedHook> | null
+): Readonly<HookOrderTracking> {
+    if (orderedHook === null || !shouldReplaceHighestSeenHookOrder(layer, orderedHook)) {
+        return {
+            highestSeenHookOrderName: layer.highestSeenHookOrderName,
+            highestSeenHookOrderRank: layer.highestSeenHookOrderRank
+        };
+    }
+
+    return {
+        highestSeenHookOrderName: orderedHook.name,
+        highestSeenHookOrderRank: orderedHook.rank
+    };
+}
+
+function getUsedHookNames(
+    layer: Readonly<StructureLayer>,
+    currentKind: StructureEntityKind,
+    visitorContext: Readonly<VisitorContext>
+): Readonly<Set<string>> {
+    const usedHookNames = new Set(layer.usedHookNames);
+
+    if (currentKind === 'hook') {
+        usedHookNames.add(visitorContext.name);
+    }
+
+    return usedHookNames;
+}
+
 function isSuiteBodyLayer(layer: Readonly<StructureLayer>): boolean {
     return !isProgram(layer.scopeNode);
 }
@@ -261,20 +305,8 @@ function createTrackedLayer(
     visitorContext: Readonly<VisitorContext>,
     hasReportedMixedStructure: boolean
 ): Readonly<StructureLayer> {
-    const usedHookNames = new Set(layer.usedHookNames);
     const trackedOrderedHook = getTrackedOrderedHook(currentKind, visitorContext);
-    const highestSeenHookOrderRank = trackedOrderedHook !== null &&
-        (layer.highestSeenHookOrderRank === null || trackedOrderedHook.rank > layer.highestSeenHookOrderRank)
-        ? trackedOrderedHook.rank
-        : layer.highestSeenHookOrderRank;
-    const highestSeenHookOrderName = trackedOrderedHook !== null &&
-        (layer.highestSeenHookOrderRank === null || trackedOrderedHook.rank > layer.highestSeenHookOrderRank)
-        ? trackedOrderedHook.name
-        : layer.highestSeenHookOrderName;
-
-    if (currentKind === 'hook') {
-        usedHookNames.add(visitorContext.name);
-    }
+    const { highestSeenHookOrderName, highestSeenHookOrderRank } = getNextHookOrderTracking(layer, trackedOrderedHook);
 
     return {
         hasReportedMixedStructure: layer.hasReportedMixedStructure || hasReportedMixedStructure,
@@ -284,7 +316,7 @@ function createTrackedLayer(
         highestSeenHookOrderRank,
         highestSeenKind: getHighestSeenKind(layer.highestSeenKind, currentKind),
         scopeNode: layer.scopeNode,
-        usedHookNames
+        usedHookNames: getUsedHookNames(layer, currentKind, visitorContext)
     };
 }
 
@@ -327,6 +359,44 @@ function reportDuplicateHook(context: Readonly<Rule.RuleContext>, visitorContext
     });
 }
 
+function getStructureReports(
+    trackedStructureContext: Readonly<TrackedStructureContext>,
+    options: Readonly<StructureTrackingOptions>
+): Readonly<StructureReports> {
+    const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
+    const { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = options;
+    const orderedHook = getTrackedOrderedHook(currentKind, visitorContext);
+
+    return {
+        reportsMixedStructure: isSuiteBodyLayer(currentLayer) &&
+            disallowMixedTestsAndSuites &&
+            shouldReportMixedStructure(currentLayer, currentKind),
+        reportsDuplicateHook: disallowDuplicateHooks &&
+            shouldReportDuplicateHook(currentLayer, currentKind, visitorContext),
+        previousHookName: shouldReportHookOrder(currentLayer, hookOrder, orderedHook)
+            ? currentLayer.highestSeenHookOrderName
+            : null
+    };
+}
+
+function reportStructureReports(
+    context: Readonly<Rule.RuleContext>,
+    visitorContext: Readonly<VisitorContext>,
+    reports: Readonly<StructureReports>
+): void {
+    if (reports.reportsMixedStructure) {
+        reportMixedStructure(context, visitorContext);
+    }
+
+    if (reports.reportsDuplicateHook) {
+        reportDuplicateHook(context, visitorContext);
+    }
+
+    if (reports.previousHookName !== null) {
+        reportUnexpectedHookOrder(context, visitorContext, reports.previousHookName);
+    }
+}
+
 function trackStructureLayer(
     context: Readonly<Rule.RuleContext>,
     layers: StructureLayer[],
@@ -334,28 +404,13 @@ function trackStructureLayer(
     options: Readonly<StructureTrackingOptions>
 ): void {
     const { currentKind, currentLayer, visitorContext } = trackedStructureContext;
-    const { disallowDuplicateHooks, disallowMixedTestsAndSuites, hookOrder } = options;
-    const reportsMixedStructure = isSuiteBodyLayer(currentLayer) &&
-        disallowMixedTestsAndSuites &&
-        shouldReportMixedStructure(currentLayer, currentKind);
-    const reportsDuplicateHook = disallowDuplicateHooks &&
-        shouldReportDuplicateHook(currentLayer, currentKind, visitorContext);
-    const orderedHook = getTrackedOrderedHook(currentKind, visitorContext);
-    const reportsHookOrder = shouldReportHookOrder(currentLayer, hookOrder, orderedHook);
+    const reports = getStructureReports(trackedStructureContext, options);
 
-    if (reportsMixedStructure) {
-        reportMixedStructure(context, visitorContext);
-    }
-
-    if (reportsDuplicateHook) {
-        reportDuplicateHook(context, visitorContext);
-    }
-
-    if (reportsHookOrder && currentLayer.highestSeenHookOrderName !== null) {
-        reportUnexpectedHookOrder(context, visitorContext, currentLayer.highestSeenHookOrderName);
-    }
-
-    replaceCurrentLayer(layers, createTrackedLayer(currentLayer, currentKind, visitorContext, reportsMixedStructure));
+    reportStructureReports(context, visitorContext, reports);
+    replaceCurrentLayer(
+        layers,
+        createTrackedLayer(currentLayer, currentKind, visitorContext, reports.reportsMixedStructure)
+    );
 }
 
 export const consistentStructureRule: Readonly<Rule.RuleModule> = {


### PR DESCRIPTION
Add the `hookOrder` option for ordering recognized setup and teardown phases.

This enables the option in the `all` config and updates the rule documentation.