### PR TITLE
Propagate `engines` to Packtory `package.json`

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -29,6 +29,7 @@ function commonPackageSettings(packageInfo) {
             author: packageInfo.author,
             contributors: packageInfo.contributors,
             description: packageInfo.description,
+            engines: packageInfo.engines,
             keywords: packageInfo.keywords,
             license: packageInfo.license,
             repository: packageInfo.repository


### PR DESCRIPTION
Packtory now copies the root `package.json` `engines` field into the generated package manifest. This keeps the published package Node.js support constraint aligned with the source package metadata.