### PR TITLE
Fix `handle-done-callback` for nested callback handoffs

### DIFF
--- a/documentation/rules/handle-done-callback.md
+++ b/documentation/rules/handle-done-callback.md
@@ -77,6 +77,16 @@ it('foo', function (done) {
     asyncFunction({ callback: done });
 });
 
+it('foo', function (done) {
+    loadData()
+        .then(function () {
+            done();
+        })
+        .catch(function (error) {
+            done(error);
+        });
+});
+
 before(function (done) {
     asyncInitialization(function () {
         initialized = true;

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -89,7 +89,6 @@ export async function buildConfig() {
     return {
         registrySettings: registrySettings(),
         changelog: {
-            packageTagFormat: '{version}',
             prLog: {
                 ignoredLabels: [ 'release' ],
                 collapseRules: [

--- a/source/callback-handling-state.reported-nodes.test.ts
+++ b/source/callback-handling-state.reported-nodes.test.ts
@@ -116,6 +116,12 @@ function callOperation(
     };
 }
 
+function callbackHandoff(
+    node: Readonly<Rule.Node>
+): Extract<CallbackHandlingOperation, { readonly type: 'callbackHandoff'; }> {
+    return { node, type: 'callbackHandoff' };
+}
+
 suite('callback handling reported nodes', function () {
     test('getCodeAfterCallbackHandlingNode() reports non-callback operations after the callback', function () {
         const sourceCode = createSourceCode();
@@ -155,6 +161,16 @@ suite('callback handling reported nodes', function () {
         assert.strictEqual(
             getCodeAfterCallbackHandlingNode(sourceCode, state, dynamicDelegateCall),
             dynamicDelegateCall.node
+        );
+    });
+
+    test('getCodeAfterCallbackHandlingNode() ignores callback handoff operations', function () {
+        const sourceCode = createSourceCode();
+        const state = createPathState();
+
+        assert.strictEqual(
+            getCodeAfterCallbackHandlingNode(sourceCode, state, callbackHandoff(identifier('callbackArgument'))),
+            undefined
         );
     });
 });

--- a/source/callback-handling-state.test.ts
+++ b/source/callback-handling-state.test.ts
@@ -220,6 +220,12 @@ function callOperation(
     };
 }
 
+function callbackHandoff(
+    node: Readonly<Rule.Node>
+): Extract<CallbackHandlingOperation, { readonly type: 'callbackHandoff'; }> {
+    return { node, type: 'callbackHandoff' };
+}
+
 function createChangedClone(state: Readonly<CallbackPathState>): CallbackPathState {
     const clone = clonePathState(state);
     const callbackProperties = clone.handledReferences.containerPropertiesByBinding.get('callbacks') ?? [];
@@ -237,6 +243,15 @@ function createChangedClone(state: Readonly<CallbackPathState>): CallbackPathSta
 }
 
 suite('callback handling state helpers', function () {
+    test('updatePathState() treats callback handoffs as callback handling', function () {
+        const sourceCode = createSourceCode();
+        const state = createPathState();
+        const nextState = updatePathState(sourceCode, state, callbackHandoff(identifier('callbackArgument')));
+
+        assert.strictEqual(nextState.callbackHandled, true);
+        assert.deepStrictEqual(readSortedStrings(nextState.handledReferences.aliasBindings), [ 'done' ]);
+    });
+
     test('clonePathState() deep-copies alias and container state', function () {
         const state = createPathState({
             callbackHandled: true,

--- a/source/callback-handling-state.ts
+++ b/source/callback-handling-state.ts
@@ -49,6 +49,10 @@ export type CallbackHandlingOperation =
         readonly source: Readonly<Rule.Node> | null;
         readonly target: TrackedBinding;
         readonly type: 'bindingAssignment';
+    }
+    | {
+        readonly node: Rule.Node;
+        readonly type: 'callbackHandoff';
     };
 
 export type CallbackHandlingContext = {
@@ -320,11 +324,26 @@ function mergeReferenceStates(
     };
 }
 
+function markCallbackHandled(state: Readonly<CallbackPathState>): CallbackPathState {
+    return {
+        callbackHandled: true,
+        handledReferences: mergeReferenceStates([
+            state.handledReferences,
+            state.unhandledReferences
+        ]),
+        unhandledReferences: cloneReferenceState(state.unhandledReferences)
+    };
+}
+
 export function updatePathState(
     sourceCode: Readonly<Rule.RuleContext['sourceCode']>,
     state: Readonly<CallbackPathState>,
     operation: Readonly<CallbackHandlingOperation>
 ): CallbackPathState {
+    if (operation.type === 'callbackHandoff') {
+        return markCallbackHandled(state);
+    }
+
     if (operation.type === 'bindingAssignment') {
         return {
             callbackHandled: state.callbackHandled,
@@ -345,14 +364,7 @@ export function updatePathState(
         return clonePathState(state);
     }
 
-    return {
-        callbackHandled: true,
-        handledReferences: mergeReferenceStates([
-            state.handledReferences,
-            state.unhandledReferences
-        ]),
-        unhandledReferences: cloneReferenceState(state.unhandledReferences)
-    };
+    return markCallbackHandled(state);
 }
 
 function isCallbackHandlingCallInAnyTrackedReferenceState(
@@ -371,6 +383,10 @@ export function getCodeAfterCallbackHandlingNode(
     state: Readonly<CallbackPathState>,
     operation: Readonly<CallbackHandlingOperation>
 ): Rule.Node | undefined {
+    if (operation.type === 'callbackHandoff') {
+        return undefined;
+    }
+
     return state.callbackHandled && !isCallbackHandlingCallInAnyTrackedReferenceState(sourceCode, state, operation)
         ? operation.node
         : undefined;

--- a/source/done-callback-paths.code-path.test.ts
+++ b/source/done-callback-paths.code-path.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+import type { Rule } from 'eslint';
+import { suite, test } from 'mocha';
+import {
+    analyzeOperations,
+    bindingAssignment,
+    callOperation,
+    containerPropertyAssignment,
+    createCodePath,
+    createSegment,
+    createSegmentGraph,
+    identifier,
+    type ObjectExpressionNode,
+    readSegment
+} from './done-callback-paths.test-support.ts';
+
+function createMissingPredecessorCodePath(): Rule.CodePath {
+    const segments = createSegmentGraph(
+        [ 'start', 'missing', 'end' ],
+        [
+            [ 'start', 'end' ],
+            [ 'missing', 'end' ]
+        ]
+    );
+
+    return createCodePath(readSegment(segments, 'start'), [ readSegment(segments, 'end') ]);
+}
+
+function createLoopCodePath(): Rule.CodePath {
+    const start = readSegment(
+        createSegmentGraph([ 'start' ], [ [ 'start', 'start' ] ]),
+        'start'
+    );
+
+    return createCodePath(start, [ start ]);
+}
+
+function createConvergingLoopCodePath(): Rule.CodePath {
+    const segments = createSegmentGraph(
+        [ 'start', 'loop', 'end' ],
+        [
+            [ 'start', 'loop' ],
+            [ 'loop', 'loop' ],
+            [ 'loop', 'end' ]
+        ]
+    );
+
+    return createCodePath(readSegment(segments, 'start'), [ readSegment(segments, 'end') ]);
+}
+
+suite('done callback code path helpers', function () {
+    test('hasUnhandledReturnPath() treats missing predecessor states as handled', function () {
+        const result = analyzeOperations(new Map(), createMissingPredecessorCodePath());
+
+        assert.strictEqual(result, true);
+    });
+
+    test('hasUnhandledReturnPath() ignores returned segments without exit state', function () {
+        const start = createSegment('start');
+        const missing = createSegment('missing');
+
+        const result = analyzeOperations(new Map(), createCodePath(start, [ missing ]));
+
+        assert.strictEqual(result, false);
+    });
+
+    test('hasUnhandledReturnPath() reuses unchanged loop state', function () {
+        const result = analyzeOperations(
+            new Map([
+                [ 'start', [ containerPropertyAssignment('obj', 'someFunc', identifier('done')) ] ]
+            ]),
+            createLoopCodePath()
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    test('hasUnhandledReturnPath() revisits loops until aliased callback state stabilizes', function () {
+        const result = analyzeOperations(
+            new Map([
+                [ 'start', [ bindingAssignment('next', identifier('done')) ] ],
+                [
+                    'loop',
+                    [
+                        bindingAssignment('later', identifier('next')),
+                        bindingAssignment('next', null)
+                    ]
+                ],
+                [ 'end', [ callOperation(identifier('foo'), [ identifier('later') ]) ] ]
+            ]),
+            createConvergingLoopCodePath()
+        );
+
+        assert.strictEqual(result, true);
+    });
+
+    test('hasUnhandledReturnPath() ignores getter-based callback container properties', function () {
+        const start = createSegment('start');
+
+        const result = analyzeOperations(
+            new Map([
+                [
+                    'start',
+                    [
+                        callOperation(identifier('foo'), [ {
+                            properties: [ {
+                                computed: false,
+                                key: identifier('someFunc'),
+                                kind: 'get',
+                                type: 'Property',
+                                value: identifier('done')
+                            } ],
+                            type: 'ObjectExpression'
+                        } as unknown as ObjectExpressionNode ])
+                    ]
+                ]
+            ]),
+            createCodePath(start, [ start ])
+        );
+
+        assert.strictEqual(result, true);
+    });
+});

--- a/source/done-callback-paths.test-support.ts
+++ b/source/done-callback-paths.test-support.ts
@@ -203,6 +203,10 @@ export function callOperation(
     };
 }
 
+export function callbackHandoff(node: Readonly<Rule.Node>): Operation {
+    return { node, type: 'callbackHandoff' };
+}
+
 export function analyzeOperations(
     operationsBySegmentId: ReadonlyMap<string, readonly Operation[]>,
     codePath: Readonly<Rule.CodePath>

--- a/source/done-callback-paths.test.ts
+++ b/source/done-callback-paths.test.ts
@@ -4,6 +4,7 @@ import { suite, test } from 'mocha';
 import {
     analyzeOperations,
     bindingAssignment,
+    callbackHandoff,
     callExpression,
     callOperation,
     containerPropertyAssignment,
@@ -16,7 +17,6 @@ import {
     literal,
     memberExpression,
     objectExpression,
-    type ObjectExpressionNode,
     privateIdentifier,
     property,
     readSegment,
@@ -44,40 +44,6 @@ function createLinearCodePath(): Rule.CodePath {
     const segments = createSegmentGraph(
         [ 'start', 'end' ],
         [ [ 'start', 'end' ] ]
-    );
-
-    return createCodePath(readSegment(segments, 'start'), [ readSegment(segments, 'end') ]);
-}
-
-function createMissingPredecessorCodePath(): Rule.CodePath {
-    const segments = createSegmentGraph(
-        [ 'start', 'missing', 'end' ],
-        [
-            [ 'start', 'end' ],
-            [ 'missing', 'end' ]
-        ]
-    );
-
-    return createCodePath(readSegment(segments, 'start'), [ readSegment(segments, 'end') ]);
-}
-
-function createLoopCodePath(): Rule.CodePath {
-    const start = readSegment(
-        createSegmentGraph([ 'start' ], [ [ 'start', 'start' ] ]),
-        'start'
-    );
-
-    return createCodePath(start, [ start ]);
-}
-
-function createConvergingLoopCodePath(): Rule.CodePath {
-    const segments = createSegmentGraph(
-        [ 'start', 'loop', 'end' ],
-        [
-            [ 'start', 'loop' ],
-            [ 'loop', 'loop' ],
-            [ 'loop', 'end' ]
-        ]
     );
 
     return createCodePath(readSegment(segments, 'start'), [ readSegment(segments, 'end') ]);
@@ -239,6 +205,17 @@ suite('done callback path helpers', function () {
     });
 
     suite('callback containers', function () {
+        test('hasUnhandledReturnPath() treats handled callback arguments as callback handoffs', function () {
+            const start = createSegment('start');
+
+            const result = analyzeOperations(
+                new Map([ [ 'start', [ callbackHandoff(identifier('callbackArgument')) ] ] ]),
+                createCodePath(start, [ start ])
+            );
+
+            assert.strictEqual(result, false);
+        });
+
         test('hasUnhandledReturnPath() handles inline callback containers with static keys', function () {
             const start = createSegment('start');
 
@@ -438,80 +415,6 @@ suite('done callback path helpers', function () {
                             callOperation(identifier('foo'), [
                                 memberExpression(identifier('obj'), identifier('someFunc'))
                             ])
-                        ]
-                    ]
-                ]),
-                createCodePath(start, [ start ])
-            );
-
-            assert.strictEqual(result, true);
-        });
-    });
-
-    suite('code paths', function () {
-        test('hasUnhandledReturnPath() treats missing predecessor states as handled', function () {
-            const result = analyzeOperations(new Map(), createMissingPredecessorCodePath());
-
-            assert.strictEqual(result, true);
-        });
-
-        test('hasUnhandledReturnPath() ignores returned segments without exit state', function () {
-            const start = createSegment('start');
-            const missing = createSegment('missing');
-
-            const result = analyzeOperations(new Map(), createCodePath(start, [ missing ]));
-
-            assert.strictEqual(result, false);
-        });
-
-        test('hasUnhandledReturnPath() reuses unchanged loop state', function () {
-            const result = analyzeOperations(
-                new Map([
-                    [ 'start', [ containerPropertyAssignment('obj', 'someFunc', identifier('done')) ] ]
-                ]),
-                createLoopCodePath()
-            );
-
-            assert.strictEqual(result, true);
-        });
-
-        test('hasUnhandledReturnPath() revisits loops until aliased callback state stabilizes', function () {
-            const result = analyzeOperations(
-                new Map([
-                    [ 'start', [ bindingAssignment('next', identifier('done')) ] ],
-                    [
-                        'loop',
-                        [
-                            bindingAssignment('later', identifier('next')),
-                            bindingAssignment('next', null)
-                        ]
-                    ],
-                    [ 'end', [ callOperation(identifier('foo'), [ identifier('later') ]) ] ]
-                ]),
-                createConvergingLoopCodePath()
-            );
-
-            assert.strictEqual(result, true);
-        });
-
-        test('hasUnhandledReturnPath() ignores getter-based callback container properties', function () {
-            const start = createSegment('start');
-
-            const result = analyzeOperations(
-                new Map([
-                    [
-                        'start',
-                        [
-                            callOperation(identifier('foo'), [ {
-                                properties: [ {
-                                    computed: false,
-                                    key: identifier('someFunc'),
-                                    kind: 'get',
-                                    type: 'Property',
-                                    value: identifier('done')
-                                } ],
-                                type: 'ObjectExpression'
-                            } as unknown as ObjectExpressionNode ])
                         ]
                     ]
                 ]),

--- a/source/done-callback-paths.ts
+++ b/source/done-callback-paths.ts
@@ -22,6 +22,10 @@ type Operation =
         readonly type: 'call';
     }
     | {
+        readonly node: Readonly<Rule.Node>;
+        readonly type: 'callbackHandoff';
+    }
+    | {
         readonly propertyName: string | undefined;
         readonly source: Readonly<Rule.Node> | null;
         readonly target: TrackedBinding;
@@ -94,6 +98,10 @@ function applyOperation(
     state: Readonly<PendingPathState>,
     operation: Operation
 ): PendingPathState {
+    if (operation.type === 'callbackHandoff') {
+        return createHandledPendingPathState();
+    }
+
     if (operation.type === 'bindingAssignment') {
         return applyBindingAssignment(sourceCode, state, operation);
     }

--- a/source/repeated-callback-handling-paths.test.ts
+++ b/source/repeated-callback-handling-paths.test.ts
@@ -239,6 +239,12 @@ function callOperation(
     };
 }
 
+function callbackHandoff(
+    node: Readonly<Rule.Node>
+): Extract<CallbackHandlingOperation, { readonly type: 'callbackHandoff'; }> {
+    return { node, type: 'callbackHandoff' };
+}
+
 function analyzeOperations(
     operationsBySegmentId: ReadonlyMap<string, CallbackHandlingOperation[]>,
     codePath: Readonly<Rule.CodePath>
@@ -448,6 +454,23 @@ suite('repeated callback handling path helpers', function () {
                         ]
                     ]
                 ]),
+                createCodePath(start, [ start ])
+            );
+
+            assert.deepStrictEqual(result, []);
+        });
+
+        test('collectRepeatedCallbackHandlingNodes() ignores callback handoffs as repeats', function () {
+            const start = createSegment('start');
+
+            const result = analyzeOperations(
+                new Map([ [
+                    'start',
+                    [
+                        callOperation(identifier('done'), []),
+                        callbackHandoff(identifier('callbackArgument'))
+                    ]
+                ] ]),
                 createCodePath(start, [ start ])
             );
 

--- a/source/repeated-callback-handling-paths.ts
+++ b/source/repeated-callback-handling-paths.ts
@@ -13,6 +13,9 @@ function getRepeatedCallbackHandlingNode(
     operation: Readonly<CallbackHandlingOperation>
 ): Rule.Node | undefined {
     const repeatedNodeByOperationType = {
+        callbackHandoff() {
+            return undefined;
+        },
         bindingAssignment() {
             return undefined;
         },

--- a/source/rules/callback-tracking.test.ts
+++ b/source/rules/callback-tracking.test.ts
@@ -46,7 +46,8 @@ function collectOperationTypes(code: string): readonly string[] {
                     operationTypes = operations.map(function (operation) {
                         return operation.type;
                     });
-                }
+                },
+                trackHandledCallbackArguments: false
             });
         }
     };
@@ -75,7 +76,8 @@ suite('callback tracking', function () {
                 includeInheritedCallbackBinding: true,
                 onTrackedFunctionEnd(trackedFunction) {
                     trackedFunctions.push(trackedFunction);
-                }
+                },
+                trackHandledCallbackArguments: false
             }
         );
         const codePath = createCodePath();

--- a/source/rules/callback-tracking.ts
+++ b/source/rules/callback-tracking.ts
@@ -3,6 +3,7 @@ import { createMochaVisitors } from '../ast/mocha-visitors.ts';
 import { isFunction } from '../ast/node-types.ts';
 import { asRuleNode } from '../ast/rule-node.ts';
 import type { CallbackHandlingOperation } from '../callback-handling-state.ts';
+import { hasUnhandledReturnPath } from '../done-callback-paths.ts';
 import { getIdentifierCallbackParameter } from '../mocha/callback-parameter.ts';
 import {
     getMemberExpressionBindingAndProperty,
@@ -28,6 +29,7 @@ export type TrackedCallbackFunction = DirectTrackedCallbackFunction | InheritedT
 
 type SharedCallbackTrackingOptions = {
     readonly ignorePending: boolean;
+    readonly trackHandledCallbackArguments: boolean;
 };
 type CallbackTrackingOptions =
     | SharedCallbackTrackingOptions & {
@@ -49,6 +51,7 @@ type TrackedCallbackFunctionContext = {
     readonly trackedCallbackNodes: Readonly<WeakSet<Rule.Node>>;
 };
 type FunctionState = {
+    readonly node: Readonly<Rule.Node>;
     readonly tracked: TrackedCallbackFunction | undefined;
     readonly upper: FunctionState | null;
 };
@@ -143,6 +146,12 @@ function isDirectTrackedCallbackFunction(
     return trackedFunction.callbackName !== undefined;
 }
 
+function isInheritedTrackedCallbackFunction(
+    trackedFunction: Readonly<TrackedCallbackFunction>
+): trackedFunction is Readonly<InheritedTrackedCallbackFunction> {
+    return trackedFunction.callbackName === undefined;
+}
+
 function reportTrackedFunction(
     callbackTrackingOptions: Readonly<CallbackTrackingOptions>,
     trackedFunction: Readonly<TrackedCallbackFunction>
@@ -166,6 +175,7 @@ export function createTrackedCallbackVisitors(
     callbackTrackingOptions: Readonly<CallbackTrackingOptions>
 ): Readonly<Rule.RuleListener> {
     const trackedCallbackNodes = new WeakSet<Rule.Node>();
+    const handledCallbackNodes = new WeakSet<Rule.Node>();
     let currentFunction: FunctionState | null = null;
 
     function recordOperation(operation: Readonly<CallbackHandlingOperation>): void {
@@ -184,6 +194,7 @@ export function createTrackedCallbackVisitors(
 
         if (currentFunction !== null) {
             currentFunction = {
+                node: currentFunction.node,
                 tracked: {
                     ...trackedFunction,
                     operationsBySegmentId
@@ -210,6 +221,34 @@ export function createTrackedCallbackVisitors(
         trackedCallbackNodes.add(node);
     }
 
+    function trackHandledCallbackNode(
+        node: Readonly<Rule.Node>,
+        trackedFunction: Readonly<TrackedCallbackFunction>
+    ): void {
+        if (
+            callbackTrackingOptions.trackHandledCallbackArguments &&
+            isInheritedTrackedCallbackFunction(trackedFunction) &&
+            !hasUnhandledReturnPath({
+                callbackBinding: trackedFunction.callbackBinding,
+                codePath: trackedFunction.codePath,
+                operationsBySegmentId: trackedFunction.operationsBySegmentId,
+                sourceCode: context.sourceCode
+            })
+        ) {
+            handledCallbackNodes.add(asRuleNode(node));
+        }
+    }
+
+    function hasHandledCallbackArgument(
+        node: Readonly<Parameters<Exclude<Rule.RuleListener['CallExpression'], undefined>>[0]>
+    ): boolean {
+        return node.arguments.some(function (argument) {
+            const candidate = argument.type === 'SpreadElement' ? argument.argument : argument;
+
+            return handledCallbackNodes.has(asRuleNode(candidate));
+        });
+    }
+
     return createMochaVisitors(context, {
         testCaseCallback(visitorContext) {
             if (visitorContext.modifier === 'pending' && callbackTrackingOptions.ignorePending) {
@@ -225,6 +264,7 @@ export function createTrackedCallbackVisitors(
 
         onCodePathStart(codePath, node) {
             currentFunction = {
+                node,
                 tracked: createTrackedCallbackFunction({
                     sourceCode: context.sourceCode,
                     trackedCallbackNodes,
@@ -238,9 +278,14 @@ export function createTrackedCallbackVisitors(
         },
 
         onCodePathEnd() {
+            const endedFunction = currentFunction;
             const trackedFunction = currentFunction?.tracked;
 
             if (trackedFunction !== undefined) {
+                if (endedFunction !== null) {
+                    trackHandledCallbackNode(endedFunction.node, trackedFunction);
+                }
+
                 reportTrackedFunction(callbackTrackingOptions, trackedFunction);
             }
 
@@ -270,6 +315,10 @@ export function createTrackedCallbackVisitors(
         },
 
         'CallExpression:exit'(node) {
+            if (callbackTrackingOptions.trackHandledCallbackArguments && hasHandledCallbackArgument(node)) {
+                recordOperation({ node, type: 'callbackHandoff' });
+            }
+
             recordOperation({ node, type: 'call' });
         },
 

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -33,6 +33,15 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         'it("", function (done) { var obj = {}; obj["someFunc"] = done; somethingThatCallsSomeFuncOnObj(obj); });',
         'it("", function (done) { done(new Error("foo")); });',
         'it("", function (done) { promise.then(done).catch(done); });',
+        'it("", function (done) { asyncFunction(function () { done(); }); });',
+        'it("", function (done) { asyncFunction(function (error) { if (error) { done(error); } else { done(); } }); });',
+        'it("", function (done) { Promise.resolve().then(function () { done(); }).catch(function (error) { done(error); }); });',
+        'it("", function (done) { Promise.resolve().then(() => { done(); }).catch((error) => { done(error); }); });',
+        'it("", function (done) { promise.then(function () { done(); }, function (error) { done(error); }); });',
+        'it("", function (done) { promise.then(() => done(), (error) => done(error)); });',
+        'it("", function (done) { promise.then(function () { done(); }).catch(done); });',
+        'it("", function (done) { promise.then(done).catch(function (error) { done(error); }); });',
+        'beforeEach(function (done) { loadFixture(function () { done(); }); });',
         'it("", function (done) { var [next] = [done]; done(); });',
         'it("", function (done) { ({ current: next } = source); done(); });',
         'it("", function (done) { factory().someFunc = done; done(); });',
@@ -40,6 +49,7 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         'it("", function (done) { var obj = { someFunc: done }; obj.someFunc++; done(); });',
         'it("", function (done) { factory().someFunc++; done(); });',
         'it("", function (done) { typeof done; done(); });',
+        'it("", function (done) { receiver(...callbacks); done(); });',
         'it("", function (done) { delete factory().someFunc; done(); });',
         'it("", function (done) { var obj = { someFunc: done }; delete obj.someFunc; done(); });',
         'it.only("", function (done) { done(); });',
@@ -122,6 +132,16 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         },
         {
             code: 'it("", function (done) { asyncFunction(function (error) { expect(error).to.be.null; }); });',
+            errors: [ {
+                message: 'Expected "done" callback to be handled.',
+                column: 18,
+                line: 1,
+                endLine: 1,
+                endColumn: 22
+            } ]
+        },
+        {
+            code: 'it("", function (done) { asyncFunction(function () { if (ready) { done(); } }); });',
             errors: [ {
                 message: 'Expected "done" callback to be handled.',
                 column: 18,

--- a/source/rules/handle-done-callback.ts
+++ b/source/rules/handle-done-callback.ts
@@ -1,7 +1,11 @@
 import type { Rule } from 'eslint';
 import { hasUnhandledReturnPath } from '../done-callback-paths.ts';
 import { getRuleOption, type InferSchemaOption } from '../rule-options.ts';
-import { createTrackedCallbackVisitors, type DirectTrackedCallbackFunction } from './callback-tracking.ts';
+import {
+    createTrackedCallbackVisitors,
+    type DirectTrackedCallbackFunction,
+    type TrackedCallbackFunction
+} from './callback-tracking.ts';
 
 const optionSchema = {
     type: 'object',
@@ -41,6 +45,12 @@ function reportUnhandledDoneCallback(
     });
 }
 
+function isDirectTrackedCallbackFunction(
+    trackedFunction: Readonly<TrackedCallbackFunction>
+): trackedFunction is Readonly<DirectTrackedCallbackFunction> {
+    return trackedFunction.callbackName !== undefined;
+}
+
 export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
     meta: {
         type: 'problem',
@@ -60,10 +70,13 @@ export const handleDoneCallbackRule: Readonly<Rule.RuleModule> = {
         const { ignorePending } = getRuleOption<ResolvedOption>(context);
         return createTrackedCallbackVisitors(context, {
             ignorePending,
-            includeInheritedCallbackBinding: false,
+            includeInheritedCallbackBinding: true,
             onTrackedFunctionEnd(trackedFunction) {
-                reportUnhandledDoneCallback(context, trackedFunction);
-            }
+                if (isDirectTrackedCallbackFunction(trackedFunction)) {
+                    reportUnhandledDoneCallback(context, trackedFunction);
+                }
+            },
+            trackHandledCallbackArguments: true
         });
     }
 };

--- a/source/rules/no-code-after-done.ts
+++ b/source/rules/no-code-after-done.ts
@@ -41,7 +41,8 @@ export const noCodeAfterDoneRule: Readonly<Rule.RuleModule> = {
             includeInheritedCallbackBinding: true,
             onTrackedFunctionEnd(trackedFunction) {
                 reportCodeAfterDone(context, trackedFunction);
-            }
+            },
+            trackHandledCallbackArguments: false
         });
     }
 };

--- a/source/rules/no-done-twice.ts
+++ b/source/rules/no-done-twice.ts
@@ -41,7 +41,8 @@ export const noDoneTwiceRule: Readonly<Rule.RuleModule> = {
             includeInheritedCallbackBinding: false,
             onTrackedFunctionEnd(trackedFunction) {
                 reportDoneTwice(context, trackedFunction);
-            }
+            },
+            trackHandledCallbackArguments: false
         });
     }
 };


### PR DESCRIPTION
Fixes #548.

`handle-done-callback` now tracks nested callback functions that inherit the Mocha callback binding and handle it on every normal code path. Passing one of those locally verified callbacks to another call counts as a callback handoff, without modeling Promise, stream, event, or other external async protocol semantics.