### PR TITLE
⬆️ Update dependency `@packtory/cli` from `0.0.68` to `0.0.69`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@enormora/eslint-config-mocha-node-assert": "0.0.7",
                 "@enormora/eslint-config-node": "0.0.39",
                 "@enormora/eslint-config-typescript": "0.0.60",
-                "@packtory/cli": "0.0.68",
+                "@packtory/cli": "0.0.69",
                 "@stryker-mutator/core": "9.6.1",
                 "@stryker-mutator/mocha-runner": "9.6.1",
                 "@types/estree": "1.0.9",
@@ -3674,9 +3674,9 @@
             ]
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.68",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.68.tgz",
-            "integrity": "sha512-lGrjAOvuvwVhfU0s9Yp3EzQac6raauqaN6JXWEjw7Q6UClVd6MZQV2cJmNtrcz08yY1ZoAK9XiDvEYAozK/CDw==",
+            "version": "0.0.69",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.69.tgz",
+            "integrity": "sha512-4VdYBTgde+dKqzvOfweiNk2hyISp/JrZAuba8eDFYapfba42Ttn6WuH59rIAX1C8fbvx1RVvXeKbeEcUfMAofw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3687,7 +3687,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.62",
+                "packtory": "0.0.63",
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
@@ -3800,9 +3800,9 @@
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {
-            "version": "0.0.13",
-            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.13.tgz",
-            "integrity": "sha512-SrXjMdbVSlrS9wOkbq1OX/c+vHcpx9Q+cO/XQqWZm92uaNZ2GYMPqmrK7ZaVQt70glueUYiBANXg0AEsiUWwGQ==",
+            "version": "0.0.14",
+            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.14.tgz",
+            "integrity": "sha512-idk99FvWFX21Vs0jOcxVQEd7N8l1Veh7JlJHJLglw+enVO0HwPWYL2de588vdHE4Anonj7o4Du9bgVJZ+K+qnQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8889,9 +8889,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.2.tgz",
+            "integrity": "sha512-aNJVEVdXTr/g5+N2VCLo+CTrFLo/Y+9rx9RC5BpxPtf7NEknmzY+UQvMO8Fjni5KFmDaHJieL8HCMJKjJXsTgg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11989,9 +11989,9 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.62.tgz",
-            "integrity": "sha512-BChlDHnEW8va5Gj+yUU3UUWpav2KRBbFPoUikDtchwoUTSXnvp3Z/OQo6xiZxyjj59QKpkcHT4DeT946GWSgvQ==",
+            "version": "0.0.63",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.63.tgz",
+            "integrity": "sha512-jSWD+Z7qMDkzch0/LjKauHtjMUt4sNv+9MHM4N/7SVLeTNn3FsxMEznTsBUNAv+L11bDSOUkhWsxOWVsKUk53Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11999,7 +11999,7 @@
                 "@cyclonedx/cyclonedx-library": "10.1.0",
                 "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
-                "@schema-hub/zod-error-formatter": "0.0.13",
+                "@schema-hub/zod-error-formatter": "0.0.14",
                 "@ts-morph/common": "0.29.0",
                 "@types/npm-registry-fetch": "8.0.9",
                 "common-tags": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@enormora/eslint-config-mocha-node-assert": "0.0.7",
         "@enormora/eslint-config-node": "0.0.39",
         "@enormora/eslint-config-typescript": "0.0.60",
-        "@packtory/cli": "0.0.68",
+        "@packtory/cli": "0.0.69",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/mocha-runner": "9.6.1",
         "@types/estree": "1.0.9",


### PR DESCRIPTION
Updates `@packtory/cli` to `0.0.69` and refreshes `package-lock.json` for the matching `packtory` release and transitive dependencies.

Verified `npx packtory --help`, `npx just compile`, and `GITHUB_TOKEN=... npx just pack-preview`.