### PR TITLE
Fix npm 10 lockfile metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12496,6 +12496,25 @@
                 }
             }
         },
+        "node_modules/packtory/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/packtory/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -12505,6 +12524,15 @@
             "engines": {
                 "node": ">=0.3.1"
             }
+        },
+        "node_modules/packtory/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/parent-module": {
             "version": "1.0.1",


### PR DESCRIPTION
PR #516 merged after conflict resolution but before the npm 10 lockfile fix landed. This restores the peer dependency lockfile entries required by `npm clean-install --ignore-scripts` on Node 22.
