### PR TITLE
Fix `handle-done-callback` for object property callbacks

### DIFF
--- a/source/rules/callback-tracking.ts
+++ b/source/rules/callback-tracking.ts
@@ -170,6 +170,15 @@ function reportTrackedFunction(
     }
 }
 
+function isHandledCallbackObjectArgument(
+    node: Readonly<Rule.Node>,
+    handledCallbackNodes: Readonly<WeakSet<Rule.Node>>
+): boolean {
+    return node.type === 'ObjectExpression' && node.properties.some(function (property) {
+        return property.type === 'Property' && handledCallbackNodes.has(asRuleNode(property.value));
+    });
+}
+
 export function createTrackedCallbackVisitors(
     context: Readonly<Rule.RuleContext>,
     callbackTrackingOptions: Readonly<CallbackTrackingOptions>
@@ -245,7 +254,11 @@ export function createTrackedCallbackVisitors(
         return node.arguments.some(function (argument) {
             const candidate = argument.type === 'SpreadElement' ? argument.argument : argument;
 
-            return handledCallbackNodes.has(asRuleNode(candidate));
+            if (handledCallbackNodes.has(asRuleNode(candidate))) {
+                return true;
+            }
+
+            return isHandledCallbackObjectArgument(asRuleNode(candidate), handledCallbackNodes);
         });
     }
 

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -34,9 +34,24 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         'it("", function (done) { done(new Error("foo")); });',
         'it("", function (done) { promise.then(done).catch(done); });',
         'it("", function (done) { asyncFunction(function () { done(); }); });',
+        'it("", function (done) { runTask({ onSuccess: function () { done(); } }); });',
         'it("", function (done) { asyncFunction(function (error) { if (error) { done(error); } else { done(); } }); });',
         'it("", function (done) { Promise.resolve().then(function () { done(); }).catch(function (error) { done(error); }); });',
         'it("", function (done) { Promise.resolve().then(() => { done(); }).catch((error) => { done(error); }); });',
+        {
+            code: 'it("", function (done) { runTask({ onSuccess: () => { done(); } }); });',
+            languageOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: 'it("", function (done) { runTask({ onSuccess() { done(); }, ' +
+                'onFailure() { expect(error).to.exist; } }); });',
+            languageOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: 'it("", function (done) { runTask({ next() { calculate(); }, ' +
+                'onSuccess() { done(); }, onError() { done(error); } }); });',
+            languageOptions: { ecmaVersion: 6 }
+        },
         'it("", function (done) { promise.then(function () { done(); }, function (error) { done(error); }); });',
         'it("", function (done) { promise.then(() => done(), (error) => done(error)); });',
         'it("", function (done) { promise.then(function () { done(); }).catch(done); });',
@@ -132,6 +147,17 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         },
         {
             code: 'it("", function (done) { asyncFunction(function (error) { expect(error).to.be.null; }); });',
+            errors: [ {
+                message: 'Expected "done" callback to be handled.',
+                column: 18,
+                line: 1,
+                endLine: 1,
+                endColumn: 22
+            } ]
+        },
+        {
+            code: 'it("", function (done) { runTask({ onSuccess() { expect(true).to.equal(true); } }); });',
+            languageOptions: { ecmaVersion: 6 },
             errors: [ {
                 message: 'Expected "done" callback to be handled.',
                 column: 18,


### PR DESCRIPTION
Treat object expression arguments as callback handoffs when one of their property values is a nested callback that handles the inherited Mocha callback. This fixes false positives for APIs that accept configuration objects with callbacks, such as `runTask({ onSuccess: () => done() })`.

Closes #560.