### PR TITLE
Remove obsolete `@packtory/cli` release Git config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
             )
         uses: ./.github/workflows/release-publish.yml
         permissions:
-            contents: write # required to push release tags and create GitHub releases
+            contents: write # required to create release tags and GitHub releases
             id-token: write # required by npm trusted publishing to mint the OIDC token
             pull-requests: read # required to validate release PR identity before publishing
         with:
@@ -185,10 +185,6 @@ jobs:
                   node-version: 24
             - name: Install dependencies
               run: npm clean-install --ignore-scripts
-            - name: Configure release author
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
             - name: Maintain release pull request
               env:
                   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Publish release
         permissions:
-            contents: write # required to push release tags and create GitHub releases
+            contents: write # required to create release tags and GitHub releases
             id-token: write # required by npm trusted publishing to mint the OIDC token
             pull-requests: read # required to validate release PR identity before publishing
         steps:
@@ -91,12 +91,6 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
               run: npx just publish-dry-run
-            - name: Configure release author
-              if: steps.publish-target.outputs.should_publish == 'true'
-              working-directory: target/release-source
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
             - name: Publish package
               if: steps.publish-target.outputs.should_publish == 'true'
               working-directory: target/release-source
@@ -104,7 +98,6 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
               run: |
                   mkdir -p target/release
-                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
 
                   set +e
                   npx just publish-release 2>&1 | tee target/release/publish.log


### PR DESCRIPTION
Packtory now creates release PR commits, release tags, and GitHub releases through the GitHub API, so the workflows no longer need local Git author setup or a tag push refspec.

The release command still keeps `--push` because Packtory requires it with `--github-release`.