### PR TITLE
Configure `pr-log` to collapse Renovate `upgrade` entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,15 @@
         "semver": "7.6.3",
         "typescript": "5.7.3"
     },
+    "pr-log": {
+        "collapseRules": [
+            {
+                "label": "upgrade",
+                "pattern": "^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$",
+                "replace": "⬆️ Update dependency $<dependency> from $<from> to $<to>"
+            }
+        ]
+    },
     "overrides": {
         "yargs": "18.0.0"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "extends": ["config:base"],
     "commitMessagePrefix": "⬆️ ",
+    "commitMessageExtra": "{{#if isGroup}}{{#if newValue}}to {{newValue}}{{/if}}{{else}}from {{displayFrom}} to {{displayTo}}{{/if}}",
     "labels": ["renovate", "upgrade"],
     "dependencyDashboard": false,
     "rebaseStalePrs": true,


### PR DESCRIPTION
The latest published `pr-log` is still `6.1.1`, so this PR prepares the repo-side config.

It makes Renovate single-dependency PR titles include `from` / `to` versions and adds the matching `pr-log` collapse rule.