### PR TITLE
Add `knip` to `lint`

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,12 +17,16 @@ eslint-fix: (eslint '--fix')
 lint-dependencies:
     depcruise --config dependency-cruiser.config.js './source/**/*.ts' './benchmarks/**/*.ts' './*.js' './*.cjs'
 
+lint-unused-code:
+    knip
+    knip --production --dependencies --files
+
 lint-docs:
     markdownlint '**/*.md'
 
 lint-eslint-docs: (update-eslint-docs '--check')
 
-lint: lint-docs lint-eslint-docs eslint lint-dependencies
+lint: lint-docs lint-eslint-docs eslint lint-dependencies lint-unused-code
 
 lint-fix: eslint-fix format-fix
 

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://unpkg.com/knip@5/schema.json",
+    "entry": [
+        "benchmarks/**/*.ts",
+        "source/**/*.test.ts",
+        "source/third-party-type-definitions.d.ts!",
+        "dependency-cruiser.config.js",
+        "packtory.config.js"
+    ],
+    "project": [
+        "benchmarks/**/*.ts",
+        "source/**/*.ts!",
+        "source/**/*.d.ts!",
+        "*.js",
+        "!source/mocha-interface-test-cases.ts!",
+        "!source/**/*.test.ts!"
+    ],
+    "ignoreDependencies": [
+        "c8",
+        "coveralls",
+        "dprint",
+        "eslint-doc-generator",
+        "markdownlint-cli",
+        "pr-log"
+    ],
+    "ignoreBinaries": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@eslint-community/eslint-utils": "4.4.1",
                 "globals": "15.14.0",
                 "json-schema-to-ts": "3.1.1",
+                "tslib": "2.8.1",
                 "type-fest": "4.40.0"
             },
             "devDependencies": {
@@ -36,11 +37,11 @@
                 "eslint": "10.4.0",
                 "eslint-doc-generator": "2.0.2",
                 "eslint-plugin-eslint-plugin": "6.4.0",
+                "knip": "6.14.2",
                 "markdownlint-cli": "0.43.0",
                 "mocha": "11.1.0",
                 "pr-log": "6.1.1",
                 "rust-just": "1.51.0",
-                "semver": "7.6.3",
                 "typescript": "5.7.3"
             },
             "engines": {
@@ -1669,6 +1670,689 @@
             "integrity": "sha512-n+L/BvrwKUn7q5O3wHGo+CJZAqfewh38+37sk+eBzv/39lM9pPgPRd4sOZRvSRzo0ukLxzyXso4WlGj2oKZ5hA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+            "integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+            "integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+            "integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+            "integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+            "integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+            "integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+            "integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+            "integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+            "integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+            "integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+            "integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+            "integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+            "integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+            "integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+            "integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+            "integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+            "integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+            "integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+            "integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+            "integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+            "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+            "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-android-arm64": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+            "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-darwin-arm64": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+            "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-darwin-x64": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+            "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-freebsd-x64": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+            "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+            "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+            "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+            "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+            "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+            "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+            "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+            "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+            "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+            "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+            "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+            "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+            "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+            "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+            "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+            "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@package-json/types": {
             "version": "0.0.12",
@@ -5819,6 +6503,16 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fd-package-json": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+            "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "walk-up-path": "^4.0.0"
+            }
+        },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -6004,6 +6698,22 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/formatly": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+            "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fd-package-json": "^2.0.0"
+            },
+            "bin": {
+                "formatly": "bin/index.mjs"
+            },
+            "engines": {
+                "node": ">=18.3.0"
             }
         },
         "node_modules/fs-minipass": {
@@ -6989,6 +7699,16 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jiti": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7165,6 +7885,59 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/knip": {
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/knip/-/knip-6.14.2.tgz",
+            "integrity": "sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/webpro"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/knip"
+                }
+            ],
+            "license": "ISC",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "formatly": "^0.3.0",
+                "get-tsconfig": "4.14.0",
+                "jiti": "^2.7.0",
+                "minimist": "^1.2.8",
+                "oxc-parser": "^0.130.0",
+                "oxc-resolver": "^11.19.1",
+                "picomatch": "^4.0.4",
+                "smol-toml": "^1.6.1",
+                "strip-json-comments": "5.0.3",
+                "tinyglobby": "^0.2.16",
+                "unbash": "^3.0.0",
+                "yaml": "^2.9.0",
+                "zod": "^4.1.11"
+            },
+            "bin": {
+                "knip": "bin/knip.js",
+                "knip-bun": "bin/knip-bun.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/knip/node_modules/strip-json-comments": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ky": {
@@ -8310,6 +9083,76 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/oxc-parser": {
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+            "integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "^0.130.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.130.0",
+                "@oxc-parser/binding-android-arm64": "0.130.0",
+                "@oxc-parser/binding-darwin-arm64": "0.130.0",
+                "@oxc-parser/binding-darwin-x64": "0.130.0",
+                "@oxc-parser/binding-freebsd-x64": "0.130.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.130.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.130.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.130.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.130.0"
+            }
+        },
+        "node_modules/oxc-resolver": {
+            "version": "11.19.1",
+            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+            "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+                "@oxc-resolver/binding-android-arm64": "11.19.1",
+                "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+                "@oxc-resolver/binding-darwin-x64": "11.19.1",
+                "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+                "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+                "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+                "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+                "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+                "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+                "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+                "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+                "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+                "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+                "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+                "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+                "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+                "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+                "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
             }
         },
         "node_modules/p-limit": {
@@ -10590,9 +11433,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/tuf-js": {
             "version": "2.2.1",
@@ -10673,6 +11514,16 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/unbash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+            "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/undici-types": {
             "version": "7.24.6",
@@ -10939,6 +11790,16 @@
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/walk-up-path": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+            "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/watskeburt": {
             "version": "5.0.3",
@@ -11255,6 +12116,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@eslint-community/eslint-utils": "4.4.1",
         "globals": "15.14.0",
         "json-schema-to-ts": "3.1.1",
+        "tslib": "2.8.1",
         "type-fest": "4.40.0"
     },
     "devDependencies": {
@@ -36,11 +37,11 @@
         "eslint": "10.4.0",
         "eslint-doc-generator": "2.0.2",
         "eslint-plugin-eslint-plugin": "6.4.0",
+        "knip": "6.14.2",
         "markdownlint-cli": "0.43.0",
         "mocha": "11.1.0",
         "pr-log": "6.1.1",
         "rust-just": "1.51.0",
-        "semver": "7.6.3",
         "typescript": "5.7.3"
     },
     "pr-log": {

--- a/source/ast/node-types.ts
+++ b/source/ast/node-types.ts
@@ -57,19 +57,19 @@ export function isAssignmentProperty(property: ObjectPattern['properties'][numbe
     return property.type === 'Property';
 }
 
-export type FunctionExpression = NodeType<'FunctionExpression'>;
-export type FunctionDeclaration = NodeType<'FunctionDeclaration'>;
+type FunctionExpression = NodeType<'FunctionExpression'>;
+type FunctionDeclaration = NodeType<'FunctionDeclaration'>;
 export type ArrowFunctionExpression = NodeType<'ArrowFunctionExpression'>;
 
 export function isArrowFunctionExpression(node: Except<Rule.Node, 'parent'>): node is ArrowFunctionExpression {
     return node.type === 'ArrowFunctionExpression';
 }
 
-export function isFunctionExpression(node: Except<Rule.Node, 'parent'>): node is FunctionExpression {
+function isFunctionExpression(node: Except<Rule.Node, 'parent'>): node is FunctionExpression {
     return node.type === 'FunctionExpression';
 }
 
-export function isFunctionDeclaration(node: Except<Rule.Node, 'parent'>): node is FunctionDeclaration {
+function isFunctionDeclaration(node: Except<Rule.Node, 'parent'>): node is FunctionDeclaration {
     return node.type === 'FunctionDeclaration';
 }
 
@@ -78,8 +78,6 @@ export type AnyFunction = ArrowFunctionExpression | FunctionDeclaration | Functi
 export function isFunction(node: Except<Rule.Node, 'parent'>): node is AnyFunction {
     return isFunctionExpression(node) || isArrowFunctionExpression(node) || isFunctionDeclaration(node);
 }
-
-export type MetaProperty = NodeType<'MetaProperty'>;
 
 export type Literal = NodeType<'Literal'>;
 

--- a/source/mocha/all-name-details.ts
+++ b/source/mocha/all-name-details.ts
@@ -12,12 +12,12 @@ export type CustomNameConfig = Pick<NameDetailsConfig, 'interface'> & {
     type: CustomMochaEntityType;
 };
 
-export function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readonly<NameDetailsConfig> {
+function nameConfigToNameDetails(nameConfig: Readonly<CustomNameConfig>): Readonly<NameDetailsConfig> {
     const { name, ...rest } = nameConfig;
     return { path: convertNameToPathArray(name), modifier: null, config: null, ...rest };
 }
 
-export const builtinNameDetailsList = buildAllNameDetailsWithVariants(builtinNames);
+const builtinNameDetailsList = buildAllNameDetailsWithVariants(builtinNames);
 
 function hasMatchingInterface(
     nameDetails: Readonly<NameDetailsConfig>,

--- a/source/mocha/descriptors.ts
+++ b/source/mocha/descriptors.ts
@@ -32,11 +32,6 @@ export type NameDetailsConfig = {
     config: MochaConfigCall | null;
 };
 
-export const MODIFIERS = {
-    pending: 'pending',
-    exclusive: 'exclusive'
-};
-
 export const builtinNames: readonly NameDetailsConfig[] = [
     { path: ['describe'], interface: 'BDD', type: 'suite', modifier: null, config: null },
     { path: ['context'], interface: 'BDD', type: 'suite', modifier: null, config: null },

--- a/source/rules/no-identical-title.ts
+++ b/source/rules/no-identical-title.ts
@@ -15,7 +15,7 @@ function newLayer(): Readonly<Layer> {
     };
 }
 
-export function extractTitleArgument(node: Readonly<Rule.Node>): string | null {
+function extractTitleArgument(node: Readonly<Rule.Node>): string | null {
     if (isCallExpression(node)) {
         const [firstArg] = node.arguments;
         if (firstArg !== undefined && isLiteral(firstArg)) {

--- a/source/rules/no-pending-tests.ts
+++ b/source/rules/no-pending-tests.ts
@@ -53,7 +53,7 @@ type KnownLocation = Locatable & {
 };
 type KnownLocationComment = EstreeComment & KnownLocation;
 
-export function isCallbackMissing(node: CallExpression): boolean {
+function isCallbackMissing(node: CallExpression): boolean {
     const [firstArgument] = node.arguments;
     return firstArgument !== undefined && firstArgument.type === 'Literal' && node.arguments.length === 1;
 }
@@ -191,7 +191,7 @@ function visitThisSkipCalls(
     });
 }
 
-export function reportSkipped(
+function reportSkipped(
     context: Readonly<Rule.RuleContext>,
     node: CallExpression,
     messageId: 'unexpectedPendingTest' | 'unexpectedSkippedTestWithoutComment'


### PR DESCRIPTION
Add `knip` to the existing `lint` task and keep a production-only pass for dependency and file checks.

This also adds `tslib`, removes the unused `semver` dependency, and trims a few unnecessary exports that `knip` surfaced.

`just lint` passes. The benchmark assertions in `just test` still fail on the same performance budgets on `origin/main`.