### PR TITLE
Enable `zizmor` workflow analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
                 node: [22, 24, 26]
         name: Node ${{ matrix.node }}
         permissions:
-            contents: read
-            pull-requests: read
+            contents: read # required for actions/checkout to read the repository source
+            pull-requests: read # required to read release PR files and metadata
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
@@ -62,6 +62,32 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   path-to-lcov: ./target/coverage/lcov.info
                   parallel: true
+    workflow-security:
+        runs-on: ubuntu-latest
+        name: Workflow security analysis
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
+            security-events: write # required by zizmor-action to upload SARIF to code scanning
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                  persist-credentials: false
+            - name: Run zizmor
+              id: zizmor
+              uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+              with:
+                  version: 1.27.0
+                  persona: pedantic
+                  min-severity: informational
+                  min-confidence: low
+                  config: .github/zizmor.yml
+            - name: Fail if zizmor reported findings
+              env:
+                  SARIF_FILE: ${{ steps.zizmor.outputs.output-file }}
+              run: |
+                  count="$(jq '[.runs[].results[]] | length' "$SARIF_FILE")"
+                  echo "zizmor findings: $count"
+                  test "$count" -eq 0
     release-pr-policy:
         needs: build
         runs-on: ubuntu-latest
@@ -71,8 +97,8 @@ jobs:
             github.event_name == 'merge_group' ||
             (github.event_name == 'workflow_dispatch' && github.ref_name == 'release/eslint-plugin-mocha')
         permissions:
-            contents: read
-            pull-requests: read
+            contents: read # required for actions/checkout to read the repository source
+            pull-requests: read # required to read release PR files and metadata
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
@@ -93,7 +119,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Mutation testing
         permissions:
-            contents: read
+            contents: read # required for actions/checkout to read the repository source
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
@@ -119,9 +145,9 @@ jobs:
             )
         uses: ./.github/workflows/release-publish.yml
         permissions:
-            contents: write
-            id-token: write
-            pull-requests: read
+            contents: write # required to push release tags and create GitHub releases
+            id-token: write # required by npm trusted publishing to mint the OIDC token
+            pull-requests: read # required to validate release PR identity before publishing
         with:
             release_pull_request_number: ${{ inputs.release_pull_request_number || '' }}
     maintain-release-pr:
@@ -142,11 +168,11 @@ jobs:
             needs.publish-release.result != 'failure' &&
             needs.publish-release.result != 'cancelled'
         permissions:
-            actions: write
-            contents: write
-            issues: write
-            pull-requests: write
-            statuses: write
+            actions: write # required to dispatch release PR CI and delete gated PR runs
+            contents: write # required to push and delete the release branch
+            issues: write # required to replace release PR labels
+            pull-requests: write # required to create, update, and close release PRs
+            statuses: write # required to mirror dispatched release PR CI results
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
@@ -172,7 +198,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Coveralls Finished
         permissions:
-            contents: read
+            contents: read # required by coverallsapp/github-action to read repository metadata
         steps:
             - name: Coveralls Finished
               uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6

--- a/.github/workflows/pull-request-label-policy.yml
+++ b/.github/workflows/pull-request-label-policy.yml
@@ -5,8 +5,8 @@ on:
         types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:
-    contents: read
-    issues: read
+    contents: read # required for actions/checkout to read the repository source
+    issues: read # required to read pull request labels
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,4 +29,5 @@ jobs:
             - name: Validate pull request label
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: npx just validate-pr-labels "${{ github.event.pull_request.number }}"
+                  PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+              run: npx just validate-pr-labels "$PULL_REQUEST_NUMBER"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,9 +24,9 @@ jobs:
         runs-on: ubuntu-latest
         name: Publish release
         permissions:
-            contents: write
-            id-token: write
-            pull-requests: read
+            contents: write # required to push release tags and create GitHub releases
+            id-token: write # required by npm trusted publishing to mint the OIDC token
+            pull-requests: read # required to validate release PR identity before publishing
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+---
+rules:
+    unpinned-uses:
+        config:
+            policies:
+                "*": hash-pin
+
+    secrets-outside-env:
+        config:
+            allow: []


### PR DESCRIPTION
Adds zizmor workflow. The workflow actions are SHA-pinned, permission scopes are documented, and pull request label validation avoids direct template expansion in shell.