### PR TITLE
Use `@enormora/eslint-config-mocha-node-assert`

### DIFF
--- a/benchmarks/runtime.bench.ts
+++ b/benchmarks/runtime.bench.ts
@@ -82,7 +82,7 @@ const iterations = 50;
 
 suite('runtime', function () {
     test('should not take longer as the defined budget to lint many files with the recommended config', function () {
-        const cpuAgnosticBudget = 2_800_000;
+        const cpuAgnosticBudget = 3_000_000;
         const budget = cpuAgnosticBudget / cpuSpeed;
 
         const { medianDuration } = runSyncBenchmark(function () {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import { baseConfig } from '@enormora/eslint-config-base';
 import { createEslintPluginConfig } from '@enormora/eslint-config-eslint-plugin';
-import { mochaConfig } from '@enormora/eslint-config-mocha';
+import { mochaNodeAssertConfig } from '@enormora/eslint-config-mocha-node-assert';
 import { nodeConfig, nodeConfigFileConfig, nodeEntryPointFileConfig } from '@enormora/eslint-config-node';
 import { typescriptConfig } from '@enormora/eslint-config-typescript';
 
@@ -34,7 +34,7 @@ export default [
         files: [ 'dependency-cruiser.config.js', 'eslint.config.js', 'packtory.config.js', 'stryker.config.js' ]
     },
     {
-        ...mochaConfig,
+        ...mochaNodeAssertConfig,
         files: [ '**/*.test.ts', '**/*.test-support.ts', 'benchmarks/**/*.bench.ts' ]
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
             "devDependencies": {
                 "@enormora/eslint-config-base": "0.0.43",
                 "@enormora/eslint-config-eslint-plugin": "0.0.6",
-                "@enormora/eslint-config-mocha": "0.0.40",
+                "@enormora/eslint-config-mocha-node-assert": "0.0.3",
                 "@enormora/eslint-config-node": "0.0.34",
                 "@enormora/eslint-config-typescript": "0.0.50",
                 "@packtory/cli": "0.0.66",
@@ -1487,14 +1487,539 @@
             }
         },
         "node_modules/@enormora/eslint-config-mocha": {
-            "version": "0.0.40",
-            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha/-/eslint-config-mocha-0.0.40.tgz",
-            "integrity": "sha512-uIsJ0dCIu2in2JXT+AUgOFjc1ehLRIMOM18YmqV6RMa8kxMbaoXja5+UGYMntqpMXUuNpDqGmS4V0NAIQQ95FQ==",
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha/-/eslint-config-mocha-0.0.45.tgz",
+            "integrity": "sha512-h1EKnwGbWFQ0VxoxVpfbmIXlev4qCFEhcoaT5ur423FcFiBJ/FZo/7hHCV/xESVh+YVm/XrNgZUYjDvsgOeMJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@enormora/eslint-config-test-base": "0.0.13",
+                "@enormora/eslint-config-test-base": "0.0.19",
                 "eslint-plugin-mocha": "11.3.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha-node-assert/-/eslint-config-mocha-node-assert-0.0.3.tgz",
+            "integrity": "sha512-4nxNGVHgF135yiQ9XJJnEUyB6JSdvlWLOWjJs0jwss4TMwLGZ/PINaMhKDS0vfpaivD5uWEOcCKQ9tu1b6/Zgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@enormora/eslint-config-mocha": "0.0.45",
+                "@enormora/eslint-config-node-assert": "0.0.3"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@dprint/json": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.23.0.tgz",
+            "integrity": "sha512-FYFbZyrBr343JzCNkwa87+Lk2YnElpv0gzl+i5CXfMjixXzWWAKK2vEuzKoeCsJys4B3bfxmi0ByJ/xW2CY2jw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@enormora/eslint-config-base": {
+            "version": "0.0.49",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-base/-/eslint-config-base-0.0.49.tgz",
+            "integrity": "sha512-0Nv3Zx7fJ8GVjE/lUp1mOFADdqSo5ywznsujwbuZxHdkSSqKsvVAv8kZYUrkEw8xjI64MwkIA78SG6v/f5CLZg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@ben_12/eslint-plugin-dprint": "1.22.0",
+                "@cspell/eslint-plugin": "10.0.1",
+                "@dprint/json": "0.23.0",
+                "@dprint/markdown": "0.22.1",
+                "@dprint/toml": "0.7.0",
+                "@dprint/typescript": "0.96.1",
+                "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
+                "@eslint/markdown": "8.0.3",
+                "@eslint/plugin-kit": "0.7.2",
+                "@stylistic/eslint-plugin": "5.10.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "dprint-plugin-yaml": "0.6.0",
+                "eslint-plugin-array-func": "5.1.1",
+                "eslint-plugin-destructuring": "2.2.1",
+                "eslint-plugin-import-x": "4.17.1",
+                "eslint-plugin-json-schema-validator": "6.2.0",
+                "eslint-plugin-markdown-links": "0.9.1",
+                "eslint-plugin-markdown-preferences": "0.41.1",
+                "eslint-plugin-no-barrel-files": "1.3.1",
+                "eslint-plugin-no-secrets": "2.3.3",
+                "eslint-plugin-package-json": "1.5.0",
+                "eslint-plugin-promise": "7.3.0",
+                "eslint-plugin-regexp": "3.1.1",
+                "eslint-plugin-sonarjs": "4.1.0",
+                "eslint-plugin-unicorn": "71.1.0",
+                "jsonc-eslint-parser": "3.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@enormora/eslint-config-test-base": {
+            "version": "0.0.19",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-test-base/-/eslint-config-test-base-0.0.19.tgz",
+            "integrity": "sha512-VStL4yu4zBRGigRUIqxwuCRhZo5EIG5FQwAS/lqCVfrnl3NJaMatjf1BeguhPTjXo1Ljf03fYvMejnRmIeeSsw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@enormora/eslint-config-base": "0.0.49"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@eslint/markdown": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+            "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "workspaces": [
+                "examples/*"
+            ],
+            "dependencies": {
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.2",
+                "github-slugger": "^2.0.0",
+                "mdast-util-from-markdown": "^2.0.2",
+                "mdast-util-frontmatter": "^2.0.1",
+                "mdast-util-gfm": "^3.1.0",
+                "mdast-util-math": "^3.0.0",
+                "micromark-extension-frontmatter": "^2.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "micromark-extension-math": "^3.1.0",
+                "micromark-util-normalize-identifier": "^2.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/project-service": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/types": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/utils": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.63.0",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-import-x": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+            "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/types": "^8.56.0",
+                "comment-parser": "^1.4.1",
+                "debug": "^4.4.1",
+                "eslint-import-context": "^0.1.9",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.3 || ^10.1.2",
+                "semver": "^7.7.2",
+                "stable-hash-x": "^0.2.0",
+                "unrs-resolver": "^1.9.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-import-x"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/utils": "^8.56.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "eslint-import-resolver-node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/utils": {
+                    "optional": true
+                },
+                "eslint-import-resolver-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-markdown-links": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-markdown-links/-/eslint-plugin-markdown-links-0.9.1.tgz",
+            "integrity": "sha512-dDVhweFe44HOf6inWAfQe59pqVsRvyTAFw3MtN/CYz0YJ8s5/jj/4u6dQTdZSEY/mNkVZCSw3/70/kFD+PSPZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@mdit-vue/shared": "^3.0.2",
+                "entities": "^8.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "github-slugger": "^2.0.0",
+                "sdbm": "^3.0.0",
+                "synckit": "^0.11.11",
+                "undici": "^7.15.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "@eslint/markdown": "^7.1.0 || ^8.0.0",
+                "eslint": ">=9.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-package-json": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.5.0.tgz",
+            "integrity": "sha512-KQkAdn+7I4vn1W4Va+V8M94RhcgZBvgrxMglDqgEhJgQDRUJ9RdtrEiHoe/84oVTIlp0jiPttLYwkExdvHYhZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@altano/repository-tools": "^2.0.1",
+                "change-case": "^5.4.4",
+                "detect-indent": "^7.0.2",
+                "detect-newline": "^4.0.1",
+                "eslint-fix-utils": "~0.4.1",
+                "eslint-json-compat-utils": "^0.2.3",
+                "jsonc-eslint-parser": "^3.1.0",
+                "package-json-validator": "^1.5.0",
+                "semver": "^7.7.3",
+                "sort-object-keys": "^2.0.0",
+                "sort-package-json": "^4.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || >=24.15.0"
+            },
+            "peerDependencies": {
+                "@eslint/json": ">=1.0.0",
+                "eslint": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@eslint/json": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-regexp": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.1.tgz",
+            "integrity": "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.11.0",
+                "comment-parser": "^1.4.0",
+                "jsdoc-type-pratt-parser": "^7.0.0",
+                "refa": "^0.12.1",
+                "regexp-ast-analysis": "^0.7.1",
+                "scslre": "^0.3.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "peerDependencies": {
+                "eslint": ">=9.38.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-sonarjs": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.1.0.tgz",
+            "integrity": "sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==",
+            "dev": true,
+            "license": "LGPL-3.0-only",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.12.2",
+                "builtin-modules": "^3.3.0",
+                "bytes": "^3.1.2",
+                "functional-red-black-tree": "^1.0.1",
+                "globals": "^17.6.0",
+                "jsx-ast-utils-x": "^0.1.0",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^10.2.5",
+                "scslre": "^0.3.0",
+                "semver": "^7.8.4",
+                "ts-api-utils": "^2.5.0",
+                "typescript": ">=5",
+                "yaml": "^2.9.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/eslint-plugin-unicorn": {
+            "version": "71.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.1.0.tgz",
+            "integrity": "sha512-dn3YmR3qLLUeYyo/os3ubZ7UHQJ1WbBAgC9cIhnLTyMj9J6kivuc2U1fCmYetLexUlTDVYtBqhjSj/VaebTe6Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "browserslist": "^4.28.4",
+                "change-case": "^5.4.4",
+                "ci-info": "^4.4.0",
+                "core-js-compat": "^3.49.0",
+                "detect-indent": "^7.0.2",
+                "find-up-simple": "^1.0.1",
+                "globals": "^17.7.0",
+                "indent-string": "^5.0.0",
+                "is-builtin-module": "^5.0.0",
+                "is-identifier": "^1.1.0",
+                "pluralize": "^8.0.0",
+                "quote-js-string": "^0.1.0",
+                "regjsparser": "^0.13.2",
+                "reserved-identifiers": "^1.2.0",
+                "semver": "^7.8.5",
+                "strip-indent": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+            },
+            "peerDependencies": {
+                "eslint": ">=10.4"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/globals": {
+            "version": "17.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+            "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha/node_modules/sort-package-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-4.0.0.tgz",
+            "integrity": "sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "detect-indent": "^7.0.2",
+                "detect-newline": "^4.0.1",
+                "git-hooks-list": "^4.1.1",
+                "is-plain-obj": "^4.1.0",
+                "semver": "^7.7.3",
+                "sort-object-keys": "^2.0.1",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "sort-package-json": "cli.js"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@enormora/eslint-config-node": {
@@ -1508,6 +2033,16 @@
                 "globals": "17.6.0"
             }
         },
+        "node_modules/@enormora/eslint-config-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-node-assert/-/eslint-config-node-assert-0.0.3.tgz",
+            "integrity": "sha512-m2q5EJLIq5QQWHnC5/7In1QgTBWQnlijAFXNn6kBPgf2FekDH9SlTC8Ejj1vTemyHDPB30drcA+1LxZ24AKp2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@enormora/eslint-plugin-node-assert": "0.0.1"
+            }
+        },
         "node_modules/@enormora/eslint-config-node/node_modules/globals": {
             "version": "17.6.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
@@ -1519,16 +2054,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@enormora/eslint-config-test-base": {
-            "version": "0.0.13",
-            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-test-base/-/eslint-config-test-base-0.0.13.tgz",
-            "integrity": "sha512-ngZNtcz8E/kKFxFPOcegZUciS+GHWtuNj7fGLbKe3cn3HP1MZvjZQ0Ojpc9JMTLtCoKSrWhOZZptsBO9QcAYLw==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@enormora/eslint-config-base": "0.0.43"
             }
         },
         "node_modules/@enormora/eslint-config-typescript": {
@@ -1585,6 +2110,192 @@
                 "eslint-plugin-import-x": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-plugin-node-assert/-/eslint-plugin-node-assert-0.0.1.tgz",
+            "integrity": "sha512-dWNe4o03/xYM/C6BCN97a05jmusBx2XfxKBR+zIZ0H2i7La6D3soQGKvzAwwGz3g0Y8sENvRX0O+QwFV02mhOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "8.62.1"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/project-service": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+            "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.62.1",
+                "@typescript-eslint/types": "^8.62.1",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+            "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/visitor-keys": "8.62.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+            "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/types": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+            "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+            "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.62.1",
+                "@typescript-eslint/tsconfig-utils": "8.62.1",
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/visitor-keys": "8.62.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+            "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.1",
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/typescript-estree": "8.62.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+            "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.62.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
@@ -5156,9 +5867,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.31",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5418,9 +6129,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "dev": true,
             "funding": [
                 {
@@ -5438,10 +6149,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -5611,9 +6322,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001805",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
             "dev": true,
             "funding": [
                 {
@@ -6081,6 +6792,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/convert-source-map": {
@@ -6781,9 +7506,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.360",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
-            "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+            "version": "1.5.392",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+            "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
             "dev": true,
             "license": "ISC"
         },
@@ -8427,6 +9152,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -8892,6 +9631,23 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/identifier-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+            "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "reserved-identifiers": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ignore": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -9152,6 +9908,24 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-identifier": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+            "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "identifier-regex": "^1.1.0",
+                "super-regex": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-immutable-type": {
@@ -10113,6 +10887,25 @@
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
@@ -11681,9 +12474,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.45",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",
-            "integrity": "sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12042,6 +12835,23 @@
                 "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
             }
         },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12080,6 +12890,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -12958,6 +13782,20 @@
             ],
             "license": "MIT"
         },
+        "node_modules/quote-js-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+            "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13274,6 +14112,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/reserved-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+            "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/resolve": {
@@ -14155,6 +15007,25 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14336,6 +15207,23 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
+            }
+        },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tinyglobby": {
@@ -15081,6 +15969,14 @@
             "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/when-exit": {
             "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "devDependencies": {
         "@enormora/eslint-config-base": "0.0.43",
         "@enormora/eslint-config-eslint-plugin": "0.0.6",
-        "@enormora/eslint-config-mocha": "0.0.40",
+        "@enormora/eslint-config-mocha-node-assert": "0.0.3",
         "@enormora/eslint-config-node": "0.0.34",
         "@enormora/eslint-config-typescript": "0.0.50",
         "@packtory/cli": "0.0.66",

--- a/source/ast/find-mocha-variable-calls.config-call.test.ts
+++ b/source/ast/find-mocha-variable-calls.config-call.test.ts
@@ -171,11 +171,29 @@ suite('findMochaVariableCalls() config calls', function () {
 
         const [ configCall, baseCall ] = expectTwoCalls(calls);
 
-        assert.deepStrictEqual(configCall.path, [ 'foo', 'bar()', 'timeout()' ]);
-        assert.deepStrictEqual(configCall.resolvedPath, [ 'foo', 'bar()', 'timeout()' ]);
-        assert.strictEqual(configCall.name, 'foo.bar().timeout()');
-        assert.deepStrictEqual(baseCall.path, [ 'foo', 'bar()' ]);
-        assert.deepStrictEqual(baseCall.resolvedPath, [ 'foo', 'bar()' ]);
-        assert.strictEqual(baseCall.name, 'foo.bar()');
+        assert.deepStrictEqual(
+            {
+                path: configCall.path,
+                resolvedPath: configCall.resolvedPath,
+                name: configCall.name
+            },
+            {
+                path: [ 'foo', 'bar()', 'timeout()' ],
+                resolvedPath: [ 'foo', 'bar()', 'timeout()' ],
+                name: 'foo.bar().timeout()'
+            }
+        );
+        assert.deepStrictEqual(
+            {
+                path: baseCall.path,
+                resolvedPath: baseCall.resolvedPath,
+                name: baseCall.name
+            },
+            {
+                path: [ 'foo', 'bar()' ],
+                resolvedPath: [ 'foo', 'bar()' ],
+                name: 'foo.bar()'
+            }
+        );
     });
 });

--- a/source/plugin.test.ts
+++ b/source/plugin.test.ts
@@ -203,15 +203,41 @@ suite('eslint-plugin-mocha', function () {
 
     suite('configs', function () {
         test('should expose itself in flat configs', function () {
-            assert.strictEqual(plugin.configs.all.plugins.mocha, plugin);
-            assert.strictEqual(plugin.configs.recommended.plugins.mocha, plugin);
+            assert.deepStrictEqual(
+                {
+                    all: plugin.configs.all.plugins.mocha,
+                    recommended: plugin.configs.recommended.plugins.mocha
+                },
+                {
+                    all: plugin,
+                    recommended: plugin
+                }
+            );
         });
 
         test('should expose the expected flat config metadata', function () {
-            assert.strictEqual(plugin.configs.all.name, 'mocha/all');
-            assert.strictEqual(plugin.configs.recommended.name, 'mocha/recommended');
-            assert.strictEqual(plugin.configs.all.languageOptions?.globals, globals.mocha);
-            assert.strictEqual(plugin.configs.recommended.languageOptions?.globals, globals.mocha);
+            assert.deepStrictEqual(
+                {
+                    all: {
+                        name: plugin.configs.all.name,
+                        globals: plugin.configs.all.languageOptions?.globals
+                    },
+                    recommended: {
+                        name: plugin.configs.recommended.name,
+                        globals: plugin.configs.recommended.languageOptions?.globals
+                    }
+                },
+                {
+                    all: {
+                        name: 'mocha/all',
+                        globals: globals.mocha
+                    },
+                    recommended: {
+                        name: 'mocha/recommended',
+                        globals: globals.mocha
+                    }
+                }
+            );
         });
 
         test('should configure the all config as intended', function () {

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -12,6 +12,12 @@ type ReadExpressionResult = {
     readonly expression: Readonly<Rule.Node>;
 };
 
+type NestedMemberCallExpression = {
+    readonly expression: Extract<Rule.Node, { readonly type: 'CallExpression'; }>;
+    readonly callee: Extract<Rule.Node, { readonly type: 'MemberExpression'; }>;
+    readonly calleeObject: Extract<Rule.Node, { readonly type: 'MemberExpression'; }>;
+};
+
 function readExpression(
     code: string
 ): ReadExpressionResult {
@@ -49,6 +55,22 @@ function readExpression(
         readonly sourceCode: Readonly<SourceCode>;
         readonly expression: Readonly<Rule.Node>;
     };
+}
+
+function readNestedMemberCallExpression(code: string): NestedMemberCallExpression {
+    const { expression } = readExpression(code);
+    if (expression.type !== 'CallExpression') {
+        throw new Error('Expected call expression.');
+    }
+    const { callee } = expression;
+    if (callee.type !== 'MemberExpression') {
+        throw new Error('Expected member expression callee.');
+    }
+    const calleeObject = callee.object;
+    if (calleeObject.type !== 'MemberExpression') {
+        throw new Error('Expected nested member expression callee.');
+    }
+    return { expression, callee, calleeObject };
 }
 
 ruleTester.run('consistent-structure', consistentStructureRule, {
@@ -334,15 +356,24 @@ suite('consistent-structure helpers', function () {
     });
 
     test('getTopLevelMochaExpression() walks up member expressions', function () {
-        const { expression } = readExpression('foo.bar.baz();');
+        const { expression, callee, calleeObject } = readNestedMemberCallExpression('foo.bar.baz();');
 
-        assert.strictEqual(expression.type, 'CallExpression');
-        assert.strictEqual(expression.callee.type, 'MemberExpression');
-        assert.strictEqual(expression.callee.object.type, 'MemberExpression');
+        assert.deepStrictEqual(
+            {
+                type: expression.type,
+                calleeType: callee.type,
+                calleeObjectType: calleeObject.type
+            },
+            {
+                type: 'CallExpression',
+                calleeType: 'MemberExpression',
+                calleeObjectType: 'MemberExpression'
+            }
+        );
 
-        const result = getTopLevelMochaExpression(expression.callee.object.object as unknown as Rule.Node);
+        const result = getTopLevelMochaExpression(calleeObject.object);
 
         assert.strictEqual(result.type, 'MemberExpression');
-        assert.strictEqual(result, expression.callee);
+        assert.strictEqual(result, callee);
     });
 });

--- a/source/rules/consistent-structure.test.ts
+++ b/source/rules/consistent-structure.test.ts
@@ -62,11 +62,11 @@ function readNestedMemberCallExpression(code: string): NestedMemberCallExpressio
     if (expression.type !== 'CallExpression') {
         throw new Error('Expected call expression.');
     }
-    const { callee } = expression;
+    const callee = expression.callee as Readonly<Rule.Node>;
     if (callee.type !== 'MemberExpression') {
         throw new Error('Expected member expression callee.');
     }
-    const calleeObject = callee.object;
+    const calleeObject = callee.object as Readonly<Rule.Node>;
     if (calleeObject.type !== 'MemberExpression') {
         throw new Error('Expected nested member expression callee.');
     }
@@ -371,7 +371,7 @@ suite('consistent-structure helpers', function () {
             }
         );
 
-        const result = getTopLevelMochaExpression(calleeObject.object);
+        const result = getTopLevelMochaExpression(calleeObject.object as Readonly<Rule.Node>);
 
         assert.strictEqual(result.type, 'MemberExpression');
         assert.strictEqual(result, callee);

--- a/source/rules/no-hooks-for-single-child.test.ts
+++ b/source/rules/no-hooks-for-single-child.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { type Rule, RuleTester } from 'eslint';
 import { suite, test } from 'mocha';
 import { noHooksForSingleChildRule } from './no-hooks-for-single-child.ts';
@@ -384,7 +383,5 @@ suite('no-hooks-for-single-child create()', function () {
                 }
             }
         } as unknown as Rule.RuleContext);
-
-        assert.ok(true);
     });
 });

--- a/source/rules/no-hooks.test.ts
+++ b/source/rules/no-hooks.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { type Rule, RuleTester } from 'eslint';
 import { suite, test } from 'mocha';
 import { noHooksRule } from './no-hooks.ts';
@@ -180,7 +179,5 @@ suite('no-hooks create()', function () {
                 }
             }
         } as unknown as Rule.RuleContext);
-
-        assert.ok(true);
     });
 });

--- a/source/rules/no-setup-in-suite.test.ts
+++ b/source/rules/no-setup-in-suite.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { type Rule, RuleTester } from 'eslint';
 import { suite, test } from 'mocha';
 import { withInterface } from '../mocha-interface-test-cases.ts';
@@ -436,7 +435,5 @@ suite('no-setup-in-suite create()', function () {
                 }
             }
         } as unknown as Rule.RuleContext);
-
-        assert.ok(true);
     });
 });


### PR DESCRIPTION
`Mocha` tests in this repository already use `node:assert`, so this switches ESLint test linting to `@enormora/eslint-config-mocha-node-assert`. Assertions were updated for the additional `node-assert` rules reported by that preset.