### PR TITLE
Ignore dependency install scripts in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
             - name: Install dependencies
-              run: npm clean-install
+              run: npm clean-install --ignore-scripts
             - name: Compile
               run: npx just compile
             - name: Run linters
@@ -129,7 +129,7 @@ jobs:
               with:
                   node-version: 26
             - name: Install dependencies
-              run: npm clean-install
+              run: npm clean-install --ignore-scripts
             - name: Run mutation tests
               run: npx just test-mutation
               timeout-minutes: 30


### PR DESCRIPTION
CI now installs from `package-lock.json` with `npm clean-install --ignore-scripts` in the build and mutation jobs. This blocks dependency lifecycle scripts from running in PR and main CI while keeping release-specific installs aligned with the existing workflow.