### PR TITLE
Rename `no-return-and-callback` to `no-return-and-done`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For maintainers: the rules table below is generated, and the headers in `documen
 | [no-nested-suites](documentation/rules/no-nested-suites.md)                                   | Disallow suites to be nested within other suites                        |    |    | ✅  |    |    |
 | [no-nested-tests](documentation/rules/no-nested-tests.md)                                     | Disallow tests to be nested within other tests                          | ✅  |    |    |    |    |
 | [no-pending-tests](documentation/rules/no-pending-tests.md)                                   | Disallow pending tests                                                  |    | ✅  |    |    | 💡 |
-| [no-return-and-callback](documentation/rules/no-return-and-callback.md)                       | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
+| [no-return-and-done](documentation/rules/no-return-and-done.md)                               | Disallow returning in a test or hook function that uses a callback      | ✅  |    |    |    |    |
 | [no-return-from-async](documentation/rules/no-return-from-async.md)                           | Disallow returning from an async test or hook                           |    |    | ✅  |    |    |
 | [no-root-hooks](documentation/rules/no-root-hooks.md)                                         | Disallow root hooks                                                     |    |    | ✅  |    |    |
 | [no-setup-in-suite](documentation/rules/no-setup-in-suite.md)                                 | Disallow setup in suite blocks                                          |    |    | ✅  |    |    |

--- a/documentation/rules/no-return-and-done.md
+++ b/documentation/rules/no-return-and-done.md
@@ -1,4 +1,4 @@
-# Disallow returning in a test or hook function that uses a callback (`mocha/no-return-and-callback`)
+# Disallow returning in a test or hook function that uses a callback (`mocha/no-return-and-done`)
 
 💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/lo1tuma/eslint-plugin-mocha#configs).
 

--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -16,7 +16,8 @@ async function importModuleExports(filePath: string): Promise<Readonly<Record<st
 }
 
 async function determineAllRuleFiles(): Promise<string[]> {
-    const sourceRuleFiles = new Set((await fs.promises.readdir(sourceRulesDir)).flatMap((file) => {
+    const knownSourceRuleFiles = await fs.promises.readdir(sourceRulesDir);
+    const sourceRuleFiles = new Set(knownSourceRuleFiles.flatMap((file) => {
         return !file.endsWith('.test.ts') && file.endsWith('.ts')
             ? [`${path.basename(file, '.ts')}.js`]
             : [];

--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -8,6 +8,7 @@ import plugin from './plugin.js';
 const { pathname: currentFolderName } = new URL('.', import.meta.url);
 
 const rulesDir = path.join(currentFolderName, './rules/');
+const sourceRulesDir = path.join(currentFolderName, '../../../source/rules/');
 const documentationDir = path.join(currentFolderName, '../../../documentation/rules/');
 
 async function importModuleExports(filePath: string): Promise<Readonly<Record<string, unknown>>> {
@@ -15,9 +16,14 @@ async function importModuleExports(filePath: string): Promise<Readonly<Record<st
 }
 
 async function determineAllRuleFiles(): Promise<string[]> {
+    const sourceRuleFiles = new Set((await fs.promises.readdir(sourceRulesDir)).flatMap((file) => {
+        return !file.endsWith('.test.ts') && file.endsWith('.ts')
+            ? [`${path.basename(file, '.ts')}.js`]
+            : [];
+    }));
     const knownRuleFiles = await fs.promises.readdir(rulesDir);
     const ruleFiles = knownRuleFiles.filter((file) => {
-        return !file.endsWith('.test.js') && file.endsWith('.js');
+        return !file.endsWith('.test.js') && file.endsWith('.js') && sourceRuleFiles.has(file);
     });
 
     if (rulesDir.length === 0) {

--- a/source/plugin.ts
+++ b/source/plugin.ts
@@ -25,7 +25,7 @@ import { noMochaArrowsRule } from './rules/no-mocha-arrows.js';
 import { noNestedSuitesRule } from './rules/no-nested-suites.js';
 import { noNestedTestsRule } from './rules/no-nested-tests.js';
 import { noPendingTestsRule } from './rules/no-pending-tests.js';
-import { noReturnAndCallbackRule } from './rules/no-return-and-callback.js';
+import { noReturnAndDoneRule } from './rules/no-return-and-done.js';
 import { noReturnFromAsyncRule } from './rules/no-return-from-async.js';
 import { noRootHooksRule } from './rules/no-root-hooks.js';
 import { noSetupInSuiteRule } from './rules/no-setup-in-suite.js';
@@ -67,7 +67,7 @@ const allRules: Linter.RulesRecord = {
     'mocha/no-nested-suites': 'error',
     'mocha/no-nested-tests': 'error',
     'mocha/no-pending-tests': 'error',
-    'mocha/no-return-and-callback': 'error',
+    'mocha/no-return-and-done': 'error',
     'mocha/no-return-from-async': 'error',
     'mocha/no-setup-in-suite': 'error',
     'mocha/no-synchronous-tests': 'error',
@@ -103,7 +103,7 @@ const recommendedRules: Linter.RulesRecord = {
     'mocha/no-nested-suites': 'off',
     'mocha/no-nested-tests': 'error',
     'mocha/no-pending-tests': 'warn',
-    'mocha/no-return-and-callback': 'error',
+    'mocha/no-return-and-done': 'error',
     'mocha/no-return-from-async': 'off',
     'mocha/no-setup-in-suite': 'off',
     'mocha/no-synchronous-tests': 'off',
@@ -139,7 +139,7 @@ const rules = {
     'no-nested-suites': noNestedSuitesRule,
     'no-nested-tests': noNestedTestsRule,
     'no-pending-tests': noPendingTestsRule,
-    'no-return-and-callback': noReturnAndCallbackRule,
+    'no-return-and-done': noReturnAndDoneRule,
     'no-return-from-async': noReturnFromAsyncRule,
     'no-setup-in-suite': noSetupInSuiteRule,
     'no-synchronous-tests': noSynchronousTestsRule,

--- a/source/rules/no-return-and-done.test.ts
+++ b/source/rules/no-return-and-done.test.ts
@@ -1,10 +1,10 @@
 import { type Rule, RuleTester } from 'eslint';
 import assert from 'node:assert';
 import {
-    checkNodeForReturnAndCallback,
-    noReturnAndCallbackRule,
+    checkNodeForReturnAndDone,
+    noReturnAndDoneRule,
     reportIfFunctionWithBlock
-} from './no-return-and-callback.js';
+} from './no-return-and-done.js';
 
 const ruleTester = new RuleTester({ languageOptions: { sourceType: 'script' } });
 const message = 'Unexpected use of `return` in a test with callback';
@@ -13,7 +13,7 @@ const es6LanguageOptions = {
     ecmaVersion: 6
 } as const;
 
-ruleTester.run('no-return-and-callback', noReturnAndCallbackRule, {
+ruleTester.run('no-return-and-done', noReturnAndDoneRule, {
     valid: [
         'it("title", function(done) { done(); });',
         'it("title", function(done) { foo.then(function() { return done(); }); });',
@@ -125,7 +125,7 @@ ruleTester.run('no-return-and-callback', noReturnAndCallbackRule, {
     ]
 });
 
-describe('no-return-and-callback helpers', function () {
+describe('no-return-and-done helpers', function () {
     it('reportIfFunctionWithBlock() ignores non-block bodies', function () {
         const reports: string[] = [];
 
@@ -140,10 +140,10 @@ describe('no-return-and-callback helpers', function () {
         assert.deepStrictEqual(reports, []);
     });
 
-    it('checkNodeForReturnAndCallback() ignores non-function nodes', function () {
+    it('checkNodeForReturnAndDone() ignores non-function nodes', function () {
         const reports: string[] = [];
 
-        checkNodeForReturnAndCallback({
+        checkNodeForReturnAndDone({
             report() {
                 reports.push('reported');
             }
@@ -152,10 +152,10 @@ describe('no-return-and-callback helpers', function () {
         assert.deepStrictEqual(reports, []);
     });
 
-    it('checkNodeForReturnAndCallback() ignores functions without an identifier callback parameter', function () {
+    it('checkNodeForReturnAndDone() ignores functions without an identifier callback parameter', function () {
         const reports: string[] = [];
 
-        checkNodeForReturnAndCallback({
+        checkNodeForReturnAndDone({
             report() {
                 reports.push('reported');
             }

--- a/source/rules/no-return-and-done.ts
+++ b/source/rules/no-return-and-done.ts
@@ -21,24 +21,24 @@ function isFunctionCallWithName(node: Except<Rule.Node, 'parent'> | null | undef
         node.callee.name === name;
 }
 
-function isAllowedReturnStatement(node: Readonly<ReturnStatement>, doneName: string): boolean {
+function isAllowedReturnStatement(node: Readonly<ReturnStatement>, callbackName: string): boolean {
     if (isReturnOfUndefined(node) || node.argument?.type === 'Literal') {
         return true;
     }
 
-    return isFunctionCallWithName(node.argument, doneName);
+    return isFunctionCallWithName(node.argument, callbackName);
 }
 
 export function reportIfFunctionWithBlock(
     context: Readonly<Rule.RuleContext>,
     node: Readonly<AnyFunction>,
-    doneName: string
+    callbackName: string
 ): void {
     if (node.body.type !== 'BlockStatement') {
         return;
     }
     const returnStatement = findReturnStatement(node.body.body);
-    if (returnStatement !== undefined && !isAllowedReturnStatement(returnStatement, doneName)) {
+    if (returnStatement !== undefined && !isAllowedReturnStatement(returnStatement, callbackName)) {
         context.report({
             node: returnStatement,
             messageId: 'unexpectedReturnWithCallback'
@@ -46,7 +46,7 @@ export function reportIfFunctionWithBlock(
     }
 }
 
-export function checkNodeForReturnAndCallback(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
+export function checkNodeForReturnAndDone(context: Readonly<Rule.RuleContext>, node: Readonly<Rule.Node>): void {
     if (!isFunction(node)) {
         return;
     }
@@ -60,13 +60,13 @@ export function checkNodeForReturnAndCallback(context: Readonly<Rule.RuleContext
     }
 }
 
-export const noReturnAndCallbackRule: Readonly<Rule.RuleModule> = {
+export const noReturnAndDoneRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
         languages: ['js/js'],
         docs: {
             description: 'Disallow returning in a test or hook function that uses a callback',
-            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-return-and-callback.md'
+            url: 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/documentation/rules/no-return-and-done.md'
         },
         messages: {
             implicitReturnWithCallback: 'Confusing implicit return in a test with callback',
@@ -77,7 +77,7 @@ export const noReturnAndCallbackRule: Readonly<Rule.RuleModule> = {
     create(context) {
         return createMochaVisitors(context, {
             anyTestEntityCallback(visitorContext) {
-                checkNodeForReturnAndCallback(context, visitorContext.node);
+                checkNodeForReturnAndDone(context, visitorContext.node);
             }
         });
     }


### PR DESCRIPTION
Rename the public rule id to match the existing `*-and-done` callback rule names.

Ignore stale generated rule files in `source/plugin.test.ts` so incremental test builds stay stable after rule moves.

BREAKING CHANGE: replace `mocha/no-return-and-callback` with `mocha/no-return-and-done` in ESLint configs.
