### PR TITLE
Fix handle-done-callback false positive for assigned callback handoffs

### DIFF
--- a/source/rules/callback-tracking.ts
+++ b/source/rules/callback-tracking.ts
@@ -179,6 +179,16 @@ function isHandledCallbackObjectArgument(
     });
 }
 
+function isOrContainsHandledCallback(
+    node: Readonly<Rule.Node>,
+    handledCallbackNodes: Readonly<WeakSet<Rule.Node>>
+): boolean {
+    if (handledCallbackNodes.has(asRuleNode(node))) {
+        return true;
+    }
+    return isHandledCallbackObjectArgument(node, handledCallbackNodes);
+}
+
 export function createTrackedCallbackVisitors(
     context: Readonly<Rule.RuleContext>,
     callbackTrackingOptions: Readonly<CallbackTrackingOptions>
@@ -254,11 +264,7 @@ export function createTrackedCallbackVisitors(
         return node.arguments.some(function (argument) {
             const candidate = argument.type === 'SpreadElement' ? argument.argument : argument;
 
-            if (handledCallbackNodes.has(asRuleNode(candidate))) {
-                return true;
-            }
-
-            return isHandledCallbackObjectArgument(asRuleNode(candidate), handledCallbackNodes);
+            return isOrContainsHandledCallback(asRuleNode(candidate), handledCallbackNodes);
         });
     }
 
@@ -336,6 +342,14 @@ export function createTrackedCallbackVisitors(
         },
 
         'VariableDeclarator:exit'(node) {
+            if (
+                callbackTrackingOptions.trackHandledCallbackArguments &&
+                node.init !== null &&
+                isOrContainsHandledCallback(asRuleNode(node.init), handledCallbackNodes)
+            ) {
+                recordOperation({ node, type: 'callbackHandoff' });
+            }
+
             if (node.id.type !== 'Identifier') {
                 return;
             }
@@ -349,6 +363,13 @@ export function createTrackedCallbackVisitors(
         },
 
         'AssignmentExpression:exit'(node) {
+            if (
+                callbackTrackingOptions.trackHandledCallbackArguments &&
+                isOrContainsHandledCallback(asRuleNode(node.right), handledCallbackNodes)
+            ) {
+                recordOperation({ node, type: 'callbackHandoff' });
+            }
+
             if (node.left.type === 'Identifier') {
                 recordOperation({
                     node,

--- a/source/rules/handle-done-callback.test.ts
+++ b/source/rules/handle-done-callback.test.ts
@@ -91,7 +91,14 @@ ruleTester.run('handle-done-callback', handleDoneCallbackRule, {
         {
             code: 'before(async function setupApplication(this: Mocha.Context) { this.timeout(6000); });',
             languageOptions: typescriptLanguageOptions
-        }
+        },
+        'it("", function (done) { const handler = function () { done(); }; });',
+        'it("", function (done) { let handler; handler = function () { done(); }; });',
+        'it("", function (done) { var writable = {}; writable._final = function (callback) { done(); }; });',
+        {
+            code: 'it("", function (done) { const handler = () => { done(); }; });',
+            languageOptions: { ecmaVersion: 6 }
+        },
     ],
 
     invalid: [

--- a/source/rules/no-code-after-done.test.ts
+++ b/source/rules/no-code-after-done.test.ts
@@ -18,6 +18,8 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
         'it("title", function(done) { getCallbacks().complete = done; done(); });',
         'it("title", async function() { await work(); });',
         'it("title", function() { work(); });',
+        'it("title", function(done) { const obj = {}; obj.method = function() { done(); }; return obj; });',
+        'it("title", function(done) { let handler; handler = function() { done(); }; });',
         'notMocha("title", function(done) { done(); expect(true).to.be.false; });',
 
         {
@@ -73,6 +75,10 @@ ruleTester.run('no-code-after-done', noCodeAfterDoneRule, {
             code: 'it("title", function(this: Mocha.Context, done) { done(); expect(true).to.be.true; });',
             languageOptions: typescriptLanguageOptions,
             errors: [ { message, line: 1, column: 59, endLine: 1, endColumn: 71 } ]
-        }
+        },
+        {
+            code: 'it("title", function(done) { const obj = {}; obj.method = function() { done(); expect(true).to.be.true; }; });',
+            errors: [ { message, line: 1, column: 80, endLine: 1, endColumn: 92 } ]
+        },
     ]
 });


### PR DESCRIPTION
Hi! It fixes a false positive in `handle-done-callback` where a function calling `done()` is assigned to a variable or an object property (e.g., Node.js Stream handlers like `writable._final = function(...) { done(); }`).

Previously, `handle-done-callback` recognized callback handoffs when a function calling `done()` was passed directly as a function argument (e.g., `doAsync(function() { done(); })`).

However, if a function that calls `done()` was assigned to a variable or an object property, the rule did not record a `callbackHandoff` operation for the outer scope. This led to false positives where the rule reported the `done` callback as unhandled, even though responsibility for calling `done()` was delegated to the assigned handler/property.

### Previously flagged as unhandled `done` (False Positive) / but now is valid:

```js
// Variable declarations/assignments
it('handles variable assignment', function (done) {
    const handler = function () {
        done();
    };
    handler(handler);
});

// Assigning a handler to an object property (e.g. Node.js Writable stream)
it('should handle stream completion', function (done) {
    const writable = new Writable();
    
    writable._final = function (callback) {
        callback();
        done(); // Called inside assigned handler
    };
    
    writable.pipe(writable);
});
```

- Added unit tests for property assignments and variable declarators to handle-done-callback.test.ts
- Added unit tests to no-code-after-done.test.ts

Feel free to push edits directly to this branch, refactor the code as you see fit, or close this PR if you prefer a different approach.