### PR TITLE
Add `dependency-cruiser` checks to `just lint`

### DIFF
--- a/dependency-cruiser.config.js
+++ b/dependency-cruiser.config.js
@@ -1,0 +1,129 @@
+const configFiles = ['^dependency-cruiser\\.config\\.js$', '^eslint\\.config\\.js$', '^packtory\\.config\\.js$'];
+const entryPointFiles = ['^source/plugin\\.ts$'];
+const benchmarkFiles = ['^benchmarks/', '\\.bench\\.ts$'];
+const testFiles = ['\\.test\\.ts$'];
+const testSupportFiles = ['^source/mocha-interface-test-cases\\.ts$'];
+const excludedFiles = ['^(\\./)?target/'];
+
+const ignoreFromOrphans = [...configFiles, ...entryPointFiles, ...benchmarkFiles, ...testFiles, ...testSupportFiles];
+
+/** @type {import('dependency-cruiser').IConfiguration} */
+export default {
+    forbidden: [
+        {
+            name: 'no-circular',
+            severity: 'error',
+            from: {},
+            to: {
+                circular: true
+            }
+        },
+        {
+            name: 'no-orphans',
+            severity: 'error',
+            from: {
+                orphan: true,
+                pathNot: [...ignoreFromOrphans, '\\.d\\.ts$']
+            },
+            to: {}
+        },
+        {
+            name: 'no-internal-orphans',
+            severity: 'error',
+            from: {
+                pathNot: []
+            },
+            module: {
+                numberOfDependentsLessThan: 1,
+                pathNot: [...ignoreFromOrphans, '\\.d\\.ts$']
+            }
+        },
+        {
+            name: 'no-internal-but-tested-orphans',
+            severity: 'error',
+            from: {
+                pathNot: [...testFiles, ...benchmarkFiles]
+            },
+            module: {
+                numberOfDependentsLessThan: 1,
+                pathNot: [
+                    ...ignoreFromOrphans,
+                    '.*(?<!\\.(ts|js))$',
+                    '^node_modules/',
+                    ...excludedFiles,
+                    '\\.d\\.ts$'
+                ]
+            }
+        },
+        {
+            name: 'no-deprecated-npm',
+            severity: 'error',
+            from: {},
+            to: {
+                dependencyTypes: ['deprecated']
+            }
+        },
+        {
+            name: 'no-duplicate-dep-types',
+            severity: 'error',
+            from: {},
+            to: {
+                dependencyTypes: ['npm'],
+                dependencyTypesNot: ['type-only'],
+                moreThanOneDependencyType: true
+            }
+        },
+        {
+            name: 'not-to-dev-dep',
+            severity: 'error',
+            from: {
+                path: '^source/',
+                pathNot: testFiles
+            },
+            to: {
+                dependencyTypes: ['npm-dev'],
+                moreThanOneDependencyType: false,
+                pathNot: ['^node_modules/@types/', '\\.d\\.ts$']
+            }
+        },
+        {
+            name: 'no-non-package-json',
+            severity: 'error',
+            from: {},
+            to: {
+                dependencyTypes: ['npm-no-pkg', 'npm-unknown']
+            }
+        },
+        {
+            name: 'not-test-file-import',
+            severity: 'error',
+            from: {
+                pathNot: [...testFiles, ...benchmarkFiles]
+            },
+            to: {
+                path: [...testFiles, ...benchmarkFiles]
+            }
+        }
+    ],
+    options: {
+        doNotFollow: {
+            path: 'node_modules|target/',
+            dependencyTypes: ['npm', 'npm-dev', 'npm-optional', 'npm-peer', 'npm-bundled', 'npm-no-pkg']
+        },
+        exclude: {
+            path: excludedFiles
+        },
+        moduleSystems: ['cjs', 'es6', 'tsd'],
+        tsPreCompilationDeps: true,
+        tsConfig: {
+            fileName: 'tsconfig.json'
+        },
+        preserveSymlinks: false,
+        combinedDependencies: true,
+        reporterOptions: {
+            dot: {
+                collapsePattern: 'node_modules/[^/]+'
+            }
+        }
+    }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,7 +70,7 @@ export default [
     },
     {
         ...nodeConfigFileConfig,
-        files: ['eslint.config.js']
+        files: ['dependency-cruiser.config.js', 'eslint.config.js', 'packtory.config.js']
     },
     {
         ...mochaConfig,

--- a/justfile
+++ b/justfile
@@ -14,12 +14,15 @@ eslint *options:
 
 eslint-fix: (eslint '--fix')
 
+lint-dependencies:
+    depcruise --config dependency-cruiser.config.js './source/**/*.ts' './benchmarks/**/*.ts' './*.js' './*.cjs'
+
 lint-docs:
     markdownlint '**/*.md'
 
 lint-eslint-docs: (update-eslint-docs '--check')
 
-lint: lint-docs lint-eslint-docs eslint
+lint: lint-docs lint-eslint-docs eslint lint-dependencies
 
 lint-fix: eslint-fix format-fix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@eslint-community/eslint-utils": "4.4.1",
                 "globals": "15.14.0",
+                "json-schema-to-ts": "3.1.1",
                 "type-fest": "4.40.0"
             },
             "devDependencies": {
@@ -23,17 +24,18 @@
                 "@enormora/eslint-config-node": "0.0.27",
                 "@enormora/eslint-config-typescript": "0.0.37",
                 "@packtory/cli": "0.0.5",
+                "@types/estree": "1.0.9",
                 "@types/mocha": "10.0.10",
                 "@typescript-eslint/parser": "8.59.3",
                 "c8": "11.0.0",
                 "change-case": "5.4.4",
                 "coveralls": "3.1.1",
+                "dependency-cruiser": "17.4.2",
                 "dprint": "0.48.0",
                 "dprint-plugin-yaml": "0.6.0",
                 "eslint": "10.4.0",
                 "eslint-doc-generator": "2.0.2",
                 "eslint-plugin-eslint-plugin": "6.4.0",
-                "json-schema-to-ts": "3.1.1",
                 "markdownlint-cli": "0.43.0",
                 "mocha": "11.1.0",
                 "pr-log": "6.1.1",
@@ -77,7 +79,6 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
             "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -832,9 +833,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -849,9 +847,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -866,9 +861,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -883,9 +875,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -900,9 +889,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2676,9 +2662,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2693,9 +2676,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2710,9 +2690,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2727,9 +2704,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2744,9 +2718,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2761,9 +2732,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2778,9 +2746,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2795,9 +2760,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2812,9 +2774,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2829,9 +2788,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2932,6 +2888,39 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-jsx-walk": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+            "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/acorn-loose": {
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+            "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.15.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.5",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/agent-base": {
@@ -4466,6 +4455,67 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/dependency-cruiser": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.4.2.tgz",
+            "integrity": "sha512-XbrWY2EkIRoqvJL3feRlwHiYrPD2h6iYZ+LaMZgMLpxDBFXKb3+rXGVAli3/fV+yd9rgTBtFpuAYMDt4RjHQUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "8.16.0",
+                "acorn-jsx": "5.3.2",
+                "acorn-jsx-walk": "2.0.0",
+                "acorn-loose": "8.5.2",
+                "acorn-walk": "8.3.5",
+                "commander": "14.0.3",
+                "enhanced-resolve": "5.22.0",
+                "ignore": "7.0.5",
+                "interpret": "3.1.1",
+                "is-installed-globally": "1.0.0",
+                "json5": "2.2.3",
+                "picomatch": "4.0.4",
+                "prompts": "2.4.2",
+                "rechoir": "0.8.0",
+                "safe-regex": "2.1.1",
+                "semver": "7.8.1",
+                "tsconfig-paths-webpack-plugin": "4.2.0",
+                "watskeburt": "5.0.3"
+            },
+            "bin": {
+                "depcruise": "bin/dependency-cruise.mjs",
+                "depcruise-baseline": "bin/depcruise-baseline.mjs",
+                "depcruise-fmt": "bin/depcruise-fmt.mjs",
+                "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+                "dependency-cruise": "bin/dependency-cruise.mjs",
+                "dependency-cruiser": "bin/dependency-cruise.mjs"
+            },
+            "engines": {
+                "node": "^20.12||^22||>=24"
+            }
+        },
+        "node_modules/dependency-cruiser/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/dependency-cruiser/node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/deprecation": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4686,9 +4736,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.6",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-            "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+            "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6499,6 +6549,16 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/interpret": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/ip-address": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -6579,6 +6639,22 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-error-instance": {
@@ -6978,7 +7054,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
             "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
@@ -7006,6 +7081,19 @@
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
@@ -8433,6 +8521,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/path-scurry": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -8661,6 +8756,30 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/prompts/node_modules/kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/proto-list": {
@@ -9028,6 +9147,19 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/rechoir": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve": "^1.20.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
         "node_modules/refa": {
             "version": "0.12.1",
             "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
@@ -9163,6 +9295,28 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve-from": {
@@ -9607,6 +9761,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/safe-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+            "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regexp-tree": "~0.1.1"
+            }
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9703,6 +9867,13 @@
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
+        },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
@@ -9966,6 +10137,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/strip-final-newline": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -10033,6 +10214,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/synckit": {
@@ -10312,7 +10506,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
             "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ts-api-utils": {
@@ -10360,6 +10553,37 @@
             "dependencies": {
                 "@ts-morph/common": "~0.24.0",
                 "code-block-writer": "^13.0.1"
+            }
+        },
+        "node_modules/tsconfig-paths": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json5": "^2.2.2",
+                "minimist": "^1.2.6",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tsconfig-paths-webpack-plugin": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+            "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.7.0",
+                "tapable": "^2.2.1",
+                "tsconfig-paths": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/tslib": {
@@ -10715,6 +10939,19 @@
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/watskeburt": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+            "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "watskeburt": "dist/run-cli.js"
+            },
+            "engines": {
+                "node": "^20.12||^22.13||>=24.0"
+            }
         },
         "node_modules/when-exit": {
             "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "@eslint-community/eslint-utils": "4.4.1",
         "globals": "15.14.0",
+        "json-schema-to-ts": "3.1.1",
         "type-fest": "4.40.0"
     },
     "devDependencies": {
@@ -23,17 +24,18 @@
         "@enormora/eslint-config-node": "0.0.27",
         "@enormora/eslint-config-typescript": "0.0.37",
         "@packtory/cli": "0.0.5",
+        "@types/estree": "1.0.9",
         "@types/mocha": "10.0.10",
         "@typescript-eslint/parser": "8.59.3",
         "c8": "11.0.0",
         "change-case": "5.4.4",
         "coveralls": "3.1.1",
+        "dependency-cruiser": "17.4.2",
         "dprint": "0.48.0",
         "dprint-plugin-yaml": "0.6.0",
         "eslint": "10.4.0",
         "eslint-doc-generator": "2.0.2",
         "eslint-plugin-eslint-plugin": "6.4.0",
-        "json-schema-to-ts": "3.1.1",
         "markdownlint-cli": "0.43.0",
         "mocha": "11.1.0",
         "pr-log": "6.1.1",


### PR DESCRIPTION
Add `dependency-cruiser` with a repo-specific configuration.

`just lint` now runs the dependency graph check, so the existing CI lint step covers it without workflow changes.

Also promote `json-schema-to-ts` to `dependencies` and declare `@types/estree` directly so the graph matches the published package surface.