### PR TITLE
Fail fast in Node test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
                 node: [22, 24, 26]
         name: Node ${{ matrix.node }}


### PR DESCRIPTION
Configures the Node CI matrix to cancel remaining matrix entries after the first failure. This shortens failed CI runs without changing the checks each successful matrix entry performs.