### PR TITLE
Make `release-publish.yml` callable only

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,11 +7,6 @@ on:
                 default: ""
                 required: false
                 type: string
-    workflow_dispatch:
-        inputs:
-            release_pull_request_number:
-                required: true
-                type: string
 
 permissions: {}
 


### PR DESCRIPTION
This keeps `release-publish.yml` as the reusable publish workflow for `ci.yml`, but removes its direct manual dispatch entry point. Manual release recovery now goes through `ci.yml`, matching the npm trusted publishing OIDC workflow configuration.