### PR TITLE
Align release PR required checks

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -43,7 +43,14 @@ function releasePullRequestSettings() {
         githubActionsCi: {
             trigger: 'workflow-dispatch',
             workflowFile: 'ci.yml',
-            requiredStatusContexts: [ 'Node 22', 'Node 24', 'Node 26', 'Release PR policy' ]
+            requiredStatusContexts: [
+                'Node 22',
+                'Node 24',
+                'Node 26',
+                'Workflow security analysis',
+                'Release PR policy',
+                'Mutation testing'
+            ]
         }
     };
 }


### PR DESCRIPTION
Packtory now waits for the same `ci.yml` gate jobs that the `main` ruleset requires for PRs. This keeps release PR maintenance from accepting a release branch before `Workflow security analysis` and `Mutation testing` finish.