### PR TITLE
Replace `pr-log` with Packtory release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
         branches: [main]
     pull_request:
         types: [opened, reopened, synchronize]
+    merge_group:
     workflow_dispatch:
         inputs:
             release_pull_request_number:
@@ -57,6 +58,31 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   path-to-lcov: ./target/coverage/lcov.info
                   parallel: true
+    release-pr-policy:
+        runs-on: ubuntu-latest
+        name: Release PR policy
+        if: >
+            github.event_name == 'pull_request' ||
+            github.event_name == 'merge_group' ||
+            (github.event_name == 'workflow_dispatch' && github.ref_name == 'release/eslint-plugin-mocha')
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+            - name: Validate release pull request
+              if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just validate-release-pr
     mutation-testing:
         runs-on: ubuntu-latest
         name: Mutation testing
@@ -75,14 +101,31 @@ jobs:
             - name: Run mutation tests
               run: npx just test-mutation
               timeout-minutes: 30
-    maintain-release-pr:
+    publish-release:
         needs: build
+        name: Publish release
+        if: >
+            github.event_name == 'push' ||
+            (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number != '')
+        uses: ./.github/workflows/release-publish.yml
+        permissions:
+            contents: write
+            id-token: write
+            pull-requests: read
+        with:
+            release_pull_request_number: ${{ inputs.release_pull_request_number || '' }}
+    maintain-release-pr:
+        needs: publish-release
         runs-on: ubuntu-latest
         name: Maintain release PR
-        if: github.event_name == 'push'
-        concurrency:
-            group: release-pr-maintenance
-            cancel-in-progress: false
+        if: >
+            always() &&
+            (
+                github.event_name == 'push' ||
+                (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number == '')
+            ) &&
+            needs.publish-release.result != 'failure' &&
+            needs.publish-release.result != 'cancelled'
         permissions:
             actions: write
             contents: write
@@ -109,111 +152,6 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
               run: npx just prepare-release
-    publish-release:
-        needs: build
-        runs-on: ubuntu-latest
-        name: Publish release
-        if: >
-            github.event_name == 'push' ||
-            (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number != '')
-        permissions:
-            contents: write
-            id-token: write
-            pull-requests: read
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-            - name: Use Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 24
-            - name: Install dependencies
-              run: npm clean-install --ignore-scripts
-            - name: Authorize release publish
-              id: publish-target
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  RELEASE_PULL_REQUEST_NUMBER: ${{ inputs.release_pull_request_number }}
-              run: |
-                  set -euo pipefail
-
-                  if [ -n "$RELEASE_PULL_REQUEST_NUMBER" ]; then
-                      npx just authorize-release-publish --release-pull-request "$RELEASE_PULL_REQUEST_NUMBER"
-                  else
-                      npx just authorize-release-publish
-                  fi
-            - uses: actions/checkout@v4
-              if: steps.publish-target.outputs.should_publish == 'true'
-              with:
-                  ref: ${{ steps.publish-target.outputs.publish_commit_sha }}
-                  fetch-depth: 0
-                  persist-credentials: true
-            - name: Use Node.js
-              if: steps.publish-target.outputs.should_publish == 'true'
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 24
-            - name: Install dependencies
-              if: steps.publish-target.outputs.should_publish == 'true'
-              run: npm clean-install --ignore-scripts
-            - name: Check packages
-              if: steps.publish-target.outputs.should_publish == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: npx just publish-dry-run
-            - name: Audit npm signatures and attestations
-              if: steps.publish-target.outputs.should_publish == 'true'
-              run: |
-                  mkdir -p target/release
-                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
-                  node --input-type=module <<'NODE'
-                  import fs from 'node:fs/promises';
-
-                  const report = JSON.parse(
-                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
-                  );
-                  const packtory = report.verified.find((entry) => {
-                      return entry.name === '@packtory/cli';
-                  });
-
-                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
-                      throw new Error('Missing npm provenance for @packtory/cli');
-                  }
-                  NODE
-            - name: Publish package
-              if: steps.publish-target.outputs.should_publish == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  mkdir -p target/release
-                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
-
-                  set +e
-                  npx just publish-release 2>&1 | tee target/release/publish.log
-                  status=${PIPESTATUS[0]}
-                  set -e
-
-                  if [ "$status" -ne 0 ] && grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
-                      sleep 30
-                      npx just publish-release
-                      status=0
-                  fi
-
-                  if [ "$status" -ne 0 ]; then
-                      exit "$status"
-                  fi
-
-                  for tag in $(git tag --points-at HEAD 'eslint-plugin-mocha@*'); do
-                      version="${tag#eslint-plugin-mocha@}"
-
-                      if ! git rev-parse --verify "refs/tags/$version" >/dev/null 2>&1; then
-                          git tag -a "$version" -m "$version" HEAD
-                      fi
-
-                      git push origin "refs/tags/$version:refs/tags/$version"
-                  done
     coverage:
         needs: build
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
         branches: [main]
     pull_request:
         types: [opened, reopened, synchronize]
+    workflow_dispatch:
+        inputs:
+            release_pull_request_number:
+                required: false
+                type: string
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     build:
@@ -14,14 +25,20 @@ jobs:
             matrix:
                 node: [22, 24, 26]
         name: Node ${{ matrix.node }}
+        permissions:
+            contents: read
+            pull-requests: read
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node }}
             - name: Install dependencies
-              run: npm ci
+              run: npm clean-install
             - name: Compile
               run: npx just compile
             - name: Run linters
@@ -29,6 +46,11 @@ jobs:
             - name: Run tests
               run: npx just test
               timeout-minutes: 20
+            - name: Check packages
+              if: matrix.node == 24
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just publish-dry-run
             - name: Coveralls
               uses: coverallsapp/github-action@master
               with:
@@ -38,20 +60,166 @@ jobs:
     mutation-testing:
         runs-on: ubuntu-latest
         name: Mutation testing
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: 26
             - name: Install dependencies
-              run: npm ci
+              run: npm clean-install
             - name: Run mutation tests
               run: npx just test-mutation
               timeout-minutes: 30
+    maintain-release-pr:
+        needs: build
+        runs-on: ubuntu-latest
+        name: Maintain release PR
+        if: github.event_name == 'push'
+        concurrency:
+            group: release-pr-maintenance
+            cancel-in-progress: false
+        permissions:
+            actions: write
+            contents: write
+            issues: write
+            pull-requests: write
+            statuses: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  persist-credentials: true
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+            - name: Configure release author
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            - name: Maintain release pull request
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just prepare-release
+    publish-release:
+        needs: build
+        runs-on: ubuntu-latest
+        name: Publish release
+        if: >
+            github.event_name == 'push' ||
+            (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number != '')
+        permissions:
+            contents: write
+            id-token: write
+            pull-requests: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+            - name: Authorize release publish
+              id: publish-target
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_PULL_REQUEST_NUMBER: ${{ inputs.release_pull_request_number }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -n "$RELEASE_PULL_REQUEST_NUMBER" ]; then
+                      npx just authorize-release-publish --release-pull-request "$RELEASE_PULL_REQUEST_NUMBER"
+                  else
+                      npx just authorize-release-publish
+                  fi
+            - uses: actions/checkout@v4
+              if: steps.publish-target.outputs.should_publish == 'true'
+              with:
+                  ref: ${{ steps.publish-target.outputs.publish_commit_sha }}
+                  fetch-depth: 0
+                  persist-credentials: true
+            - name: Use Node.js
+              if: steps.publish-target.outputs.should_publish == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install dependencies
+              if: steps.publish-target.outputs.should_publish == 'true'
+              run: npm clean-install --ignore-scripts
+            - name: Check packages
+              if: steps.publish-target.outputs.should_publish == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just publish-dry-run
+            - name: Audit npm signatures and attestations
+              if: steps.publish-target.outputs.should_publish == 'true'
+              run: |
+                  mkdir -p target/release
+                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+
+                  const report = JSON.parse(
+                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
+                  );
+                  const packtory = report.verified.find((entry) => {
+                      return entry.name === '@packtory/cli';
+                  });
+
+                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
+                      throw new Error('Missing npm provenance for @packtory/cli');
+                  }
+                  NODE
+            - name: Publish package
+              if: steps.publish-target.outputs.should_publish == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  mkdir -p target/release
+                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
+
+                  set +e
+                  npx just publish-release 2>&1 | tee target/release/publish.log
+                  status=${PIPESTATUS[0]}
+                  set -e
+
+                  if [ "$status" -ne 0 ] && grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
+                      sleep 30
+                      npx just publish-release
+                      status=0
+                  fi
+
+                  if [ "$status" -ne 0 ]; then
+                      exit "$status"
+                  fi
+
+                  for tag in $(git tag --points-at HEAD 'eslint-plugin-mocha@*'); do
+                      version="${tag#eslint-plugin-mocha@}"
+
+                      if ! git rev-parse --verify "refs/tags/$version" >/dev/null 2>&1; then
+                          git tag -a "$version" -m "$version" HEAD
+                      fi
+
+                      git push origin "refs/tags/$version:refs/tags/$version"
+                  done
     coverage:
         needs: build
         runs-on: ubuntu-latest
+        name: Coveralls Finished
+        permissions:
+            contents: read
         steps:
             - name: Coveralls Finished
               uses: coverallsapp/github-action@master

--- a/.github/workflows/pull-request-label-policy.yml
+++ b/.github/workflows/pull-request-label-policy.yml
@@ -1,21 +1,21 @@
-name: Release PR policy
+name: Pull request label policy
 
 on:
     pull_request:
-        types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+        types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:
     contents: read
-    pull-requests: read
+    issues: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-    release-pr-policy:
+    pull-request-label-policy:
         runs-on: ubuntu-latest
-        name: Release PR policy
+        name: Pull request label policy
         steps:
             - uses: actions/checkout@v4
               with:
@@ -26,7 +26,7 @@ jobs:
                   node-version: 24
             - name: Install dependencies
               run: npm clean-install --ignore-scripts
-            - name: Validate release pull request
+            - name: Validate pull request label
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: npx just validate-release-pr
+              run: npx just validate-pr-labels "${{ github.event.pull_request.number }}"

--- a/.github/workflows/release-pr-policy.yml
+++ b/.github/workflows/release-pr-policy.yml
@@ -1,0 +1,32 @@
+name: Release PR policy
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    release-pr-policy:
+        runs-on: ubuntu-latest
+        name: Release PR policy
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+            - name: Validate release pull request
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just validate-release-pr

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,132 @@
+name: Release publish
+
+on:
+    workflow_call:
+        inputs:
+            release_pull_request_number:
+                default: ""
+                required: false
+                type: string
+    workflow_dispatch:
+        inputs:
+            release_pull_request_number:
+                required: true
+                type: string
+
+permissions: {}
+
+concurrency:
+    group: release-publish
+    cancel-in-progress: false
+
+jobs:
+    publish-release:
+        runs-on: ubuntu-latest
+        name: Publish release
+        permissions:
+            contents: write
+            id-token: write
+            pull-requests: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install workflow dependencies
+              run: npm clean-install --ignore-scripts
+            - name: Authorize release publish
+              id: publish-target
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_PULL_REQUEST_NUMBER: ${{ inputs.release_pull_request_number }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -n "$RELEASE_PULL_REQUEST_NUMBER" ]; then
+                      npx just authorize-release-publish --release-pull-request "$RELEASE_PULL_REQUEST_NUMBER"
+                  else
+                      npx just authorize-release-publish
+                  fi
+            - uses: actions/checkout@v4
+              if: steps.publish-target.outputs.should_publish == 'true'
+              with:
+                  ref: ${{ steps.publish-target.outputs.publish_commit_sha }}
+                  fetch-depth: 0
+                  path: target/release-source
+                  persist-credentials: true
+            - name: Use Node.js
+              if: steps.publish-target.outputs.should_publish == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - name: Install release dependencies
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              run: npm clean-install --ignore-scripts
+            - name: Check packages
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just publish-dry-run
+            - name: Audit release tooling
+              if: steps.publish-target.outputs.should_publish == 'true'
+              run: |
+                  mkdir -p target/release
+                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+
+                  const report = JSON.parse(
+                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
+                  );
+                  const packtory = report.verified.find((entry) => {
+                      return entry.name === '@packtory/cli';
+                  });
+
+                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
+                      throw new Error('Missing npm provenance for @packtory/cli');
+                  }
+                  NODE
+            - name: Configure release author
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            - name: Publish package
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  mkdir -p target/release
+                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
+
+                  set +e
+                  npx just publish-release 2>&1 | tee target/release/publish.log
+                  status=${PIPESTATUS[0]}
+                  set -e
+
+                  if [ "$status" -eq 0 ]; then
+                      true
+                  elif grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
+                      sleep 30
+                      npx just publish-release
+                  else
+                      exit "$status"
+                  fi
+
+                  for tag in $(git tag --points-at HEAD 'eslint-plugin-mocha@*'); do
+                      version="${tag#eslint-plugin-mocha@}"
+
+                      if ! git rev-parse --verify "refs/tags/$version" >/dev/null 2>&1; then
+                          git tag -a "$version" -m "$version" HEAD
+                      fi
+
+                      git push origin "refs/tags/$version:refs/tags/$version"
+                  done

--- a/justfile
+++ b/justfile
@@ -60,6 +60,9 @@ prepare-release: compile
 validate-release-pr:
     packtory release-pr validate
 
+validate-pr-labels pull-request-number:
+    pr-log validate-pull-request-labels {{pull-request-number}}
+
 authorize-release-publish *options:
     packtory release-pr authorize-publish {{options}}
 

--- a/justfile
+++ b/justfile
@@ -48,6 +48,9 @@ test: test-unit-with-coverage test-bench
 coveralls:
     coveralls < ./target/coverage/lcov.info
 
+changelog:
+    pr-log
+
 pack-preview:
     packtory preview
 

--- a/justfile
+++ b/justfile
@@ -48,13 +48,25 @@ test: test-unit-with-coverage test-bench
 coveralls:
     coveralls < ./target/coverage/lcov.info
 
-changelog:
-    pr-log
-
 pack-preview:
     packtory preview
 
-pack-publish:
+prepare-release: compile
+    packtory release-pr maintain --no-dry-run
+
+validate-release-pr:
+    packtory release-pr validate
+
+authorize-release-publish *options:
+    packtory release-pr authorize-publish {{options}}
+
+publish-release: compile
+    packtory release --publish --tag --push --github-release --no-dry-run
+
+publish-dry-run: compile
+    packtory publish
+
+publish: compile
     packtory publish --no-dry-run
 
 update-eslint-docs *options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12944,6 +12944,25 @@
                 }
             }
         },
+        "node_modules/packtory/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/packtory/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -12953,6 +12972,15 @@
             "engines": {
                 "node": ">=0.3.1"
             }
+        },
+        "node_modules/packtory/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/packtory/node_modules/semver": {
             "version": "7.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@enormora/eslint-config-mocha": "0.0.40",
                 "@enormora/eslint-config-node": "0.0.34",
                 "@enormora/eslint-config-typescript": "0.0.50",
-                "@packtory/cli": "0.0.46",
+                "@packtory/cli": "0.0.66",
                 "@stryker-mutator/core": "9.6.1",
                 "@stryker-mutator/mocha-runner": "9.6.1",
                 "@types/estree": "1.0.9",
@@ -37,7 +37,7 @@
                 "jscpd": "4.2.3",
                 "knip": "6.14.2",
                 "mocha": "11.1.0",
-                "pr-log": "6.3.0",
+                "pr-log": "6.4.1",
                 "rust-just": "1.51.0",
                 "typescript": "6.0.3"
             },
@@ -62,9 +62,9 @@
             "dev": true
         },
         "node_modules/@arethetypeswrong/core": {
-            "version": "0.18.4",
-            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.4.tgz",
-            "integrity": "sha512-M5F0ePyN6h2Z6XxRiyIPqjGbltotXLjR0CKA0uKspsDu0QmgTNYvRb4RSQPMUs2ZXZHCCYpbaZbFbYOXLxCjUA==",
+            "version": "0.18.5",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.5.tgz",
+            "integrity": "sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -82,9 +82,9 @@
             }
         },
         "node_modules/@arethetypeswrong/core/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2396,9 +2396,9 @@
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2419,23 +2419,33 @@
             }
         },
         "node_modules/@npmcli/git": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
-            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-8.0.0.tgz",
+            "integrity": "sha512-5P1oo+TbxZNAiiMBtpzHA8QyEGh5D69LYLexNWJEDXLdxnAZvT/SLitGJBXxjtCE4ftAcFOS/Tu2185MeIjooQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
-                "@npmcli/promise-spawn": "^9.0.0",
-                "ini": "^6.0.0",
+                "@npmcli/promise-spawn": "^10.0.0",
+                "ini": "^7.0.0",
                 "lru-cache": "^11.2.1",
-                "npm-pick-manifest": "^11.0.1",
-                "proc-log": "^6.0.0",
+                "npm-pick-manifest": "^12.0.0",
+                "proc-log": "^7.0.0",
                 "semver": "^7.3.5",
-                "which": "^6.0.0"
+                "which": "^7.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/ini": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+            "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/git/node_modules/isexe": {
@@ -2449,19 +2459,29 @@
             }
         },
         "node_modules/@npmcli/git/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }
         },
+        "node_modules/@npmcli/git/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
         "node_modules/@npmcli/git/node_modules/which": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+            "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2471,72 +2491,59 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/package-json": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
-            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-8.0.0.tgz",
+            "integrity": "sha512-agNZzYQ18MR0wKp3Emg1q5QbcC8CXigYp3Z3CvB0Sax9Ge9aF4cVyyuSG+5SbACSrZUKTvMjVULWiE1RJA38wg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^7.0.0",
+                "@npmcli/git": "^8.0.0",
                 "glob": "^13.0.0",
-                "hosted-git-info": "^9.0.0",
-                "json-parse-even-better-errors": "^5.0.0",
-                "proc-log": "^6.0.0",
+                "hosted-git-info": "^10.1.1",
+                "json-parse-even-better-errors": "^6.0.0",
+                "proc-log": "^7.0.0",
                 "semver": "^7.5.3",
                 "spdx-expression-parse": "^4.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
-            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-6.0.0.tgz",
+            "integrity": "sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
-        "node_modules/@npmcli/package-json/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+        "node_modules/@npmcli/package-json/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "engines": {
-                "node": "20 || >=22"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/promise-spawn": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
-            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-10.0.0.tgz",
+            "integrity": "sha512-llZkSzeTsimFx64U+ThT2xQM2uEce8GIQUYvxgbB6ZFvBhV2LP9LeJJb3HT+syG0uCFLsTCHjV9SfC0WNU1vtA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "which": "^6.0.0"
+                "which": "^7.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
@@ -2550,9 +2557,9 @@
             }
         },
         "node_modules/@npmcli/promise-spawn/node_modules/which": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+            "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2562,7 +2569,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@npmcli/redact": {
@@ -3392,21 +3399,20 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.46",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.46.tgz",
-            "integrity": "sha512-E0Dl2FD9/nlv830KP/lKlTOS0idFIzELvSSyZ46YB1pK+fTcRZNWXdiXMtbjGq5Tb8hDZGNgBz5e1VH4aViaqg==",
+            "version": "0.0.66",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.66.tgz",
+            "integrity": "sha512-2uSBgbdZY2vrClZfvs4rW+plk1DCsIqXH/lsaf/uDd9+829vQJEWxKe30aF3rugOrBnD7yjyZ4Hh+6ubaJBduA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@octokit/core": "7.0.6",
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-                "@pr-log/core": "0.0.2",
-                "@schema-hub/zod-error-formatter": "0.0.11",
+                "@pr-log/core": "0.0.3",
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.46",
+                "packtory": "0.0.60",
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
@@ -3513,9 +3519,9 @@
             }
         },
         "node_modules/@pr-log/core": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.2.tgz",
-            "integrity": "sha512-M+RhqKvyH1wwO8+dch3Pk6hK5Z1F8bAxmxD/1qoWp9+OX1PhUFvDsZTpQYQ04ygvDGK7bAho7MpKscd50LnIXA==",
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-zzMVv+AL5KwuDIpjxyu6jRs9qLLbEcgQYAzg6+o+mQCBuvyzL5J1e8st2xocA87WSD1DeY1lewvXXrorubFyFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3524,28 +3530,17 @@
                 "common-tags": "1.8.2",
                 "date-fns": "4.4.0",
                 "execa": "9.6.1",
-                "semver": "7.8.2",
+                "semver": "7.8.5",
                 "true-myth": "9.4.0"
             },
             "engines": {
                 "node": "^24.0.0 || ^26.0.0"
             }
         },
-        "node_modules/@pr-log/core/node_modules/date-fns": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-            "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/kossnocorp"
-            }
-        },
         "node_modules/@pr-log/core/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -3556,13 +3551,13 @@
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.11.tgz",
-            "integrity": "sha512-5U+75sWcq9BBzNO0ui7iJZfhkU3QLpeZiF4uuxrWqpSYfmrfzyGOjVGfSVWTWeGlIZaepaON2eVn9ugTWvjppQ==",
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.12.tgz",
+            "integrity": "sha512-dTUnu48Aj3VXLq4BT+HtiiKKyvBlm07tJlQ2WA1SQtv7rZzZfV/vFTJoSkwdzQ9Axi3gVrcSpXV9qtAKQ0Ybpw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^22 || ^24"
+                "node": "^24 || ^26"
             },
             "peerDependencies": {
                 "zod": "^4.0.5"
@@ -3576,26 +3571,26 @@
             "license": "MIT"
         },
         "node_modules/@sigstore/bundle": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
-            "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-5.0.0.tgz",
+            "integrity": "sha512-wefjygudENbzbQMks1t5u34EP0fFoD0XvaEP7DOUP/sXKvogzEJYFw5E6pegGyp3onGWzVEYKVa3bNZWyTYX+A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@sigstore/core": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
-            "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-4.0.1.tgz",
+            "integrity": "sha512-9v5hRjujn5NXq8o7XFEUgLyAtdr5Iisb4pzM05u3K61IS5q3hP3luWAndk0RkPPLTUFoTbg7Vb84UQ1ZQeajWQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@sigstore/protobuf-specs": {
@@ -3609,217 +3604,60 @@
             }
         },
         "node_modules/@sigstore/sign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
-            "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-5.0.0.tgz",
+            "integrity": "sha512-DSFivqz9/i5AkwZ5fq0YdjaJlc4o1WeS2Zffon0kqtChx0vy4W9NOjkEet9bF2vkzOufX72eVH8kZBIGtcBp1w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.2",
-                "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.2.0",
+                "@sigstore/bundle": "^5.0.0",
+                "@sigstore/core": "^4.0.0",
                 "@sigstore/protobuf-specs": "^0.5.0",
-                "make-fetch-happen": "^15.0.4",
-                "proc-log": "^6.1.0"
+                "make-fetch-happen": "^16.0.0",
+                "proc-log": "^7.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
-        "node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
-            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+        "node_modules/@sigstore/sign/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-            "version": "15.0.6",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
-            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            },
-            "optionalDependencies": {
-                "iconv-lite": "^0.7.2"
-            }
-        },
-        "node_modules/@sigstore/sign/node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@sigstore/tuf": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
-            "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-5.0.0.tgz",
+            "integrity": "sha512-Zyqg9tcHps3uRAlKHLNmsW4ohsUZAjb9G+31r7lg0ICh/JOcadzmJsIRdjKljlRHpaR0K4aJ2kXXIdywdcdMlA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0",
-                "tuf-js": "^4.1.0"
+                "tuf-js": "^6.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@sigstore/verify": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
-            "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-4.1.0.tgz",
+            "integrity": "sha512-p/s720RiWxLG8XtmfdPfEJOlATA6H/2knFqmtQbFkHKN3IrhWGUwPfpQAf1UnQIEES9IaH6zzhfjkrhTfeSdZw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.2.1",
+                "@sigstore/bundle": "^5.0.0",
+                "@sigstore/core": "^4.0.1",
                 "@sigstore/protobuf-specs": "^0.5.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -4111,17 +3949,17 @@
             }
         },
         "node_modules/@tufjs/models": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
-            "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-5.0.0.tgz",
+            "integrity": "sha512-U4mVcdFGOi6pt8n38LdWZp67Svn7ppnU1Pj8SGOVaBi1X4gm+G4ztQlLfkoJbKSHfjA6WeaiJp2A4V83AJF6nQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tufjs/canonical-json": "2.0.0",
-                "minimatch": "^10.1.1"
+                "minimatch": "^10.2.1"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@tybys/wasm-util": {
@@ -5248,9 +5086,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+            "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5272,25 +5110,12 @@
                 }
             }
         },
-        "node_modules/bare-os": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
         "node_modules/bare-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
             "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
+            "license": "Apache-2.0"
         },
         "node_modules/bare-stream": {
             "version": "2.13.3",
@@ -5722,26 +5547,13 @@
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/ssri": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
-            "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^7.0.3"
-            },
-            "engines": {
-                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -6554,6 +6366,17 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+            "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/debug": {
@@ -8973,9 +8796,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -10150,249 +9973,33 @@
             }
         },
         "node_modules/libnpmpublish": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.2.0.tgz",
-            "integrity": "sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-12.0.0.tgz",
+            "integrity": "sha512-F1KmLf5pmAGmOTR/NalClhPRqyLlrrdl270ZYg2xf9yk6w3oE21uF4QS9ph7hm+f4InB52AfG+UWeuFoFoqdeA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/package-json": "^8.0.0",
                 "ci-info": "^4.0.0",
-                "npm-package-arg": "^13.0.0",
-                "npm-registry-fetch": "^19.0.0",
-                "proc-log": "^6.0.0",
+                "npm-package-arg": "^14.0.0",
+                "npm-registry-fetch": "^20.0.1",
+                "proc-log": "^7.0.0",
                 "semver": "^7.3.7",
-                "sigstore": "^4.0.0",
-                "ssri": "^13.0.0"
+                "sigstore": "^5.0.0",
+                "ssri": "^14.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
-        "node_modules/libnpmpublish/node_modules/@npmcli/agent": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
-            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+        "node_modules/libnpmpublish/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/hosted-git-info": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/make-fetch-happen": {
-            "version": "15.0.6",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
-            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            },
-            "optionalDependencies": {
-                "iconv-lite": "^0.7.2"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/npm-package-arg": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/npm-registry-fetch": {
-            "version": "19.1.1",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
-            "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/redact": "^4.0.0",
-                "jsonparse": "^1.3.1",
-                "make-fetch-happen": "^15.0.0",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minizlib": "^3.0.1",
-                "npm-package-arg": "^13.0.0",
-                "proc-log": "^6.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/lines-and-columns": {
@@ -10553,19 +10160,6 @@
             "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
             "dev": true,
             "license": "ISC",
-            "engines": {
-                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/make-fetch-happen/node_modules/ssri": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
-            "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^7.0.3"
-            },
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
@@ -12163,26 +11757,26 @@
             }
         },
         "node_modules/npm-install-checks": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
-            "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-9.0.0.tgz",
+            "integrity": "sha512-t05Izcgi7p15cpldqoiXYpjzlkTTvBw33sgjmL/JjcvtV0ydbm2O4iEXO8A6smqComu5FAQhUas86HTMQ6Z1Uw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/npm-normalize-package-bin": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-            "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-6.0.0.tgz",
+            "integrity": "sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/npm-package-arg": {
@@ -12222,68 +11816,19 @@
             }
         },
         "node_modules/npm-pick-manifest": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
-            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-12.0.0.tgz",
+            "integrity": "sha512-8Fs3YLrnNOhrCdPNZy18MzNgVC58LTDAFzq1FdZO/p3BHeCC/coz+t4F5Pxabys8HJpyTUorMea26GkXsb4J/Q==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "npm-install-checks": "^8.0.0",
-                "npm-normalize-package-bin": "^5.0.0",
-                "npm-package-arg": "^13.0.0",
+                "npm-install-checks": "^9.0.0",
+                "npm-normalize-package-bin": "^6.0.0",
+                "npm-package-arg": "^14.0.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-pick-manifest/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/npm-registry-fetch": {
@@ -12528,9 +12073,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12632,24 +12177,24 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.46",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.46.tgz",
-            "integrity": "sha512-bCdqXV9+5YFs3s0m6epT27U/SVgJR+6q9uOKIK/8x03w6PtxsWvAedfQVRN+WGZrnFFCNVNbML9wYIEr6i0b4g==",
+            "version": "0.0.60",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.60.tgz",
+            "integrity": "sha512-YYxF6EIDrRx4A5FpAMFznoth9uudtaprHMUDxsob2hSdCkLBvUjzLO42nn7Fi8Lhx2oebvFNlTg5E1M8ZYz++A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@arethetypeswrong/core": "0.18.4",
+                "@arethetypeswrong/core": "0.18.5",
                 "@cyclonedx/cyclonedx-library": "10.1.0",
                 "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
-                "@schema-hub/zod-error-formatter": "0.0.11",
+                "@schema-hub/zod-error-formatter": "0.0.12",
                 "@ts-morph/common": "0.29.0",
                 "@types/npm-registry-fetch": "8.0.9",
                 "common-tags": "1.8.2",
                 "diff": "9.0.0",
                 "fflate": "0.8.3",
                 "hosted-git-info": "10.1.1",
-                "libnpmpublish": "11.2.0",
+                "libnpmpublish": "12.0.0",
                 "npm-package-arg": "14.0.0",
                 "npm-registry-fetch": "20.0.1",
                 "remeda": "2.39.0",
@@ -12659,7 +12204,7 @@
                 "true-myth": "9.4.0",
                 "ts-morph": "27.0.2",
                 "ts-pattern": "5.9.0",
-                "type-fest": "5.7.0",
+                "type-fest": "5.8.0",
                 "unix-permissions": "6.0.1",
                 "zod": "4.4.3"
             },
@@ -12767,9 +12312,9 @@
             }
         },
         "node_modules/packtory/node_modules/type-fest": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -12968,23 +12513,22 @@
             }
         },
         "node_modules/pr-log": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/pr-log/-/pr-log-6.3.0.tgz",
-            "integrity": "sha512-oEjIso49oS9AbnMxm2DF6J/omJpSlsJ9svovUraExZedVRmAYF0Cec8WtBtBbv8KOgW/rVQ44pmqauvJRPNPuQ==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/pr-log/-/pr-log-6.4.1.tgz",
+            "integrity": "sha512-xW+arpggBr0XpVCDDMgPnlsVF0jrwHJyzHvZbuLsNHoejrm41A6eoC5rEL8F+RXQY+pElCjaJA9YRpcAeCgfCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "22.0.1",
-                "@pr-log/core": "0.0.2",
+                "@pr-log/core": "0.0.4",
                 "@sindresorhus/is": "8.1.0",
-                "commander": "14.0.3",
+                "commander": "15.0.0",
                 "common-tags": "1.8.2",
                 "execa": "9.6.1",
                 "git-url-parse": "16.1.0",
                 "loglevel": "1.9.2",
                 "parse-github-repo-url": "1.4.1",
                 "prepend-file": "2.0.1",
-                "semver": "7.8.2",
                 "true-myth": "9.4.0"
             },
             "bin": {
@@ -12994,20 +12538,39 @@
                 "node": "^24.0.0 || ^26.0.0"
             }
         },
+        "node_modules/pr-log/node_modules/@pr-log/core": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.4.tgz",
+            "integrity": "sha512-dAgierqsL4tgLGhYp8k+b6czmujIBba7ovdPpu4A1hiQpBw0WnVCo3MP0MtWz1tDajLhssLBzLA7ilcwokcL9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.5",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
         "node_modules/pr-log/node_modules/commander": {
-            "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+            "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=20"
+                "node": ">=22.12.0"
             }
         },
         "node_modules/pr-log/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -14183,21 +13746,21 @@
             }
         },
         "node_modules/sigstore": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
-            "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-5.0.0.tgz",
+            "integrity": "sha512-hJqJfoG/e4qFQaauQL00c6J6FrHLBGKtkFvW3JbTSIEFOhLrSjdSM/gWd/yUOfYo/gsERehTXGC1VZWX+9X4Dg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.2.1",
+                "@sigstore/bundle": "^5.0.0",
+                "@sigstore/core": "^4.0.0",
                 "@sigstore/protobuf-specs": "^0.5.0",
-                "@sigstore/sign": "^4.1.1",
-                "@sigstore/tuf": "^4.0.2",
-                "@sigstore/verify": "^3.1.1"
+                "@sigstore/sign": "^5.0.0",
+                "@sigstore/tuf": "^5.0.0",
+                "@sigstore/verify": "^4.0.0"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/sisteransi": {
@@ -14388,16 +13951,16 @@
             }
         },
         "node_modules/ssri": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
+            "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/stable-hash-x": {
@@ -14985,185 +14548,18 @@
             "license": "0BSD"
         },
         "node_modules/tuf-js": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
-            "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-6.0.0.tgz",
+            "integrity": "sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tufjs/models": "4.1.0",
-                "debug": "^4.4.3",
-                "make-fetch-happen": "^15.0.1"
+                "@gar/promise-retry": "^1.0.3",
+                "@tufjs/models": "5.0.0",
+                "debug": "^4.4.3"
             },
             "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/@npmcli/agent": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
-            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/tuf-js/node_modules/cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/tuf-js/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/tuf-js/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/tuf-js/node_modules/make-fetch-happen": {
-            "version": "15.0.6",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
-            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            },
-            "optionalDependencies": {
-                "iconv-lite": "^0.7.2"
-            }
-        },
-        "node_modules/tuf-js/node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/tunnel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@enormora/eslint-config-mocha": "0.0.40",
                 "@enormora/eslint-config-node": "0.0.34",
                 "@enormora/eslint-config-typescript": "0.0.50",
-                "@packtory/cli": "0.0.26",
+                "@packtory/cli": "0.0.46",
                 "@stryker-mutator/core": "9.6.1",
                 "@stryker-mutator/mocha-runner": "9.6.1",
                 "@types/estree": "1.0.9",
@@ -37,7 +37,6 @@
                 "jscpd": "4.2.3",
                 "knip": "6.14.2",
                 "mocha": "11.1.0",
-                "pr-log": "6.1.1",
                 "rust-just": "1.51.0",
                 "typescript": "6.0.3"
             },
@@ -54,6 +53,56 @@
             "integrity": "sha512-cSR/ZYDF6Wp9OeAJMyLYYN1GenAAhV17W+w38ELP+3c5Ltsy9jkkCymi33nz/qnXyef3n6Fbr1h2yt3dvUN5sQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/@andrewbranch/untar.js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+            "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+            "dev": true
+        },
+        "node_modules/@arethetypeswrong/core": {
+            "version": "0.18.4",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.4.tgz",
+            "integrity": "sha512-M5F0ePyN6h2Z6XxRiyIPqjGbltotXLjR0CKA0uKspsDu0QmgTNYvRb4RSQPMUs2ZXZHCCYpbaZbFbYOXLxCjUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@andrewbranch/untar.js": "^1.0.3",
+                "@loaderkit/resolve": "^1.0.2",
+                "cjs-module-lexer": "^1.2.3",
+                "fflate": "^0.8.3",
+                "lru-cache": "^11.0.1",
+                "semver": "^7.5.4",
+                "typescript": "5.6.1-rc",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+            "version": "5.6.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+            "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
@@ -678,6 +727,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@braidai/lang": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+            "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
@@ -2229,6 +2285,16 @@
                 "spark-md5": "^3.0.2"
             }
         },
+        "node_modules/@loaderkit/resolve": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+            "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@braidai/lang": "^1.0.0"
+            }
+        },
         "node_modules/@mdit-vue/shared": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-3.0.2.tgz",
@@ -2311,17 +2377,10 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@npm/types": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@npm/types/-/types-1.0.2.tgz",
-            "integrity": "sha512-KXZccTDEnWqNrrx6JjpJKU/wJvNeg9BDgjS0XhmlZab7br921HtyVbsYzJr4L+xIvjdJ20Wh9dgxgCI2a5CEQw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@npmcli/agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-5.0.1.tgz",
-            "integrity": "sha512-PsOUeQRpNOGH+Iks/YPY8AXtttvGVqNqKIo/Cp2LhI0jpeqW32JP14yYRym+OsTg+roH4Avw281YwHMp8X8L2Q==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-5.0.2.tgz",
+            "integrity": "sha512-EkzGmEsgbQ1rqWkRJe2P0oQHx/ylZozDUNPMXCklLuSFL3GY+QyEfBUjhjCsgGXzh4OGpnHvkboSQgczjP/jJg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2433,24 +2492,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@npmcli/package-json/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
@@ -2531,207 +2572,6 @@
             "license": "ISC",
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/core": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.1.0",
-                "@octokit/request": "^8.4.1",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/endpoint": {
-            "version": "9.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/graphql": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/request": "^8.4.1",
-                "@octokit/types": "^13.0.0",
-                "universal-user-agent": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/openapi-types": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^12.6.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
-            }
-        },
-        "node_modules/@octokit/plugin-request-log": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
-            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^12.6.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
-            }
-        },
-        "node_modules/@octokit/request": {
-            "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/endpoint": "^9.0.6",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/request-error": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/rest": {
-            "version": "20.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
-            "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/core": "^5.0.0",
-                "@octokit/plugin-paginate-rest": "^9.0.0",
-                "@octokit/plugin-request-log": "^4.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/types": {
-            "version": "13.10.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "node_modules/@one-ini/wasm": {
@@ -3384,18 +3224,26 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.26",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.26.tgz",
-            "integrity": "sha512-0cDiqJB6FIqx2Mr7G1EzxPrt4YfZ7b0fnoOxDpnp5qunpZboNuGgcobFs0Wnr72O+lbSY4Tl4CneA87LNMRNJA==",
+            "version": "0.0.46",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.46.tgz",
+            "integrity": "sha512-E0Dl2FD9/nlv830KP/lKlTOS0idFIzELvSSyZ46YB1pK+fTcRZNWXdiXMtbjGq5Tb8hDZGNgBz5e1VH4aViaqg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@octokit/core": "7.0.6",
+                "@octokit/plugin-paginate-rest": "14.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "17.0.0",
+                "@pr-log/core": "0.0.2",
+                "@schema-hub/zod-error-formatter": "0.0.11",
                 "cmd-ts": "0.15.0",
+                "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.26",
-                "remeda": "2.37.0",
+                "packtory": "0.0.46",
+                "remeda": "2.39.0",
+                "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
-                "yoctocolors": "2.1.2"
+                "yoctocolors": "2.1.2",
+                "zod": "4.4.3"
             },
             "bin": {
                 "packtory": "packages/command-line-interface/command-line-interface.entry-point.js"
@@ -3403,6 +3251,181 @@
             "engines": {
                 "node": "^24 || ^26"
             }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/core": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/endpoint": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/graphql": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/openapi-types": {
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/request": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/request-error": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@octokit/types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^27.0.0"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@packtory/cli/node_modules/diff": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -3459,9 +3482,9 @@
             "license": "ISC"
         },
         "node_modules/@pnpm/npm-conf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-            "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+            "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3472,6 +3495,353 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/@pr-log/core": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.2.tgz",
+            "integrity": "sha512-M+RhqKvyH1wwO8+dch3Pk6hK5Z1F8bAxmxD/1qoWp9+OX1PhUFvDsZTpQYQ04ygvDGK7bAho7MpKscd50LnIXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.2",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/core": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/endpoint": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/graphql": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/openapi-types": {
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/plugin-request-log": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/request": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/request-error": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/rest": {
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-request-log": "^6.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@octokit/types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^27.0.0"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@sindresorhus/is": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+            "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@pr-log/core/node_modules/date-fns": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+            "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/semver": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@schema-hub/zod-error-formatter": {
             "version": "0.0.11",
@@ -3616,24 +3986,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@sigstore/sign/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@sigstore/sign/node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3764,19 +4116,6 @@
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.2.0.tgz",
-            "integrity": "sha512-yM/IGPkVnYGblhDosFBwq0ZGdnVSBkNV4onUtipGMOjZd4kB6GAu3ys91aftSbyMHh6A2GPdt+KDI5NoWP63MQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "4.0.0",
@@ -4232,18 +4571,6 @@
             "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/libnpmpublish": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@types/libnpmpublish/-/libnpmpublish-9.0.1.tgz",
-            "integrity": "sha512-9XtssAlenc4sYO1Ftn8KfKIVRWivBYIjHJBdJeTLLVnDzVJ2mzWeR0i3eNak7ECK2tppMW/SonzOXnk/lEU03w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@npm/types": "^1",
-                "@types/node-fetch": "*",
-                "@types/npm-registry-fetch": "*"
-            }
         },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
@@ -5284,9 +5611,9 @@
             }
         },
         "node_modules/bare-events": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
-            "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+            "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
             "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -5299,9 +5626,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5334,9 +5661,9 @@
             }
         },
         "node_modules/bare-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5344,12 +5671,13 @@
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+            "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
+                "b4a": "^1.8.1",
                 "streamx": "^2.25.0",
                 "teex": "^1.0.1"
             },
@@ -5371,9 +5699,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+            "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5420,13 +5748,6 @@
             "engines": {
                 "node": ">=18.18.0"
             }
-        },
-        "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-            "dev": true,
-            "license": "Apache-2.0"
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -5750,9 +6071,9 @@
             }
         },
         "node_modules/cacache": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-21.0.0.tgz",
-            "integrity": "sha512-ohgebHsACA1Q2Pc99Vn/NWqoFoFoxY5aOktQY5Og/uyIyTaOx81YdxvnzpMq8qurTDxPd+CU3I0SNFdJWDb8ig==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-21.0.1.tgz",
+            "integrity": "sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5769,24 +6090,6 @@
             },
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/cacache/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
@@ -6023,6 +6326,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cli-boxes": {
             "version": "3.0.0",
@@ -6318,6 +6628,20 @@
                 "@babel/types": "^7.6.1"
             }
         },
+        "node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6603,23 +6927,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/date-fns": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.21.0"
-            },
-            "engines": {
-                "node": ">=0.11"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/date-fns"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6800,13 +7107,6 @@
             "engines": {
                 "node": ">=20"
             }
-        },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/dequal": {
             "version": "2.0.3",
@@ -8199,30 +8499,6 @@
                 "bare-events": "^2.7.0"
             }
         },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -8578,17 +8854,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -8761,19 +9037,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-tsconfig": {
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -8807,33 +9070,30 @@
                 "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
         },
-        "node_modules/git-up": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-            "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-ssh": "^1.4.0",
-                "parse-url": "^8.1.0"
-            }
-        },
-        "node_modules/git-url-parse": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.0.0.tgz",
-            "integrity": "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "git-up": "^7.0.0"
-            }
-        },
         "node_modules/github-slugger": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
@@ -8983,9 +9243,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9043,14 +9303,15 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "9.0.0",
-                "debug": "^4.3.4"
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
                 "node": ">= 20"
@@ -9073,27 +9334,18 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "9.0.0",
-                "debug": "^4.3.4"
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
                 "node": ">= 20"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.17.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -9580,29 +9832,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-ssh": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
-            "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "protocols": "^2.0.1"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -9933,6 +10162,13 @@
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/json-with-bigint": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -10278,24 +10514,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/libnpmpublish/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/libnpmpublish/node_modules/hosted-git-info": {
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
@@ -10528,20 +10746,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/loglevel": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
-            "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
-            },
-            "funding": {
-                "type": "tidelift",
-                "url": "https://tidelift.com/funding/github/npm/loglevel"
             }
         },
         "node_modules/longest-streak": {
@@ -11638,19 +11842,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -12279,6 +12470,16 @@
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
+        "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
+            "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
         "node_modules/npm-pick-manifest": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
@@ -12345,9 +12546,9 @@
             }
         },
         "node_modules/npm-registry-fetch": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-20.0.0.tgz",
-            "integrity": "sha512-Hqaz3bQd4rnC41fskRZ2yzemzsfEvoA3WAuW7xkDC2RHtQ/W+o6n1dz8SHm61wmFFZGBITFzZD7kUPjXmYaNbw==",
+            "version": "20.0.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-20.0.1.tgz",
+            "integrity": "sha512-vzc1svxw/kw1IRjFsLi6gaxe1Olqm88V0tIfu2u5raL0b1gChe6ZEXNkyUlKxUC7s/egt5NxZHkbY18tMKKLfQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -12372,35 +12573,6 @@
             "license": "ISC",
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/oauth-sign": {
@@ -12444,22 +12616,6 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/open": {
@@ -12705,18 +12861,18 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.26",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.26.tgz",
-            "integrity": "sha512-mUsUmY1MuQjV/cB9UbGrCja9XCm8CZD+feAzlL5gaIP0ZAdjRmogMi9ZaVWIS24a0fiLpTil4tBPPCgC7iQ8iA==",
+            "version": "0.0.46",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.46.tgz",
+            "integrity": "sha512-bCdqXV9+5YFs3s0m6epT27U/SVgJR+6q9uOKIK/8x03w6PtxsWvAedfQVRN+WGZrnFFCNVNbML9wYIEr6i0b4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cyclonedx/cyclonedx-library": "10.0.0",
+                "@arethetypeswrong/core": "0.18.4",
+                "@cyclonedx/cyclonedx-library": "10.1.0",
                 "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
                 "@schema-hub/zod-error-formatter": "0.0.11",
                 "@ts-morph/common": "0.29.0",
-                "@types/libnpmpublish": "9.0.1",
                 "@types/npm-registry-fetch": "8.0.9",
                 "common-tags": "1.8.2",
                 "diff": "9.0.0",
@@ -12724,15 +12880,15 @@
                 "hosted-git-info": "10.1.1",
                 "libnpmpublish": "11.2.0",
                 "npm-package-arg": "14.0.0",
-                "npm-registry-fetch": "20.0.0",
-                "remeda": "2.37.0",
-                "semver": "7.8.1",
+                "npm-registry-fetch": "20.0.1",
+                "remeda": "2.39.0",
+                "semver": "7.8.5",
                 "spdx-expression-parse": "4.0.0",
                 "tar-stream": "3.1.8",
                 "true-myth": "9.4.0",
                 "ts-morph": "27.0.2",
                 "ts-pattern": "5.9.0",
-                "type-fest": "5.6.0",
+                "type-fest": "5.7.0",
                 "unix-permissions": "6.0.1",
                 "zod": "4.4.3"
             },
@@ -12741,9 +12897,9 @@
             }
         },
         "node_modules/packtory/node_modules/@cyclonedx/cyclonedx-library": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.0.0.tgz",
-            "integrity": "sha512-xDXf2eqzeFHdjamj6oBV3duRSfrlmsJ5+2z9tXp7q5qxJP5Awmjf4ABSutS4qkVHHj7JzKFL/EM0V0Nihc7zPg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.1.0.tgz",
+            "integrity": "sha512-4yq0KTQIA32UHJwFMDeY5xj2asp3Mk5lzx4JRVXLOb0YE8w1KeR61c1m/gJ4sjMXpiiEDfaITVQu8BLUuy7t3A==",
             "dev": true,
             "funding": [
                 {
@@ -12788,25 +12944,6 @@
                 }
             }
         },
-        "node_modules/packtory/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/packtory/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -12817,19 +12954,23 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/packtory/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "node_modules/packtory/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/packtory/node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -12854,13 +12995,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/parse-github-repo-url": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-            "integrity": "sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -12892,26 +13026,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/parse-path": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
-            "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "protocols": "^2.0.0"
-            }
-        },
-        "node_modules/parse-url": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-            "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "parse-path": "^7.0.0"
             }
         },
         "node_modules/path-browserify": {
@@ -13023,82 +13137,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pr-log": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/pr-log/-/pr-log-6.1.1.tgz",
-            "integrity": "sha512-Svd5dCYQUml+JH4FsClGltUuSrkixUyBHbHXNF6/4M/77AOKMTWlDLN2y0/QqsaaNLFTPRN2/pdx+jkYntgoKg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/rest": "20.0.2",
-                "@sindresorhus/is": "6.2.0",
-                "commander": "12.0.0",
-                "common-tags": "1.8.2",
-                "date-fns": "2.30.0",
-                "execa": "8.0.1",
-                "git-url-parse": "14.0.0",
-                "loglevel": "1.9.1",
-                "parse-github-repo-url": "1.4.1",
-                "prepend-file": "2.0.1",
-                "semver": "7.6.0",
-                "true-myth": "7.1.0"
-            },
-            "bin": {
-                "pr-log": "target/build/source/bin/pr-log.js"
-            },
-            "engines": {
-                "node": "^20"
-            }
-        },
-        "node_modules/pr-log/node_modules/commander": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-            "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/pr-log/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/pr-log/node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/pr-log/node_modules/true-myth": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-7.1.0.tgz",
-            "integrity": "sha512-DcdyFRHfNyG31HgNtxqrVAHmBf7y1w4YZCpU7IR2Ohytm4LITv+u075Vc3dLyK9cdEPq6K9398iao6YpkU8hHA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18.* || >= 20.*"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13106,19 +13144,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prepend-file": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-2.0.1.tgz",
-            "integrity": "sha512-0hXWjmOpz5YBIk6xujS0lYtCw6IAA0wCR3fw49UGTLc3E9BIhcxgqdMa8rzGvrtt2F8wFiGP42oEpQ8fo9zhRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "temp-write": "^4.0.0"
-            },
-            "engines": {
-                "node": "^10.17 || >=11.14"
             }
         },
         "node_modules/pretty-format": {
@@ -13226,12 +13251,23 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/protocols": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
-            "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/psl": {
             "version": "1.15.0",
@@ -13697,9 +13733,9 @@
             }
         },
         "node_modules/remeda": {
-            "version": "2.37.0",
-            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.37.0.tgz",
-            "integrity": "sha512-wN6BXWua0t4o7vDamqc27J3VRxnokG9cDezsFN2nOnt2JD/IkJQHTYqM6UvmEctAZETAoviwEFQZJO3kZ4Ohew==",
+            "version": "2.39.0",
+            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.39.0.tgz",
+            "integrity": "sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14421,9 +14457,9 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz",
-            "integrity": "sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14585,9 +14621,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
-            "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+            "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14708,19 +14744,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/strip-indent": {
@@ -14858,72 +14881,6 @@
                 "streamx": "^2.12.5"
             }
         },
-        "node_modules/temp-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-            "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/temp-write": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
-            "integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.15",
-                "is-stream": "^2.0.0",
-                "make-dir": "^3.0.0",
-                "temp-dir": "^1.0.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/temp-write/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/temp-write/node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/temp-write/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
@@ -14937,24 +14894,6 @@
             },
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/test-exclude/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/text-decoder": {
@@ -15261,24 +15200,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/tuf-js/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tuf-js/node_modules/http-proxy-agent": {
@@ -15615,13 +15536,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/universal-user-agent": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/universalify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -15818,13 +15732,13 @@
             }
         },
         "node_modules/validate-npm-package-name": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
-            "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/verror": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "jscpd": "4.2.3",
                 "knip": "6.14.2",
                 "mocha": "11.1.0",
+                "pr-log": "6.3.0",
                 "rust-just": "1.51.0",
                 "typescript": "6.0.3"
             },
@@ -2574,6 +2575,173 @@
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
+        "node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "content-type": "^2.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-request-log": "^6.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^27.0.0"
+            }
+        },
         "node_modules/@one-ini/wasm": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.2.0.tgz",
@@ -3252,151 +3420,6 @@
                 "node": "^24 || ^26"
             }
         },
-        "node_modules/@packtory/cli/node_modules/@octokit/auth-token": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/core": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/auth-token": "^6.0.0",
-                "@octokit/graphql": "^9.0.3",
-                "@octokit/request": "^10.0.6",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "before-after-hook": "^4.0.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/endpoint": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/graphql": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/request": "^10.0.6",
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/openapi-types": {
-            "version": "27.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/plugin-paginate-rest": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=6"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=6"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/request": {
-            "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/endpoint": "^11.0.3",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "content-type": "^2.0.0",
-                "json-with-bigint": "^3.5.3",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/request-error": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/@octokit/types": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^27.0.0"
-            }
-        },
-        "node_modules/@packtory/cli/node_modules/before-after-hook": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/@packtory/cli/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -3419,13 +3442,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@packtory/cli/node_modules/universal-user-agent": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -3515,193 +3531,6 @@
                 "node": "^24.0.0 || ^26.0.0"
             }
         },
-        "node_modules/@pr-log/core/node_modules/@octokit/auth-token": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/core": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/auth-token": "^6.0.0",
-                "@octokit/graphql": "^9.0.3",
-                "@octokit/request": "^10.0.6",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "before-after-hook": "^4.0.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/endpoint": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/graphql": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/request": "^10.0.6",
-                "@octokit/types": "^16.0.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/openapi-types": {
-            "version": "27.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/plugin-paginate-rest": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=6"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/plugin-request-log": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=6"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=6"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/request": {
-            "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/endpoint": "^11.0.3",
-                "@octokit/request-error": "^7.0.2",
-                "@octokit/types": "^16.0.0",
-                "content-type": "^2.0.0",
-                "json-with-bigint": "^3.5.3",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/request-error": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/rest": {
-            "version": "22.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/core": "^7.0.6",
-                "@octokit/plugin-paginate-rest": "^14.0.0",
-                "@octokit/plugin-request-log": "^6.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@octokit/types": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/openapi-types": "^27.0.0"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/@sindresorhus/is": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
-            "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=22"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/before-after-hook": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/@pr-log/core/node_modules/date-fns": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -3711,103 +3540,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/execa": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "cross-spawn": "^7.0.6",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.0",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.2.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/human-signals": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/npm-run-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@pr-log/core/node_modules/semver": {
@@ -3822,26 +3554,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@pr-log/core/node_modules/strip-final-newline": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/universal-user-agent": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/@schema-hub/zod-error-formatter": {
             "version": "0.0.11",
@@ -4117,6 +3829,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sindresorhus/is": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+            "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -4227,122 +3952,12 @@
                 "node": ">=20"
             }
         },
-        "node_modules/@stryker-mutator/core/node_modules/execa": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "cross-spawn": "^7.0.6",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.0",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.2.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/human-signals": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/@stryker-mutator/instrumenter": {
             "version": "9.6.1",
@@ -4679,6 +4294,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/parse-path": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+            "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/sarif": {
             "version": "2.1.7",
@@ -5748,6 +5370,13 @@
             "engines": {
                 "node": ">=18.18.0"
             }
+        },
+        "node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -8499,6 +8128,33 @@
                 "bare-events": "^2.7.0"
             }
         },
+        "node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -9037,6 +8693,23 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-tsconfig": {
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -9068,6 +8741,27 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
+            }
+        },
+        "node_modules/git-up": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+            "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-ssh": "^1.4.0",
+                "parse-url": "^9.2.0"
+            }
+        },
+        "node_modules/git-url-parse": {
+            "version": "16.1.0",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+            "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "git-up": "^8.1.0"
             }
         },
         "node_modules/github-slugger": {
@@ -9346,6 +9040,16 @@
             },
             "engines": {
                 "node": ">= 20"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -9827,6 +9531,29 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-ssh": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+            "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "protocols": "^2.0.1"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -10746,6 +10473,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/loglevel": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+            "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
             }
         },
         "node_modules/longest-streak": {
@@ -12575,6 +12316,36 @@
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
+        "node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm-run-path/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -13024,6 +12795,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-github-repo-url": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+            "integrity": "sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -13054,6 +12832,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-path": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+            "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "protocols": "^2.0.0"
+            }
+        },
+        "node_modules/parse-url": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+            "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-path": "^7.0.0",
+                "parse-path": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.13.0"
             }
         },
         "node_modules/path-browserify": {
@@ -13165,6 +12967,56 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pr-log": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/pr-log/-/pr-log-6.3.0.tgz",
+            "integrity": "sha512-oEjIso49oS9AbnMxm2DF6J/omJpSlsJ9svovUraExZedVRmAYF0Cec8WtBtBbv8KOgW/rVQ44pmqauvJRPNPuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@pr-log/core": "0.0.2",
+                "@sindresorhus/is": "8.1.0",
+                "commander": "14.0.3",
+                "common-tags": "1.8.2",
+                "execa": "9.6.1",
+                "git-url-parse": "16.1.0",
+                "loglevel": "1.9.2",
+                "parse-github-repo-url": "1.4.1",
+                "prepend-file": "2.0.1",
+                "semver": "7.8.2",
+                "true-myth": "9.4.0"
+            },
+            "bin": {
+                "pr-log": "packages/command-line-interface/bin.entry-point.js"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
+        "node_modules/pr-log/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/pr-log/node_modules/semver": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13172,6 +13024,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prepend-file": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-2.0.1.tgz",
+            "integrity": "sha512-0hXWjmOpz5YBIk6xujS0lYtCw6IAA0wCR3fw49UGTLc3E9BIhcxgqdMa8rzGvrtt2F8wFiGP42oEpQ8fo9zhRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "temp-write": "^4.0.0"
+            },
+            "engines": {
+                "node": "^10.17 || >=11.14"
             }
         },
         "node_modules/pretty-format": {
@@ -13278,6 +13143,13 @@
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/protocols": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+            "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/proxy-agent-negotiate": {
             "version": "1.1.0",
@@ -14101,116 +13973,6 @@
                 "win32"
             ]
         },
-        "node_modules/rust-just/node_modules/execa": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^4.0.0",
-                "cross-spawn": "^7.0.6",
-                "figures": "^6.1.0",
-                "get-stream": "^9.0.0",
-                "human-signals": "^8.0.1",
-                "is-plain-obj": "^4.1.0",
-                "is-stream": "^4.0.1",
-                "npm-run-path": "^6.0.0",
-                "pretty-ms": "^9.2.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^4.0.0",
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/rust-just/node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rust-just/node_modules/human-signals": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/rust-just/node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rust-just/node_modules/npm-run-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rust-just/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rust-just/node_modules/strip-final-newline": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -14774,6 +14536,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/strip-indent": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
@@ -14907,6 +14682,72 @@
             "license": "MIT",
             "dependencies": {
                 "streamx": "^2.12.5"
+            }
+        },
+        "node_modules/temp-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+            "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/temp-write": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
+            "integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.15",
+                "is-stream": "^2.0.0",
+                "make-dir": "^3.0.0",
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/temp-write/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/temp-write/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/temp-write/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/test-exclude": {
@@ -15563,6 +15404,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/universalify": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@enormora/eslint-config-mocha": "0.0.40",
         "@enormora/eslint-config-node": "0.0.34",
         "@enormora/eslint-config-typescript": "0.0.50",
-        "@packtory/cli": "0.0.26",
+        "@packtory/cli": "0.0.46",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/mocha-runner": "9.6.1",
         "@types/estree": "1.0.9",
@@ -36,18 +36,8 @@
         "jscpd": "4.2.3",
         "knip": "6.14.2",
         "mocha": "11.1.0",
-        "pr-log": "6.1.1",
         "rust-just": "1.51.0",
         "typescript": "6.0.3"
-    },
-    "pr-log": {
-        "collapseRules": [
-            {
-                "label": "upgrade",
-                "pattern": "^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$",
-                "replace": "⬆️ Update dependency $<dependency> from $<from> to $<to>"
-            }
-        ]
     },
     "overrides": {
         "yargs": "18.0.0"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,18 @@
         "jscpd": "4.2.3",
         "knip": "6.14.2",
         "mocha": "11.1.0",
+        "pr-log": "6.3.0",
         "rust-just": "1.51.0",
         "typescript": "6.0.3"
+    },
+    "pr-log": {
+        "collapseRules": [
+            {
+                "label": "upgrade",
+                "pattern": "^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$",
+                "replace": "⬆️ Update dependency $<dependency> from $<from> to $<to>"
+            }
+        ]
     },
     "overrides": {
         "yargs": "18.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@enormora/eslint-config-mocha": "0.0.40",
         "@enormora/eslint-config-node": "0.0.34",
         "@enormora/eslint-config-typescript": "0.0.50",
-        "@packtory/cli": "0.0.46",
+        "@packtory/cli": "0.0.66",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/mocha-runner": "9.6.1",
         "@types/estree": "1.0.9",
@@ -36,17 +36,13 @@
         "jscpd": "4.2.3",
         "knip": "6.14.2",
         "mocha": "11.1.0",
-        "pr-log": "6.3.0",
+        "pr-log": "6.4.1",
         "rust-just": "1.51.0",
         "typescript": "6.0.3"
     },
     "pr-log": {
-        "collapseRules": [
-            {
-                "label": "upgrade",
-                "pattern": "^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$",
-                "replace": "⬆️ Update dependency $<dependency> from $<from> to $<to>"
-            }
+        "ignoredLabels": [
+            "release"
         ]
     },
     "overrides": {

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -1,93 +1,101 @@
 // @ts-check
-/** @typedef {import('@packtory/cli/package.json')} PacktoryCliPackage */
-
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const projectFolder = process.cwd();
 const sourcesFolder = path.join(projectFolder, 'target/build/source');
-const dryRunTokenPlaceholder = 'dry-run-placeholder';
 
-// eslint-disable-next-line node/no-process-env -- publish auth comes from the environment
-const npmToken = process.env.NPM_TOKEN;
-
-function isLivePublishInvocation(commandLineArguments) {
-    return (
-        commandLineArguments.includes('publish') &&
-        commandLineArguments.includes('--no-dry-run')
-    );
+async function readPackageInfo() {
+    const packageJsonContent = await fs.readFile(path.join(projectFolder, 'package.json'), { encoding: 'utf8' });
+    return JSON.parse(packageJsonContent);
 }
 
-if (npmToken === undefined && isLivePublishInvocation(process.argv)) {
-    throw new Error('Missing NPM_TOKEN environment variable');
+function registrySettings() {
+    return {
+        auth: { type: 'npm-oidc', provider: 'github-actions' }
+    };
 }
 
-const packageJsonContent = await fs.readFile(path.join(projectFolder, 'package.json'), {
-    encoding: 'utf8'
-});
-const packageJson = JSON.parse(packageJsonContent);
-
-export const config = {
-    registrySettings: {
-        auth: {
-            publish: {
-                type: 'bearer-token',
-                token: npmToken ?? dryRunTokenPlaceholder
-            },
-            metadata: npmToken === undefined ? 'anonymous' : 'auto'
-        }
-    },
-    checks: {
-        noDevDependencyImports: {
-            enabled: true
-        },
-        requiredFiles: {
-            enabled: true,
-            files: [ 'LICENSE', 'readme.md' ]
-        },
-        uniqueTargetPaths: {
-            enabled: true
-        }
-    },
-    commonPackageSettings: {
+function commonPackageSettings(packageInfo) {
+    return {
         sourcesFolder,
-        mainPackageJson: packageJson,
+        mainPackageJson: packageInfo,
         includeSourceMapFiles: false,
         publishSettings: {
-            access: 'public'
+            access: 'public',
+            provenance: { type: 'auto' }
         },
         additionalPackageJsonAttributes: {
-            license: packageJson.license,
-            repository: packageJson.repository,
-            author: packageJson.author,
-            contributors: packageJson.contributors,
-            description: packageJson.description,
-            keywords: packageJson.keywords
+            author: packageInfo.author,
+            contributors: packageInfo.contributors,
+            description: packageInfo.description,
+            keywords: packageInfo.keywords,
+            license: packageInfo.license,
+            repository: packageInfo.repository
         }
-    },
-    packages: [
-        {
-            name: 'eslint-plugin-mocha',
-            versioning: {
-                automatic: false,
-                version: '11.3.0'
+    };
+}
+
+function releasePullRequestSettings() {
+    return {
+        branch: 'release/eslint-plugin-mocha',
+        body: 'Updates changelogs for the next `eslint-plugin-mocha` release.',
+        githubActionsCi: {
+            trigger: 'workflow-dispatch',
+            workflowFile: 'ci.yml',
+            requiredStatusContexts: [ 'Node 22', 'Node 24', 'Node 26' ]
+        }
+    };
+}
+
+function mochaPluginPackage() {
+    return {
+        name: 'eslint-plugin-mocha',
+        versioning: {
+            automatic: false,
+            source: 'pull-request-labels'
+        },
+        roots: {
+            main: {
+                js: 'plugin.js',
+                declarationFile: 'plugin.d.ts'
+            }
+        },
+        additionalFiles: [
+            {
+                sourceFilePath: path.join(projectFolder, 'README.md'),
+                targetFilePath: 'README.md'
             },
-            roots: {
-                main: {
-                    js: 'plugin.js',
-                    declarationFile: 'plugin.d.ts'
-                }
-            },
-            additionalFiles: [
-                {
-                    sourceFilePath: path.join(projectFolder, 'README.md'),
-                    targetFilePath: 'readme.md'
-                },
-                {
-                    sourceFilePath: path.join(projectFolder, 'LICENSE'),
-                    targetFilePath: 'LICENSE'
-                }
+            {
+                sourceFilePath: path.join(projectFolder, 'LICENSE'),
+                targetFilePath: 'LICENSE'
+            }
+        ]
+    };
+}
+
+/** @returns {Promise<import('@packtory/cli').PacktoryConfig & Record<string, unknown>>} */
+export async function buildConfig() {
+    const packageInfo = await readPackageInfo();
+
+    return {
+        registrySettings: registrySettings(),
+        changelog: {
+            packageTagFormat: '{version}',
+            outputs: [
+                { kind: 'repository-file', path: 'CHANGELOG.md' },
+                { kind: 'github-release' }
             ]
-        }
-    ]
-};
+        },
+        checks: {
+            noDevDependencyImports: { enabled: true },
+            requiredFiles: { enabled: true, files: [ 'LICENSE', 'README.md' ] },
+            uniqueTargetPaths: { enabled: true }
+        },
+        commonPackageSettings: commonPackageSettings(packageInfo),
+        releasePullRequest: releasePullRequestSettings(),
+        packages: [
+            mochaPluginPackage()
+        ]
+    };
+}

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -43,7 +43,7 @@ function releasePullRequestSettings() {
         githubActionsCi: {
             trigger: 'workflow-dispatch',
             workflowFile: 'ci.yml',
-            requiredStatusContexts: [ 'Node 22', 'Node 24', 'Node 26' ]
+            requiredStatusContexts: [ 'Node 22', 'Node 24', 'Node 26', 'Release PR policy' ]
         }
     };
 }
@@ -82,6 +82,16 @@ export async function buildConfig() {
         registrySettings: registrySettings(),
         changelog: {
             packageTagFormat: '{version}',
+            prLog: {
+                ignoredLabels: [ 'release' ],
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                        replace: '⬆️ Update dependency $<dependency> from $<from> to $<to>'
+                    }
+                ]
+            },
             outputs: [
                 { kind: 'repository-file', path: 'CHANGELOG.md' },
                 { kind: 'github-release' }


### PR DESCRIPTION
Moves release planning and publishing onto Packtory release PR commands, with npm OIDC provenance, generated changelog/GitHub release output, and the reusable publish workflow shape used by `pr-log`. `@packtory/cli` now receives `pr-log` render config through `changelog.prLog`, while the `pr-log` CLI remains for manual changelog generation and pull request label validation. Before the first generated release PR can publish, merged PR #429 needs one accepted release label, for example `build`.