### PR TITLE
Constrain Renovate to `npm` 10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
     "automergeType": "pr",
     "packageRules": [
         {
+            "matchPackageNames": ["npm"],
+            "matchDepTypes": ["constraints"],
+            "enabled": false
+        },
+        {
             "matchPackagePatterns": ["^@enormora/eslint-config"],
             "groupName": "@enormora/eslint-config",
             "groupSlug": "enormora-eslint-config"

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
         "enabled": true,
         "automerge": true
     },
+    "constraints": {
+        "npm": "10.9.8"
+    },
     "automerge": true,
     "automergeType": "pr",
     "packageRules": [


### PR DESCRIPTION
Pins Renovate npm constraint to `10.9.8`, matching the npm version used by the Node 22 CI leg. The package rule disables Renovate updates for that npm constraint so generated lockfile metadata stays compatible with npm 10.