### PR TITLE
chore: use https repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/lo1tuma/eslint-plugin-mocha.git"
+        "url": "git+https://github.com/lo1tuma/eslint-plugin-mocha.git"
     },
     "author": "Mathias Schreck <schreck.mathias@gmail.com>",
     "contributors": [


### PR DESCRIPTION
## Summary
- update package repository metadata from git:// to git+https://
- leave runtime code, dependencies, entry points, and package files unchanged

## Validation
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json --cache /private/tmp/codex-npm-cache-eslint-plugin-mocha
- git diff --check