### PR TITLE
Restore `npm` 10 tool constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
         "automerge": true
     },
     "constraints": {
-        "npm": "12.0.1"
+        "npm": "10.9.8"
     },
     "automerge": true,
     "automergeType": "pr",
@@ -27,13 +27,13 @@
     },
     "packageRules": [
         {
+            "matchDatasources": [
+                "npm"
+            ],
             "matchPackageNames": [
                 "npm"
             ],
-            "matchDepTypes": [
-                "constraints"
-            ],
-            "enabled": false
+            "allowedVersions": "<11.0.0"
         },
         {
             "matchPackageNames": [


### PR DESCRIPTION
Restores the Renovate npm tool constraint to `10.9.8` after Renovate updated it to npm 12.

Adds the npm package rule used by the reference config so Renovate only allows npm tool constraint versions below npm 11.
