### PR TITLE
Enable `Renovate` with `upgrade` labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+    "extends": ["config:base"],
+    "commitMessagePrefix": "⬆️ ",
+    "labels": ["renovate", "upgrade"],
+    "dependencyDashboard": false,
+    "rebaseStalePrs": true,
+    "lockFileMaintenance": {
+        "enabled": true,
+        "automerge": true
+    },
+    "automerge": true,
+    "automergeType": "pr",
+    "packageRules": [
+        {
+            "matchPackagePatterns": ["^@enormora/eslint-config"],
+            "groupName": "@enormora/eslint-config",
+            "groupSlug": "enormora-eslint-config"
+        }
+    ]
+}


### PR DESCRIPTION
Add `renovate.json` and use the `upgrade` label on Renovate PRs so `pr-log` records dependency updates.