### PR TITLE
Prevent `Pull request label policy` run cancellations

### DIFF
--- a/.github/workflows/pull-request-label-policy.yml
+++ b/.github/workflows/pull-request-label-policy.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    cancel-in-progress: false
 
 jobs:
     pull-request-label-policy:


### PR DESCRIPTION
This removes workflow-level cancellation from `Pull request label policy` so label-triggered reruns cannot leave a cancelled check run on Renovate PR heads.

Renovate treats cancelled check runs as a yellow branch status even when GitHub required checks are green, so this keeps automerge eligibility aligned with the branch ruleset.