### PR TITLE
Adjust `recommended` config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,19 +132,19 @@ For maintainers: the rules table below is generated, and the headers in `documen
 
 | Name                                                                                          | Description                                                             | 💼 | ⚠️ | 🚫 | 🔧 | 💡 |
 | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- | :- | :- | :- |
-| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             | ✅  |    |    | 🔧 |    |
-| [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               | ✅  |    |    | 🔧 |    |
+| [consistent-interface](documentation/rules/consistent-interface.md)                           | Enforces consistent use of mocha interfaces                             |    |    | ✅  | 🔧 |    |
+| [consistent-spacing-between-blocks](documentation/rules/consistent-spacing-between-blocks.md) | Require consistent spacing between blocks                               |    |    | ✅  | 🔧 |    |
 | [consistent-structure](documentation/rules/consistent-structure.md)                           | Require consistent structure for Mocha test entities                    | ✅  |    |    |    |    |
 | [handle-done-callback](documentation/rules/handle-done-callback.md)                           | Enforces handling of callbacks for async tests in every branch          | ✅  |    |    |    |    |
 | [limit-retries](documentation/rules/limit-retries.md)                                         | Enforce limits for Mocha retries                                        |    |    | ✅  |    |    |
 | [limit-slow](documentation/rules/limit-slow.md)                                               | Enforce limits for Mocha slow thresholds                                |    |    | ✅  |    |    |
 | [limit-timeout](documentation/rules/limit-timeout.md)                                         | Enforce limits for Mocha timeouts                                       |    |    | ✅  |    |    |
-| [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 | ✅  |    |    |    |    |
+| [max-top-level-suites](documentation/rules/max-top-level-suites.md)                           | Enforce the number of top-level suites in a single file                 |    |    | ✅  |    |    |
 | [no-async-and-done](documentation/rules/no-async-and-done.md)                                 | Disallow async functions that also use a Mocha callback                 | ✅  |    |    |    |    |
-| [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 |    |    | ✅  |    |    |
+| [no-async-in-sync-tests](documentation/rules/no-async-in-sync-tests.md)                       | Disallow async operations in synchronous tests or hooks                 | ✅  |    |    |    |    |
 | [no-async-suite](documentation/rules/no-async-suite.md)                                       | Disallow async functions passed to a suite                              | ✅  |    |    | 🔧 |    |
 | [no-code-after-done](documentation/rules/no-code-after-done.md)                               | Disallow executing code after calling a Mocha callback                  | ✅  |    |    |    |    |
-| [no-conditional-tests](documentation/rules/no-conditional-tests.md)                           | Disallow conditional suite and test declarations                        |    |    | ✅  |    |    |
+| [no-conditional-tests](documentation/rules/no-conditional-tests.md)                           | Disallow conditional suite and test declarations                        | ✅  |    |    |    |    |
 | [no-done-twice](documentation/rules/no-done-twice.md)                                         | Disallow calling a Mocha callback more than once                        | ✅  |    |    |    |    |
 | [no-empty-title](documentation/rules/no-empty-title.md)                                       | Disallow empty suite and test descriptions                              | ✅  |    |    |    |    |
 | [no-exclusive-tests](documentation/rules/no-exclusive-tests.md)                               | Disallow exclusive tests                                                |    | ✅  |    |    | 💡 |
@@ -158,8 +158,8 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    | 💡 |
 | [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
 | [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
-| [no-root-hooks](documentation/rules/no-root-hooks.md)                                         | Disallow root hooks                                                     |    | ✅  |    |    |    |
-| [no-setup-in-suite](documentation/rules/no-setup-in-suite.md)                                 | Disallow setup in suite blocks                                          | ✅  |    |    |    |    |
+| [no-root-hooks](documentation/rules/no-root-hooks.md)                                         | Disallow root hooks                                                     |    |    | ✅  |    |    |
+| [no-setup-in-suite](documentation/rules/no-setup-in-suite.md)                                 | Disallow setup in suite blocks                                          |    |    | ✅  |    |    |
 | [no-synchronous-tests](documentation/rules/no-synchronous-tests.md)                           | Disallow synchronous tests                                              |    |    | ✅  |    |    |
 | [no-top-level-tests](documentation/rules/no-top-level-tests.md)                               | Disallow top-level tests                                                | ✅  |    |    |    |    |
 | [prefer-arrow-callback](documentation/rules/prefer-arrow-callback.md)                         | Require using arrow functions for callbacks                             |    |    | ✅  | 🔧 |    |

--- a/documentation/rules/consistent-interface.md
+++ b/documentation/rules/consistent-interface.md
@@ -1,6 +1,6 @@
 # Enforces consistent use of mocha interfaces (`mocha/consistent-interface`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/documentation/rules/consistent-spacing-between-blocks.md
+++ b/documentation/rules/consistent-spacing-between-blocks.md
@@ -1,6 +1,6 @@
 # Require consistent spacing between blocks (`mocha/consistent-spacing-between-blocks`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/documentation/rules/max-top-level-suites.md
+++ b/documentation/rules/max-top-level-suites.md
@@ -1,6 +1,6 @@
 # Enforce the number of top-level suites in a single file (`mocha/max-top-level-suites`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 

--- a/documentation/rules/no-async-in-sync-tests.md
+++ b/documentation/rules/no-async-in-sync-tests.md
@@ -1,6 +1,6 @@
 # Disallow async operations in synchronous tests or hooks (`mocha/no-async-in-sync-tests`)
 
-🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 

--- a/documentation/rules/no-conditional-tests.md
+++ b/documentation/rules/no-conditional-tests.md
@@ -1,6 +1,6 @@
 # Disallow conditional suite and test declarations (`mocha/no-conditional-tests`)
 
-🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 

--- a/documentation/rules/no-root-hooks.md
+++ b/documentation/rules/no-root-hooks.md
@@ -1,6 +1,6 @@
 # Disallow root hooks (`mocha/no-root-hooks`)
 
-⚠️ This rule _warns_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 

--- a/documentation/rules/no-setup-in-suite.md
+++ b/documentation/rules/no-setup-in-suite.md
@@ -1,6 +1,6 @@
 # Disallow setup in suite blocks (`mocha/no-setup-in-suite`)
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
+🚫 This rule is _disabled_ in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 
 <!-- end auto-generated rule header -->
 

--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -53,6 +53,20 @@ async function determineAllDocumentationFiles(): Promise<string[]> {
     return documentationFilesWithoutReadme;
 }
 
+function selectRecommendedRuleDecisions(
+    recommendedRules: NonNullable<typeof plugin.configs.recommended.rules>
+): Record<string, unknown> {
+    return {
+        'mocha/max-top-level-suites': recommendedRules['mocha/max-top-level-suites'],
+        'mocha/no-async-in-sync-tests': recommendedRules['mocha/no-async-in-sync-tests'],
+        'mocha/no-conditional-tests': recommendedRules['mocha/no-conditional-tests'],
+        'mocha/no-setup-in-suite': recommendedRules['mocha/no-setup-in-suite'],
+        'mocha/no-root-hooks': recommendedRules['mocha/no-root-hooks'],
+        'mocha/consistent-spacing-between-blocks': recommendedRules['mocha/consistent-spacing-between-blocks'],
+        'mocha/consistent-interface': recommendedRules['mocha/consistent-interface']
+    };
+}
+
 describe('eslint-plugin-mocha', function () {
     it('should expose plugin metadata', async function () {
         assert.deepStrictEqual(plugin.meta, await readClosestPackageMetadata(import.meta.url));
@@ -101,12 +115,24 @@ describe('eslint-plugin-mocha', function () {
             assert.strictEqual(plugin.configs.recommended.plugins.mocha, plugin);
         });
 
-        it('should enable consistent-interface in the recommended config', function () {
-            assert.notStrictEqual(plugin.configs.recommended.rules, undefined);
-            assert.deepStrictEqual(plugin.configs.recommended.rules?.['mocha/consistent-interface'], [
-                'error',
-                { interface: 'BDD' }
-            ]);
+        it('should configure the recommended config as intended', function () {
+            const { rules: recommendedRules } = plugin.configs.recommended;
+
+            assert.notStrictEqual(recommendedRules, undefined);
+            assert.deepStrictEqual(
+                selectRecommendedRuleDecisions(
+                    recommendedRules as NonNullable<typeof plugin.configs.recommended.rules>
+                ),
+                {
+                    'mocha/max-top-level-suites': 'off',
+                    'mocha/no-async-in-sync-tests': 'error',
+                    'mocha/no-conditional-tests': 'error',
+                    'mocha/no-setup-in-suite': 'off',
+                    'mocha/no-root-hooks': 'off',
+                    'mocha/consistent-spacing-between-blocks': 'off',
+                    'mocha/consistent-interface': 'off'
+                }
+            );
         });
     });
 });

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -86,12 +86,12 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/limit-retries': 'off',
     'mocha/limit-slow': 'off',
     'mocha/limit-timeout': 'off',
-    'mocha/max-top-level-suites': ['error', { limit: 1 }],
+    'mocha/max-top-level-suites': 'off',
     'mocha/no-async-and-done': 'error',
-    'mocha/no-async-in-sync-tests': 'off',
+    'mocha/no-async-in-sync-tests': 'error',
     'mocha/no-async-suite': 'error',
     'mocha/no-code-after-done': 'error',
-    'mocha/no-conditional-tests': 'off',
+    'mocha/no-conditional-tests': 'error',
     'mocha/no-done-twice': 'error',
     'mocha/no-exclusive-tests': 'warn',
     'mocha/no-exports': 'error',
@@ -105,15 +105,15 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-pending-tests': 'warn',
     'mocha/no-return-and-callback': 'error',
     'mocha/no-return-from-async': 'off',
-    'mocha/no-setup-in-suite': 'error',
+    'mocha/no-setup-in-suite': 'off',
     'mocha/no-synchronous-tests': 'off',
-    'mocha/no-root-hooks': 'warn',
+    'mocha/no-root-hooks': 'off',
     'mocha/prefer-arrow-callback': 'off',
     'mocha/valid-suite-title': 'off',
     'mocha/valid-test-title': 'off',
     'mocha/no-empty-title': 'error',
-    'mocha/consistent-spacing-between-blocks': 'error',
-    'mocha/consistent-interface': ['error', { interface: 'BDD' }]
+    'mocha/consistent-spacing-between-blocks': 'off',
+    'mocha/consistent-interface': 'off'
 };
 
 const rules = {


### PR DESCRIPTION
- enable `no-async-in-sync-tests` and `no-conditional-tests` in `recommended`
- disable more opinionated `recommended` defaults for `consistent-interface`, `consistent-spacing-between-blocks`, `max-top-level-suites`, `no-root-hooks`, and `no-setup-in-suite`
- update the `recommended` config test and regenerate the rule docs
