### PR TITLE
Remove obsolete `changelog` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,9 +48,6 @@ test: test-unit-with-coverage test-bench
 coveralls:
     coveralls < ./target/coverage/lcov.info
 
-changelog:
-    pr-log
-
 pack-preview:
     packtory preview
 


### PR DESCRIPTION
Packtory now maintains the release pull request and writes changelog outputs during release automation.

This removes the standalone `changelog` recipe so `just --list` only exposes the release workflows still used by the project.